### PR TITLE
Ensure container images include LICENSE and EULA

### DIFF
--- a/cmd/alibabaoss-target-adapter/Dockerfile
+++ b/cmd/alibabaoss-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Alib
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/alibabaoss-target-adapter /alibabaoss-target-adapter
 

--- a/cmd/aws-target-adapter/Dockerfile
+++ b/cmd/aws-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for AWS"
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/aws-target-adapter /aws-target-adapter
 

--- a/cmd/awscomprehend-target-adapter/Dockerfile
+++ b/cmd/awscomprehend-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for AWS 
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/awscomprehend-target-adapter /awscomprehend-target-adapter
 

--- a/cmd/confluent-target-adapter/Dockerfile
+++ b/cmd/confluent-target-adapter/Dockerfile
@@ -47,7 +47,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Conf
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/confluent-target-adapter /confluent-target-adapter
 

--- a/cmd/datadog-target-adapter/Dockerfile
+++ b/cmd/datadog-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Data
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/datadog-target-adapter /datadog-target-adapter
 

--- a/cmd/elasticsearch-target-adapter/Dockerfile
+++ b/cmd/elasticsearch-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Elas
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/elasticsearch-target-adapter /elasticsearch-target-adapter
 

--- a/cmd/googlecloudfirestore-target-adapter/Dockerfile
+++ b/cmd/googlecloudfirestore-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Goog
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/googlecloudfirestore-target-adapter /googlecloudfirestore-target-adapter
 

--- a/cmd/googlecloudstorage-target-adapter/Dockerfile
+++ b/cmd/googlecloudstorage-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Goog
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/googlecloudstorage-target-adapter /googlecloudstorage-target-adapter
 

--- a/cmd/googlecloudworkflows-target-adapter/Dockerfile
+++ b/cmd/googlecloudworkflows-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Goog
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/googlecloudworkflows-target-adapter /googlecloudworkflows-target-adapter
 

--- a/cmd/googlesheet-target-adapter/Dockerfile
+++ b/cmd/googlesheet-target-adapter/Dockerfile
@@ -47,7 +47,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Goog
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/googlesheet-target-adapter /googlesheet-target-adapter
 

--- a/cmd/hasura-target-adapter/Dockerfile
+++ b/cmd/hasura-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Hasu
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/hasura-target-adapter /hasura-target-adapter
 

--- a/cmd/http-target-adapter/Dockerfile
+++ b/cmd/http-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for HTTP
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/http-target-adapter /http-target-adapter
 

--- a/cmd/infra-target-adapter/Dockerfile
+++ b/cmd/infra-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Clou
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/infra-target-adapter /infra-target-adapter
 

--- a/cmd/jira-target-adapter/Dockerfile
+++ b/cmd/jira-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Jira
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/jira-target-adapter /jira-target-adapter
 

--- a/cmd/logz-target-adapter/Dockerfile
+++ b/cmd/logz-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Logz
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/logz-target-adapter /logz-target-adapter
 

--- a/cmd/oracle-target-adapter/Dockerfile
+++ b/cmd/oracle-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Orac
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/oracle-target-adapter /oracle-target-adapter
 

--- a/cmd/salesforce-target-adapter/Dockerfile
+++ b/cmd/salesforce-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Sale
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/salesforce-target-adapter /salesforce-target-adapter
 

--- a/cmd/sendgrid-target-adapter/Dockerfile
+++ b/cmd/sendgrid-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Send
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/sendgrid-target-adapter /sendgrid-target-adapter
 

--- a/cmd/slack-target-adapter/Dockerfile
+++ b/cmd/slack-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Slac
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/slack-target-adapter /slack-target-adapter
 

--- a/cmd/splunk-target-adapter/Dockerfile
+++ b/cmd/splunk-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Splu
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/splunk-target-adapter /splunk-target-adapter
 

--- a/cmd/tekton-target-adapter/Dockerfile
+++ b/cmd/tekton-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Tekt
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/tekton-target-adapter /tekton-target-adapter
 

--- a/cmd/twilio-target-adapter/Dockerfile
+++ b/cmd/twilio-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Twil
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/twilio-target-adapter /twilio-target-adapter
 

--- a/cmd/uipath-target-adapter/Dockerfile
+++ b/cmd/uipath-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for UiPa
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/uipath-target-adapter /uipath-target-adapter
 

--- a/cmd/zendesk-target-adapter/Dockerfile
+++ b/cmd/zendesk-target-adapter/Dockerfile
@@ -43,7 +43,7 @@ LABEL description "This is the Triggermesh Knative Event Target Adapter for Zend
 
 ENV KO_DATA_PATH /kodata
 
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/zendesk-target-adapter /zendesk-target-adapter
 


### PR DESCRIPTION
Some COPY directives are outdated.
Both the LICENSE and EULA are at the root of the repo.