### PR TITLE
Update Go base image to 1.17-bullseye

### DIFF
--- a/cmd/alibabaoss-target-adapter/Dockerfile
+++ b/cmd/alibabaoss-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/aws-target-adapter/Dockerfile
+++ b/cmd/aws-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscloudwatchlogssource/Dockerfile
+++ b/cmd/awscloudwatchlogssource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscloudwatchsource/Dockerfile
+++ b/cmd/awscloudwatchsource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscodecommitsource/Dockerfile
+++ b/cmd/awscodecommitsource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscognitoidentitysource/Dockerfile
+++ b/cmd/awscognitoidentitysource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscognitouserpoolsource/Dockerfile
+++ b/cmd/awscognitouserpoolsource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awscomprehend-target-adapter/Dockerfile
+++ b/cmd/awscomprehend-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awsdynamodbsource/Dockerfile
+++ b/cmd/awsdynamodbsource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awskinesissource/Dockerfile
+++ b/cmd/awskinesissource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awsperformanceinsightssource/Dockerfile
+++ b/cmd/awsperformanceinsightssource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awssnssource/Dockerfile
+++ b/cmd/awssnssource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/awssqssource/Dockerfile
+++ b/cmd/awssqssource/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/azureeventhubsource-adapter/Dockerfile
+++ b/cmd/azureeventhubsource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/azurequeuestoragesource-adapter/Dockerfile
+++ b/cmd/azurequeuestoragesource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/confluent-target-adapter/Dockerfile
+++ b/cmd/confluent-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 1
 ENV GOOS linux

--- a/cmd/datadog-target-adapter/Dockerfile
+++ b/cmd/datadog-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/elasticsearch-target-adapter/Dockerfile
+++ b/cmd/elasticsearch-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/googlecloudfirestore-target-adapter/Dockerfile
+++ b/cmd/googlecloudfirestore-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/googlecloudpubsubsource-adapter/Dockerfile
+++ b/cmd/googlecloudpubsubsource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/googlecloudstorage-target-adapter/Dockerfile
+++ b/cmd/googlecloudstorage-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/googlecloudworkflows-target-adapter/Dockerfile
+++ b/cmd/googlecloudworkflows-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/googlesheet-target-adapter/Dockerfile
+++ b/cmd/googlesheet-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 1
 ENV GOOS linux

--- a/cmd/hasura-target-adapter/Dockerfile
+++ b/cmd/hasura-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/http-target-adapter/Dockerfile
+++ b/cmd/http-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/httppollersource-adapter/Dockerfile
+++ b/cmd/httppollersource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/infra-target-adapter/Dockerfile
+++ b/cmd/infra-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/jira-target-adapter/Dockerfile
+++ b/cmd/jira-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/logz-target-adapter/Dockerfile
+++ b/cmd/logz-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/ocimetricssource-adapter/Dockerfile
+++ b/cmd/ocimetricssource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/oracle-target-adapter/Dockerfile
+++ b/cmd/oracle-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/salesforce-target-adapter/Dockerfile
+++ b/cmd/salesforce-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/salesforcesource-adapter/Dockerfile
+++ b/cmd/salesforcesource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/sendgrid-target-adapter/Dockerfile
+++ b/cmd/sendgrid-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/slack-target-adapter/Dockerfile
+++ b/cmd/slack-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/slacksource-adapter/Dockerfile
+++ b/cmd/slacksource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/splunk-target-adapter/Dockerfile
+++ b/cmd/splunk-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/tekton-target-adapter/Dockerfile
+++ b/cmd/tekton-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/transformation-adapter/Dockerfile
+++ b/cmd/transformation-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/triggermesh-controller/Dockerfile
+++ b/cmd/triggermesh-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/triggermesh-webhook/Dockerfile
+++ b/cmd/triggermesh-webhook/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/twilio-target-adapter/Dockerfile
+++ b/cmd/twilio-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/twiliosource-adapter/Dockerfile
+++ b/cmd/twiliosource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/uipath-target-adapter/Dockerfile
+++ b/cmd/uipath-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/webhooksource-adapter/Dockerfile
+++ b/cmd/webhooksource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/zendesk-target-adapter/Dockerfile
+++ b/cmd/zendesk-target-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/cmd/zendesksource-adapter/Dockerfile
+++ b/cmd/zendesksource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux


### PR DESCRIPTION
Same as #24, but this time for Docker base images.