### PR TITLE
Prepare update to Knative v0.26

### DIFF
--- a/pkg/routing/adapter/filter/reconciler.go
+++ b/pkg/routing/adapter/filter/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
@@ -38,7 +39,7 @@ type Reconciler struct {
 var (
 	_ reconcilerv1alpha1.Interface         = (*Reconciler)(nil)
 	_ reconcilerv1alpha1.ReadOnlyInterface = (*Reconciler)(nil)
-	_ reconcilerv1alpha1.ReadOnlyFinalizer = (*Reconciler)(nil)
+	_ reconciler.OnDeletionInterface       = (*Reconciler)(nil)
 )
 
 // ReconcileKind implements reconcilerv1alpha1.Interface.
@@ -67,8 +68,12 @@ func (r *Reconciler) reconcile(ctx context.Context, f *v1alpha1.Filter) error {
 	return nil
 }
 
-// ObserveFinalizeKind implements reconcilerv1alpha1.ReadOnlyFinalizer.
-func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, f *v1alpha1.Filter) reconciler.Event {
+// ObserveDeletion implements reconciler.OnDeletionInterface.
+func (r *Reconciler) ObserveDeletion(ctx context.Context, key types.NamespacedName) error {
+	f := &v1alpha1.Filter{}
+	f.SetName(key.Name)
+	f.SetNamespace(key.Namespace)
+
 	return r.finalize(ctx, f)
 }
 

--- a/pkg/routing/adapter/splitter/reconciler.go
+++ b/pkg/routing/adapter/splitter/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
@@ -38,7 +39,7 @@ type Reconciler struct {
 var (
 	_ reconcilerv1alpha1.Interface         = (*Reconciler)(nil)
 	_ reconcilerv1alpha1.ReadOnlyInterface = (*Reconciler)(nil)
-	_ reconcilerv1alpha1.ReadOnlyFinalizer = (*Reconciler)(nil)
+	_ reconciler.OnDeletionInterface       = (*Reconciler)(nil)
 )
 
 // ReconcileKind implements reconcilerv1alpha1.Interface.
@@ -67,8 +68,12 @@ func (r *Reconciler) reconcile(ctx context.Context, s *v1alpha1.Splitter) error 
 	return nil
 }
 
-// ObserveFinalizeKind implements reconcilerv1alpha1.ReadOnlyFinalizer.
-func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, s *v1alpha1.Splitter) reconciler.Event {
+// ObserveDeletion implements reconciler.OnDeletionInterface.
+func (r *Reconciler) ObserveDeletion(ctx context.Context, key types.NamespacedName) error {
+	s := &v1alpha1.Splitter{}
+	s.SetName(key.Name)
+	s.SetNamespace(key.Namespace)
+
 	return r.finalize(ctx, s)
 }
 

--- a/pkg/sources/adapter/zendesksource/reconciler.go
+++ b/pkg/sources/adapter/zendesksource/reconciler.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
@@ -38,7 +40,7 @@ type Reconciler struct {
 var (
 	_ reconcilerv1alpha1.Interface         = (*Reconciler)(nil)
 	_ reconcilerv1alpha1.ReadOnlyInterface = (*Reconciler)(nil)
-	_ reconcilerv1alpha1.ReadOnlyFinalizer = (*Reconciler)(nil)
+	_ reconciler.OnDeletionInterface       = (*Reconciler)(nil)
 )
 
 // ReconcileKind implements reconcilerv1alpha1.Interface.
@@ -67,8 +69,12 @@ func (r *Reconciler) reconcile(ctx context.Context, src *v1alpha1.ZendeskSource)
 	return nil
 }
 
-// ObserveFinalizeKind implements reconcilerv1alpha1.ReadOnlyFinalizer.
-func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, src *v1alpha1.ZendeskSource) reconciler.Event {
+// ObserveDeletion implements reconciler.OnDeletionInterface.
+func (r *Reconciler) ObserveDeletion(ctx context.Context, key types.NamespacedName) error {
+	src := &v1alpha1.ZendeskSource{}
+	src.SetName(key.Name)
+	src.SetNamespace(key.Namespace)
+
 	return r.finalize(ctx, src)
 }
 
@@ -77,6 +83,7 @@ func (r *Reconciler) finalize(ctx context.Context, src *v1alpha1.ZendeskSource) 
 		return fmt.Errorf("deregistering HTTP handler: %w", err)
 	}
 
-	return reconciler.NewEvent(corev1.EventTypeNormal, ReasonHandlerDeregistered,
-		"HTTP handler deregistered")
+	logging.FromContext(ctx).Info("HTTP handler deregistered")
+
+	return nil
 }


### PR DESCRIPTION
The following interface has been deprecated and no longer exists in Knative 0.26:

- The `ReadOnlyFinalizer` interface is no longer available and was replaced with `OnDeletionInterface`.
    - See https://github.com/knative/pkg/pull/2248
    -  Closes #30 as a side effect.

Will be done while updating to Knative 0.26, because not yet in 0.25:

- `controller.NewImplFull` is no longer available and was replaced with `NewContext`.
    - See https://github.com/knative/pkg/pull/2222
- `resolver.NewURIResolver` is no longer available and was replaced with `NewURIResolverFromTracker`.
    - See https://github.com/knative/pkg/pull/2228