### PR TITLE
Streamline format of Apache 2.0 License headers

### DIFF
--- a/cmd/alibabaoss-target-adapter/Dockerfile
+++ b/cmd/alibabaoss-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/alibabaoss-target-adapter/main.go
+++ b/cmd/alibabaoss-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/aws-target-adapter/Dockerfile
+++ b/cmd/aws-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/aws-target-adapter/main.go
+++ b/cmd/aws-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/awscomprehend-target-adapter/Dockerfile
+++ b/cmd/awscomprehend-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/awscomprehend-target-adapter/main.go
+++ b/cmd/awscomprehend-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/awssnssource/main.go
+++ b/cmd/awssnssource/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/confluent-target-adapter/Dockerfile
+++ b/cmd/confluent-target-adapter/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmd/confluent-target-adapter/main.go
+++ b/cmd/confluent-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/datadog-target-adapter/Dockerfile
+++ b/cmd/datadog-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/datadog-target-adapter/main.go
+++ b/cmd/datadog-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/elasticsearch-target-adapter/Dockerfile
+++ b/cmd/elasticsearch-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/elasticsearch-target-adapter/main.go
+++ b/cmd/elasticsearch-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudfirestore-target-adapter/Dockerfile
+++ b/cmd/googlecloudfirestore-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudfirestore-target-adapter/main.go
+++ b/cmd/googlecloudfirestore-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudstorage-target-adapter/Dockerfile
+++ b/cmd/googlecloudstorage-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudstorage-target-adapter/main.go
+++ b/cmd/googlecloudstorage-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudworkflows-target-adapter/Dockerfile
+++ b/cmd/googlecloudworkflows-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlecloudworkflows-target-adapter/main.go
+++ b/cmd/googlecloudworkflows-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/googlesheet-target-adapter/Dockerfile
+++ b/cmd/googlesheet-target-adapter/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmd/googlesheet-target-adapter/main.go
+++ b/cmd/googlesheet-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/hasura-target-adapter/Dockerfile
+++ b/cmd/hasura-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/hasura-target-adapter/main.go
+++ b/cmd/hasura-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/http-target-adapter/Dockerfile
+++ b/cmd/http-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/http-target-adapter/main.go
+++ b/cmd/http-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/httppollersource-adapter/main.go
+++ b/cmd/httppollersource-adapter/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/infra-target-adapter/Dockerfile
+++ b/cmd/infra-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/infra-target-adapter/main.go
+++ b/cmd/infra-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/jira-target-adapter/Dockerfile
+++ b/cmd/jira-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/jira-target-adapter/main.go
+++ b/cmd/jira-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/logz-target-adapter/Dockerfile
+++ b/cmd/logz-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/logz-target-adapter/main.go
+++ b/cmd/logz-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/oracle-target-adapter/Dockerfile
+++ b/cmd/oracle-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/oracle-target-adapter/main.go
+++ b/cmd/oracle-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/salesforce-target-adapter/Dockerfile
+++ b/cmd/salesforce-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/salesforce-target-adapter/main.go
+++ b/cmd/salesforce-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/sendgrid-target-adapter/Dockerfile
+++ b/cmd/sendgrid-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/sendgrid-target-adapter/main.go
+++ b/cmd/sendgrid-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/slack-target-adapter/Dockerfile
+++ b/cmd/slack-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/slack-target-adapter/main.go
+++ b/cmd/slack-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/slacksource-adapter/main.go
+++ b/cmd/slacksource-adapter/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/splunk-target-adapter/Dockerfile
+++ b/cmd/splunk-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/splunk-target-adapter/main.go
+++ b/cmd/splunk-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/tekton-target-adapter/Dockerfile
+++ b/cmd/tekton-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/tekton-target-adapter/main.go
+++ b/cmd/tekton-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/twilio-target-adapter/Dockerfile
+++ b/cmd/twilio-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/twilio-target-adapter/main.go
+++ b/cmd/twilio-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/uipath-target-adapter/Dockerfile
+++ b/cmd/uipath-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/uipath-target-adapter/main.go
+++ b/cmd/uipath-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/webhooksource-adapter/main.go
+++ b/cmd/webhooksource-adapter/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/zendesk-target-adapter/Dockerfile
+++ b/cmd/zendesk-target-adapter/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/zendesk-target-adapter/main.go
+++ b/cmd/zendesk-target-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/zendesksource-adapter/main.go
+++ b/cmd/zendesksource-adapter/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-aws-crd.yaml
+++ b/config/300-aws-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscloudwatch.yaml
+++ b/config/300-awscloudwatch.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscloudwatchlogs.yaml
+++ b/config/300-awscloudwatchlogs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscodecommit.yaml
+++ b/config/300-awscodecommit.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscognitoidentity.yaml
+++ b/config/300-awscognitoidentity.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscognitouserpool.yaml
+++ b/config/300-awscognitouserpool.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscomprehend-crd.yaml
+++ b/config/300-awscomprehend-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awsdynamodb.yaml
+++ b/config/300-awsdynamodb.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awskinesis.yaml
+++ b/config/300-awskinesis.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awsperformanceinsights.yaml
+++ b/config/300-awsperformanceinsights.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awss3.yaml
+++ b/config/300-awss3.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awssns.yaml
+++ b/config/300-awssns.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awssqs.yaml
+++ b/config/300-awssqs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-confluent-crd.yaml
+++ b/config/300-confluent-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-datadog-crd.yaml
+++ b/config/300-datadog-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-elasticsearch-crd.yaml
+++ b/config/300-elasticsearch-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudstorage-crd.yaml
+++ b/config/300-googlecloudstorage-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudworkflows-crd.yaml
+++ b/config/300-googlecloudworkflows-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlefirestore-crd.yaml
+++ b/config/300-googlefirestore-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlesheet-crd.yaml
+++ b/config/300-googlesheet-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-hasura-crd.yaml
+++ b/config/300-hasura-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-http-crd.yaml
+++ b/config/300-http-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-infra-crd.yaml
+++ b/config/300-infra-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-jira-crd.yaml
+++ b/config/300-jira-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-logz-crd.yaml
+++ b/config/300-logz-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-oracle-crd.yaml
+++ b/config/300-oracle-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-salesforce-crd.yaml
+++ b/config/300-salesforce-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-sendgrid-crd.yaml
+++ b/config/300-sendgrid-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-slack-crd.yaml
+++ b/config/300-slack-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-splunk-crd.yaml
+++ b/config/300-splunk-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-tekton-crd.yaml
+++ b/config/300-tekton-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-twilio-crd.yaml
+++ b/config/300-twilio-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-uipath-crd.yaml
+++ b/config/300-uipath-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-zendesk-crd.yaml
+++ b/config/300-zendesk-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscloudwatchlogssource.yaml
+++ b/config/samples/sources/awscloudwatchlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscloudwatchsource.yaml
+++ b/config/samples/sources/awscloudwatchsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscodecommitsource.yaml
+++ b/config/samples/sources/awscodecommitsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscognitoidentitysource.yaml
+++ b/config/samples/sources/awscognitoidentitysource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscognitouserpoolsource.yaml
+++ b/config/samples/sources/awscognitouserpoolsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awsdynamodbsource.yaml
+++ b/config/samples/sources/awsdynamodbsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awskinesissource.yaml
+++ b/config/samples/sources/awskinesissource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awssnssource.yaml
+++ b/config/samples/sources/awssnssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awssqssource.yaml
+++ b/config/samples/sources/awssqssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/slacksource.yaml
+++ b/config/samples/sources/slacksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/webhooksource.yaml
+++ b/config/samples/sources/webhooksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/zendesksource.yaml
+++ b/config/samples/sources/zendesksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/100-secret.yaml
+++ b/config/samples/targets/alibabaoss/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/200-target.yaml
+++ b/config/samples/targets/alibabaoss/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/300-trigger.yaml
+++ b/config/samples/targets/alibabaoss/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/100-secret.yaml
+++ b/config/samples/targets/aws/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-dynamodb-target.yaml
+++ b/config/samples/targets/aws/200-aws-dynamodb-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-kinesis-target.yaml
+++ b/config/samples/targets/aws/200-aws-kinesis-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-lambda-target.yaml
+++ b/config/samples/targets/aws/200-aws-lambda-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-s3-target.yaml
+++ b/config/samples/targets/aws/200-aws-s3-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-sns-target.yaml
+++ b/config/samples/targets/aws/200-aws-sns-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-sqs-target.yaml
+++ b/config/samples/targets/aws/200-aws-sqs-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/300-trigger.yaml
+++ b/config/samples/targets/aws/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/100-secret.yaml
+++ b/config/samples/targets/awscomprehend/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/200-aws-comprehend-target.yaml
+++ b/config/samples/targets/awscomprehend/200-aws-comprehend-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/300-trigger.yaml
+++ b/config/samples/targets/awscomprehend/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/100-secret.yaml
+++ b/config/samples/targets/confluent/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/200-target.yaml
+++ b/config/samples/targets/confluent/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/300-trigger.yaml
+++ b/config/samples/targets/confluent/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/100-secret.yaml
+++ b/config/samples/targets/datadog/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/200-target.yaml
+++ b/config/samples/targets/datadog/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/300-trigger.yaml
+++ b/config/samples/targets/datadog/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/100-secret.yaml
+++ b/config/samples/targets/elasticsearch/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/200-elasticsearch-target.yaml
+++ b/config/samples/targets/elasticsearch/200-elasticsearch-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/300-trigger.yaml
+++ b/config/samples/targets/elasticsearch/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/100-secret.yaml
+++ b/config/samples/targets/googlecloudfirestore/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/200-target.yaml
+++ b/config/samples/targets/googlecloudfirestore/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021s TriggerMesh Inc.
+# Copyright 2021s TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/300-trigger.yaml
+++ b/config/samples/targets/googlecloudfirestore/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/100-secret.yaml
+++ b/config/samples/targets/googlecloudstorage/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/200-target.yaml
+++ b/config/samples/targets/googlecloudstorage/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021s TriggerMesh Inc.
+# Copyright 2021s TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/300-trigger.yaml
+++ b/config/samples/targets/googlecloudstorage/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/100-secret.yaml
+++ b/config/samples/targets/googlecloudworkflows/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/200-target.yaml
+++ b/config/samples/targets/googlecloudworkflows/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/300-trigger.yaml
+++ b/config/samples/targets/googlecloudworkflows/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/100-secret.yaml
+++ b/config/samples/targets/googlesheet/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/200-target.yaml
+++ b/config/samples/targets/googlesheet/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/300-trigger.yaml
+++ b/config/samples/targets/googlesheet/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/100-secret.yaml
+++ b/config/samples/targets/hasura/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/200-target.yaml
+++ b/config/samples/targets/hasura/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/300-trigger.yaml
+++ b/config/samples/targets/hasura/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/calendarific.yaml
+++ b/config/samples/targets/http/calendarific.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/covid19.yaml
+++ b/config/samples/targets/http/covid19.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/twitter-oauth.yaml
+++ b/config/samples/targets/http/twitter-oauth.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/infra/manage-fields.yaml
+++ b/config/samples/targets/infra/manage-fields.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/100-secret.yaml
+++ b/config/samples/targets/jira/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/200-target.yaml
+++ b/config/samples/targets/jira/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/300-display.yaml
+++ b/config/samples/targets/jira/300-display.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/400-eventing.yaml
+++ b/config/samples/targets/jira/400-eventing.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/100-secret.yaml
+++ b/config/samples/targets/logz/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/200-target.yaml
+++ b/config/samples/targets/logz/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/300-trigger.yaml
+++ b/config/samples/targets/logz/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/100-secret.yaml
+++ b/config/samples/targets/oracle/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/200-oracle-target.yaml
+++ b/config/samples/targets/oracle/200-oracle-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/300-trigger.yaml
+++ b/config/samples/targets/oracle/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/salesforce/salesforce-display-response.yaml
+++ b/config/samples/targets/salesforce/salesforce-display-response.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/100-secret.yaml
+++ b/config/samples/targets/sendgrid/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/200-target.yaml
+++ b/config/samples/targets/sendgrid/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/300-trigger.yaml
+++ b/config/samples/targets/sendgrid/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/100-secret.yaml
+++ b/config/samples/targets/slack/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/200-target.yaml
+++ b/config/samples/targets/slack/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/300-trigger.yaml
+++ b/config/samples/targets/slack/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/splunk/splunktarget.yaml
+++ b/config/samples/targets/splunk/splunktarget.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/config/samples/targets/tekton/200-target.yaml
+++ b/config/samples/targets/tekton/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/100-secret.yaml
+++ b/config/samples/targets/twilio/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/200-twilio-target.yaml
+++ b/config/samples/targets/twilio/200-twilio-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/300-trigger.yaml
+++ b/config/samples/targets/twilio/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/100-secret.yaml
+++ b/config/samples/targets/uipath/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/200-target.yaml
+++ b/config/samples/targets/uipath/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/300-trigger.yaml
+++ b/config/samples/targets/uipath/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/100-secret.yaml
+++ b/config/samples/targets/zendesk/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/200-target.yaml
+++ b/config/samples/targets/zendesk/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/300-trigger.yaml
+++ b/config/samples/targets/zendesk/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,6 +1,22 @@
 //go:build tools
 // +build tools
 
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hack
 
 // These imports ensure build tools are included in Go modules.

--- a/pkg/apis/sources/register.go
+++ b/pkg/apis/sources/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscodecommit_types.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awskinesis_types.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssns_types.go
+++ b/pkg/apis/sources/v1alpha1/awssns_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/conditions.go
+++ b/pkg/apis/sources/v1alpha1/conditions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/register.go
+++ b/pkg/apis/sources/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/slacksource_types.go
+++ b/pkg/apis/sources/v1alpha1/slacksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/webhooksource_types.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/zendesksource_types.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/interfaces.go
+++ b/pkg/apis/targets/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/register.go
+++ b/pkg/apis/targets/register.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/alibabaoss_types.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_common_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_dynamodb_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_dynamodb_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_lambda_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_lambda_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_s3_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_sns_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sns_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_sqs_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/common_types.go
+++ b/pkg/apis/targets/v1alpha1/common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/conditions.go
+++ b/pkg/apis/targets/v1alpha1/conditions.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/confluent_types.go
+++ b/pkg/apis/targets/v1alpha1/confluent_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/datadog_types.go
+++ b/pkg/apis/targets/v1alpha1/datadog_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/doc.go
+++ b/pkg/apis/targets/v1alpha1/doc.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh, Inc
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudworkflows_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudworkflows_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlesheet_types.go
+++ b/pkg/apis/targets/v1alpha1/googlesheet_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_types.go
+++ b/pkg/apis/targets/v1alpha1/hasura_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/http_types.go
+++ b/pkg/apis/targets/v1alpha1/http_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/infra_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/infra_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/infra_types.go
+++ b/pkg/apis/targets/v1alpha1/infra_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/jira_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/jira_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/jira_types.go
+++ b/pkg/apis/targets/v1alpha1/jira_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logz_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/logz_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logz_types.go
+++ b/pkg/apis/targets/v1alpha1/logz_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/oracle_types.go
+++ b/pkg/apis/targets/v1alpha1/oracle_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/register.go
+++ b/pkg/apis/targets/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/register_test.go
+++ b/pkg/apis/targets/v1alpha1/register_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1alpha1
 
 import (

--- a/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/salesforce_types.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/sendgrid_types.go
+++ b/pkg/apis/targets/v1alpha1/sendgrid_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/slack_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/slack_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/slack_types.go
+++ b/pkg/apis/targets/v1alpha1/slack_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/splunk_types.go
+++ b/pkg/apis/targets/v1alpha1/splunk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/tekton_types.go
+++ b/pkg/apis/targets/v1alpha1/tekton_types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/twilio_types.go
+++ b/pkg/apis/targets/v1alpha1/twilio_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/uipath_types.go
+++ b/pkg/apis/targets/v1alpha1/uipath_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/zendesk_types.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscodecommitsource/adapter.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscodecommitsource/adapter_test.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/events.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awskinesissource/adapter.go
+++ b/pkg/sources/adapter/awskinesissource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awskinesissource/adapter_test.go
+++ b/pkg/sources/adapter/awskinesissource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/adapter.go
+++ b/pkg/sources/adapter/awssnssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/adapter_test.go
+++ b/pkg/sources/adapter/awssnssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/adapter.go
+++ b/pkg/sources/adapter/awssqssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/adapter_test.go
+++ b/pkg/sources/adapter/awssqssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/delete.go
+++ b/pkg/sources/adapter/awssqssource/delete.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/process.go
+++ b/pkg/sources/adapter/awssqssource/process.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/receive.go
+++ b/pkg/sources/adapter/awssqssource/receive.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2020 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/testing/listers.go
+++ b/pkg/sources/adapter/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/webhook_test.go
+++ b/pkg/sources/adapter/webhooksource/webhook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/adapter.go
+++ b/pkg/sources/adapter/zendesksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/handler/events.go
+++ b/pkg/sources/adapter/zendesksource/handler/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/handler/handler.go
+++ b/pkg/sources/adapter/zendesksource/handler/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/creds.go
+++ b/pkg/sources/aws/creds.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/creds_test.go
+++ b/pkg/sources/aws/creds_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/sns/client.go
+++ b/pkg/sources/client/sns/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/reconciler.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/reconciler.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/sources/reconciler/awscodecommitsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/controller.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/controller_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/reconciler.go
+++ b/pkg/sources/reconciler/awscodecommitsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/reconciler.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/reconciler.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/reconciler.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/controller.go
+++ b/pkg/sources/reconciler/awskinesissource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/controller_test.go
+++ b/pkg/sources/reconciler/awskinesissource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/reconciler.go
+++ b/pkg/sources/reconciler/awskinesissource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/sources/reconciler/awskinesissource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/reconciler.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/controller.go
+++ b/pkg/sources/reconciler/awssnssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/controller_test.go
+++ b/pkg/sources/reconciler/awssnssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/reconciler.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/subscription.go
+++ b/pkg/sources/reconciler/awssnssource/subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/controller.go
+++ b/pkg/sources/reconciler/awssqssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/controller_test.go
+++ b/pkg/sources/reconciler/awssqssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/reconciler.go
+++ b/pkg/sources/reconciler/awssqssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssqssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/adapter.go
+++ b/pkg/sources/reconciler/common/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/base.go
+++ b/pkg/sources/reconciler/common/base.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/doc.go
+++ b/pkg/sources/reconciler/common/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/env.go
+++ b/pkg/sources/reconciler/common/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/event/event_test.go
+++ b/pkg/sources/reconciler/common/event/event_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/labels.go
+++ b/pkg/sources/reconciler/common/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/reconcile.go
+++ b/pkg/sources/reconciler/common/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/container.go
+++ b/pkg/sources/reconciler/common/resource/container.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/container_test.go
+++ b/pkg/sources/reconciler/common/resource/container_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/deployment_test.go
+++ b/pkg/sources/reconciler/common/resource/deployment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/knservice_test.go
+++ b/pkg/sources/reconciler/common/resource/knservice_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/object_test.go
+++ b/pkg/sources/reconciler/common/resource/object_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/podspecable.go
+++ b/pkg/sources/reconciler/common/resource/podspecable.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/controller.go
+++ b/pkg/sources/reconciler/slacksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/controller_test.go
+++ b/pkg/sources/reconciler/slacksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/reconciler.go
+++ b/pkg/sources/reconciler/slacksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/reconciler_test.go
+++ b/pkg/sources/reconciler/slacksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/controller.go
+++ b/pkg/sources/reconciler/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/factory.go
+++ b/pkg/sources/reconciler/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/listers.go
+++ b/pkg/sources/reconciler/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/reconcile.go
+++ b/pkg/sources/reconciler/testing/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/utils.go
+++ b/pkg/sources/reconciler/testing/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/controller.go
+++ b/pkg/sources/reconciler/webhooksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/controller_test.go
+++ b/pkg/sources/reconciler/webhooksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/reconciler.go
+++ b/pkg/sources/reconciler/webhooksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/reconciler_test.go
+++ b/pkg/sources/reconciler/webhooksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/controller.go
+++ b/pkg/sources/reconciler/zendesksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/controller_test.go
+++ b/pkg/sources/reconciler/zendesksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/reconciler.go
+++ b/pkg/sources/reconciler/zendesksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/reconciler_test.go
+++ b/pkg/sources/reconciler/zendesksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/zendesk.go
+++ b/pkg/sources/reconciler/zendesksource/zendesk.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/testing/event/event.go
+++ b/pkg/sources/testing/event/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/testing/structs/structs.go
+++ b/pkg/sources/testing/structs/structs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/alibabaosstarget/adapter.go
+++ b/pkg/targets/adapter/alibabaosstarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/alibabaosstarget/config.go
+++ b/pkg/targets/adapter/alibabaosstarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/awscomphrehendtarget/adapter.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/awscomphrehendtarget/config.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/awscomphrehendtarget/types.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/awstarget/adapter.go
+++ b/pkg/targets/adapter/awstarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/awstarget/arn.go
+++ b/pkg/targets/adapter/awstarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awstarget/arn_test.go
+++ b/pkg/targets/adapter/awstarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awstarget/config.go
+++ b/pkg/targets/adapter/awstarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/doc.go
+++ b/pkg/targets/adapter/cloudevents/doc.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/replier.go
+++ b/pkg/targets/adapter/cloudevents/replier.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/replier_options.go
+++ b/pkg/targets/adapter/cloudevents/replier_options.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/replier_test.go
+++ b/pkg/targets/adapter/cloudevents/replier_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/response_header.go
+++ b/pkg/targets/adapter/cloudevents/response_header.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/cloudevents/response_options.go
+++ b/pkg/targets/adapter/cloudevents/response_options.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/confluenttarget/adapter_test.go
+++ b/pkg/targets/adapter/confluenttarget/adapter_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/confluenttarget/config.go
+++ b/pkg/targets/adapter/confluenttarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/confluenttarget/kafka.go
+++ b/pkg/targets/adapter/confluenttarget/kafka.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/datadogtarget/adapter.go
+++ b/pkg/targets/adapter/datadogtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/datadogtarget/config.go
+++ b/pkg/targets/adapter/datadogtarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/datadogtarget/types.go
+++ b/pkg/targets/adapter/datadogtarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/elasticsearchtarget/adapter.go
+++ b/pkg/targets/adapter/elasticsearchtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/elasticsearchtarget/config.go
+++ b/pkg/targets/adapter/elasticsearchtarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/elasticsearchtarget/config_test.go
+++ b/pkg/targets/adapter/elasticsearchtarget/config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package elasticsearchtarget
 
 import (

--- a/pkg/targets/adapter/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudfirestoretarget/config.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudfirestoretarget/types.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudstoragetarget/config.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudstoragetarget/types.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudworkflowstarget/config.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlecloudworkflowstarget/types.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlesheettarget/adapter.go
+++ b/pkg/targets/adapter/googlesheettarget/adapter.go
@@ -1,9 +1,12 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-   http://www.apache.org/licenses/LICENSE-2.0
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/targets/adapter/googlesheettarget/adapter_test.go
+++ b/pkg/targets/adapter/googlesheettarget/adapter_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlesheettarget/config.go
+++ b/pkg/targets/adapter/googlesheettarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/googlesheettarget/types.go
+++ b/pkg/targets/adapter/googlesheettarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/hasuratarget/adapter.go
+++ b/pkg/targets/adapter/hasuratarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/hasuratarget/config.go
+++ b/pkg/targets/adapter/hasuratarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/httptarget/adapter_test.go
+++ b/pkg/targets/adapter/httptarget/adapter_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/httptarget/config.go
+++ b/pkg/targets/adapter/httptarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/httptarget/types.go
+++ b/pkg/targets/adapter/httptarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/infratarget/adapter.go
+++ b/pkg/targets/adapter/infratarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/infratarget/adapter_test.go
+++ b/pkg/targets/adapter/infratarget/adapter_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/infratarget/config.go
+++ b/pkg/targets/adapter/infratarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/infratarget/vm/javascript/javascript_vm.go
+++ b/pkg/targets/adapter/infratarget/vm/javascript/javascript_vm.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/infratarget/vm/vm.go
+++ b/pkg/targets/adapter/infratarget/vm/vm.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/jiratarget/adapter.go
+++ b/pkg/targets/adapter/jiratarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/jiratarget/adapter_test.go
+++ b/pkg/targets/adapter/jiratarget/adapter_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/jiratarget/config.go
+++ b/pkg/targets/adapter/jiratarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/jiratarget/types.go
+++ b/pkg/targets/adapter/jiratarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/logztarget/adapter.go
+++ b/pkg/targets/adapter/logztarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/logztarget/config.go
+++ b/pkg/targets/adapter/logztarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/oracletarget/adapter.go
+++ b/pkg/targets/adapter/oracletarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/oracletarget/config.go
+++ b/pkg/targets/adapter/oracletarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/salesforcetarget/adapter.go
+++ b/pkg/targets/adapter/salesforcetarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/salesforcetarget/auth/jwt.go
+++ b/pkg/targets/adapter/salesforcetarget/auth/jwt.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/salesforcetarget/client/client.go
+++ b/pkg/targets/adapter/salesforcetarget/client/client.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/salesforcetarget/client/types.go
+++ b/pkg/targets/adapter/salesforcetarget/client/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/salesforcetarget/config.go
+++ b/pkg/targets/adapter/salesforcetarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/sendgridtarget/adapter.go
+++ b/pkg/targets/adapter/sendgridtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/sendgridtarget/config.go
+++ b/pkg/targets/adapter/sendgridtarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/sendgridtarget/types.go
+++ b/pkg/targets/adapter/sendgridtarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/slacktarget/adapter.go
+++ b/pkg/targets/adapter/slacktarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/slacktarget/config.go
+++ b/pkg/targets/adapter/slacktarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/slacktarget/slack/methods.go
+++ b/pkg/targets/adapter/slacktarget/slack/methods.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/slacktarget/slack/webapi.go
+++ b/pkg/targets/adapter/slacktarget/slack/webapi.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/slacktarget/slack/webapi_test.go
+++ b/pkg/targets/adapter/slacktarget/slack/webapi_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/splunktarget/adapter.go
+++ b/pkg/targets/adapter/splunktarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/splunktarget/adapter_test.go
+++ b/pkg/targets/adapter/splunktarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh, Inc
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/tektontarget/adapter.go
+++ b/pkg/targets/adapter/tektontarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/tektontarget/config.go
+++ b/pkg/targets/adapter/tektontarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/test/test_cloudevents.go
+++ b/pkg/targets/adapter/test/test_cloudevents.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/twiliotarget/adapter.go
+++ b/pkg/targets/adapter/twiliotarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/twiliotarget/config.go
+++ b/pkg/targets/adapter/twiliotarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/twiliotarget/types.go
+++ b/pkg/targets/adapter/twiliotarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/uipathtarget/adapter.go
+++ b/pkg/targets/adapter/uipathtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/uipathtarget/config.go
+++ b/pkg/targets/adapter/uipathtarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/uipathtarget/types.go
+++ b/pkg/targets/adapter/uipathtarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/zendesktarget/adapter.go
+++ b/pkg/targets/adapter/zendesktarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/zendesktarget/config.go
+++ b/pkg/targets/adapter/zendesktarget/config.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/adapter/zendesktarget/types.go
+++ b/pkg/targets/adapter/zendesktarget/types.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/alibabaosstarget/adapter.go
+++ b/pkg/targets/reconciler/alibabaosstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/controller.go
+++ b/pkg/targets/reconciler/alibabaosstarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/alibabaosstarget/controller_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/reconciler.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/adapter.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/controller.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awscomprehendtarget/controller_test.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/reconciler.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/dynamodb_controller.go
+++ b/pkg/targets/reconciler/awstarget/dynamodb_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/dynamodb_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/dynamodb_reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/kinesis_controller.go
+++ b/pkg/targets/reconciler/awstarget/kinesis_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/kinesis_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/kinesis_reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package awstarget
 
 import (

--- a/pkg/targets/reconciler/awstarget/lambda_controller.go
+++ b/pkg/targets/reconciler/awstarget/lambda_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/lambda_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/lambda_reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package awstarget
 
 import (

--- a/pkg/targets/reconciler/awstarget/s3_controller.go
+++ b/pkg/targets/reconciler/awstarget/s3_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/s3_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/s3_reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package awstarget
 
 import (

--- a/pkg/targets/reconciler/awstarget/sns_controller.go
+++ b/pkg/targets/reconciler/awstarget/sns_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/sns_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/sns_reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package awstarget
 
 import (

--- a/pkg/targets/reconciler/awstarget/sqs_controller.go
+++ b/pkg/targets/reconciler/awstarget/sqs_controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/awstarget/sqs_reconciler.go
+++ b/pkg/targets/reconciler/awstarget/sqs_reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package awstarget
 
 import (

--- a/pkg/targets/reconciler/awstarget/target_adapter.go
+++ b/pkg/targets/reconciler/awstarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/adapter.go
+++ b/pkg/targets/reconciler/confluenttarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/confluenttarget/controller.go
+++ b/pkg/targets/reconciler/confluenttarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/confluenttarget/controller_test.go
+++ b/pkg/targets/reconciler/confluenttarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/reconciler.go
+++ b/pkg/targets/reconciler/confluenttarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/datadogtarget/adapter.go
+++ b/pkg/targets/reconciler/datadogtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/controller.go
+++ b/pkg/targets/reconciler/datadogtarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/datadogtarget/controller_test.go
+++ b/pkg/targets/reconciler/datadogtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/reconciler.go
+++ b/pkg/targets/reconciler/datadogtarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/deployment.go
+++ b/pkg/targets/reconciler/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/doc.go
+++ b/pkg/targets/reconciler/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/controller.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/elasticsearchtarget/controller_test.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/reconciler.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/target_adapter.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/event/event.go
+++ b/pkg/targets/reconciler/event/event.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/event/event_test.go
+++ b/pkg/targets/reconciler/event/event_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudstoragetarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlesheettarget/controller.go
+++ b/pkg/targets/reconciler/googlesheettarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/googlesheettarget/controller_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/reconciler.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/target_adapter.go
+++ b/pkg/targets/reconciler/googlesheettarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/adapter.go
+++ b/pkg/targets/reconciler/hasuratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/controller.go
+++ b/pkg/targets/reconciler/hasuratarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/controller_test.go
+++ b/pkg/targets/reconciler/hasuratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/reconciler.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/adapter.go
+++ b/pkg/targets/reconciler/httptarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/controller.go
+++ b/pkg/targets/reconciler/httptarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/httptarget/controller_test.go
+++ b/pkg/targets/reconciler/httptarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/reconciler.go
+++ b/pkg/targets/reconciler/httptarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/httptarget/reconciler_test.go
+++ b/pkg/targets/reconciler/httptarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/adapter.go
+++ b/pkg/targets/reconciler/infratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/controller.go
+++ b/pkg/targets/reconciler/infratarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/infratarget/controller_test.go
+++ b/pkg/targets/reconciler/infratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/reconciler.go
+++ b/pkg/targets/reconciler/infratarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/infratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/infratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/adapter.go
+++ b/pkg/targets/reconciler/jiratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/controller.go
+++ b/pkg/targets/reconciler/jiratarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/jiratarget/controller_test.go
+++ b/pkg/targets/reconciler/jiratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/reconciler.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/jiratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/kservice.go
+++ b/pkg/targets/reconciler/kservice.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/adapter.go
+++ b/pkg/targets/reconciler/logztarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/logztarget/controller.go
+++ b/pkg/targets/reconciler/logztarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/logztarget/controller_test.go
+++ b/pkg/targets/reconciler/logztarget/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/logztarget/reconciler.go
+++ b/pkg/targets/reconciler/logztarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/logztarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logztarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/controller.go
+++ b/pkg/targets/reconciler/oracletarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/oracletarget/controller_test.go
+++ b/pkg/targets/reconciler/oracletarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/reconciler.go
+++ b/pkg/targets/reconciler/oracletarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/oracletarget/target_adapter.go
+++ b/pkg/targets/reconciler/oracletarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/reconcile_adapter.go
+++ b/pkg/targets/reconciler/reconcile_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/resources/env.go
+++ b/pkg/targets/reconciler/resources/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/resources/kservice.go
+++ b/pkg/targets/reconciler/resources/kservice.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/resources/labels.go
+++ b/pkg/targets/reconciler/resources/labels.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/salesforcetarget/adapter.go
+++ b/pkg/targets/reconciler/salesforcetarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/controller.go
+++ b/pkg/targets/reconciler/salesforcetarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/salesforcetarget/controller_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/reconciler.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/semantic/semantic.go
+++ b/pkg/targets/reconciler/semantic/semantic.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/semantic/semantic_test.go
+++ b/pkg/targets/reconciler/semantic/semantic_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/controller.go
+++ b/pkg/targets/reconciler/sendgridtarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/sendgridtarget/controller_test.go
+++ b/pkg/targets/reconciler/sendgridtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/reconciler.go
+++ b/pkg/targets/reconciler/sendgridtarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/sendgridtarget/target_adapter.go
+++ b/pkg/targets/reconciler/sendgridtarget/target_adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/service.go
+++ b/pkg/targets/reconciler/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/controller.go
+++ b/pkg/targets/reconciler/slacktarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/slacktarget/controller_test.go
+++ b/pkg/targets/reconciler/slacktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/reconciler.go
+++ b/pkg/targets/reconciler/slacktarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/slacktarget/target_adapter.go
+++ b/pkg/targets/reconciler/slacktarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/splunktarget/controller.go
+++ b/pkg/targets/reconciler/splunktarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/controller_test.go
+++ b/pkg/targets/reconciler/splunktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/labels.go
+++ b/pkg/targets/reconciler/splunktarget/labels.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/splunktarget/reconciler.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/splunktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/stateful.go
+++ b/pkg/targets/reconciler/stateful.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/status.go
+++ b/pkg/targets/reconciler/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/controller.go
+++ b/pkg/targets/reconciler/tektontarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/tektontarget/reconciler.go
+++ b/pkg/targets/reconciler/tektontarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/tektontarget/serviceaccount.go
+++ b/pkg/targets/reconciler/tektontarget/serviceaccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/target_adapter.go
+++ b/pkg/targets/reconciler/tektontarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/controller.go
+++ b/pkg/targets/reconciler/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/doc.go
+++ b/pkg/targets/reconciler/testing/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/factory.go
+++ b/pkg/targets/reconciler/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/listers.go
+++ b/pkg/targets/reconciler/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/ownerrefable.go
+++ b/pkg/targets/reconciler/testing/ownerrefable.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/testing/utils.go
+++ b/pkg/targets/reconciler/testing/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/controller.go
+++ b/pkg/targets/reconciler/twiliotarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/twiliotarget/controller_test.go
+++ b/pkg/targets/reconciler/twiliotarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/reconciler.go
+++ b/pkg/targets/reconciler/twiliotarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/twiliotarget/target_adapter.go
+++ b/pkg/targets/reconciler/twiliotarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/adapter.go
+++ b/pkg/targets/reconciler/uipathtarget/adapter.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/uipathtarget/controller.go
+++ b/pkg/targets/reconciler/uipathtarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/uipathtarget/controller_test.go
+++ b/pkg/targets/reconciler/uipathtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/reconciler.go
+++ b/pkg/targets/reconciler/uipathtarget/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/values_from.go
+++ b/pkg/targets/reconciler/values_from.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/controller.go
+++ b/pkg/targets/reconciler/zendesktarget/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/targets/reconciler/zendesktarget/controller_test.go
+++ b/pkg/targets/reconciler/zendesktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/reconciler.go
+++ b/pkg/targets/reconciler/zendesktarget/reconciler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package zendesktarget
 
 import (

--- a/pkg/targets/reconciler/zendesktarget/target_adapter.go
+++ b/pkg/targets/reconciler/zendesktarget/target_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Add missing headers ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/pkg/targets/adapter/elasticsearchtarget/config_test.go#L1))
- Remove '(c)' ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/cmd/googlecloudfirestore-target-adapter/main.go#L2))
- "TriggerMesh, Inc" -> "TriggerMesh Inc." ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/pkg/apis/targets/v1alpha1/doc.go#L2))
- Replace date ranges ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/pkg/sources/reconciler/common/doc.go#L2))
- Use proper indentation of hyperlink ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/cmd/googlecloudfirestore-target-adapter/main.go#L8))
- Fix format where needed ([example](https://github.com/triggermesh/triggermesh/blob/905749cac8c29c9cffb72bcf8c92b2205b225eae/pkg/targets/adapter/googlesheettarget/adapter.go#L1-L12))

---

I used this command to detect missing and broken headers:
```shell
# https://github.com/mattmoor/boilerplate-check
boilerplate-check check --boilerplate hack/boilerplate/boilerplate.go.txt --file-extension 'go'
```