### PR TITLE
Port knative target CRD updates

### DIFF
--- a/config/300-alibabaoss-crd.yaml
+++ b/config/300-alibabaoss-crd.yaml
@@ -49,17 +49,22 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Alibaba Object Storage Service.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               endpoint:
                 type: string
+                description: The domain name used to access the OSS. For more information, please refer to the region and endpoint guide at https://www.alibabacloud.com/help/doc-detail/31837.htm?spm=a2c63.p38356.879954.8.23bc7d91ARN6Hy#concept-zt4-cvy-5db
                 pattern: ^oss-([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{1,3}$
               bucket:
                 type: string
+                description: The unique container to store objects in OSS.
               accessKeySecret:
                 type: object
+                description: Alibaba SDK access key secret as registered. For more information on how to create an access key pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
                 properties:
                   secretKeyRef:
                     type: object
@@ -70,6 +75,7 @@ spec:
                         type: string
               accessKeyID:
                 type: object
+                description: Alibaba SDK access key id as registered. For more information on how to create an access key pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
                 properties:
                   secretKeyRef:
                     type: object
@@ -80,6 +86,7 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
@@ -91,8 +98,10 @@ spec:
             - endpoint
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
+                description: Array of cloud events this target will accept for processing.
                 type: array
                 items:
                   type: string

--- a/config/300-aws-crd.yaml
+++ b/config/300-aws-crd.yaml
@@ -46,12 +46,17 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for AWS DynamoDB.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               awsApiKey:
                 type: object
+                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -61,6 +66,9 @@ spec:
                       name:
                         type: string
               awsApiSecret:
+                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   secretKeyRef:
@@ -71,6 +79,8 @@ spec:
                       name:
                         type: string
               arn:
+                description: ARN of the DynamoDB table to post events to. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazondynamodb.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:dynamodb:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:table\/[a-zA-Z0-9-_.]{3,255}$
             required:
@@ -79,6 +89,7 @@ spec:
             - awsApiKey
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer
@@ -153,12 +164,17 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for AWS Lambda.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               awsApiKey:
                 type: object
+                description: API Key to interact with the Amazon Lambda API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -169,6 +185,9 @@ spec:
                         type: string
               awsApiSecret:
                 type: object
+                description: API Secret to interact with the Amazon Lambda API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -178,12 +197,16 @@ spec:
                       name:
                         type: string
               arn:
+                description: ARN of the Lambda function that will receive events. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:lambda:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:(function|layer|event-source-mapping):.+$
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from the lambda function.
                 type: boolean
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer
@@ -258,12 +281,17 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for AWS Simple Notification Service.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               awsApiKey:
                 type: object
+                description: API Key to interact with the SNS API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -274,6 +302,9 @@ spec:
                         type: string
               awsApiSecret:
                 type: object
+                description: API Secret to interact with the SNS API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -283,12 +314,16 @@ spec:
                       name:
                         type: string
               arn:
+                description: ARN of the SNS queue that will receive events. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsns.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from the SNS API call.
                 type: boolean
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer
@@ -363,11 +398,16 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for AWS Simple Queue Service.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               awsApiKey:
+                description: API Key to interact with the Amazon SQS API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   secretKeyRef:
@@ -378,6 +418,9 @@ spec:
                       name:
                         type: string
               awsApiSecret:
+                description: API Secret to interact with the Amazon SQS API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   secretKeyRef:
@@ -388,12 +431,16 @@ spec:
                       name:
                         type: string
               arn:
+                description: ARN of the SQS queue that will receive events. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from the lambda function.
                 type: boolean
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer
@@ -468,12 +515,16 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: An event target that can stream events into an AWS Kinesis stream.
         properties:
           spec:
             type: object
             properties:
               awsApiKey:
                 type: object
+                description: API Key to interact with the Amazon Kinesis API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -484,6 +535,9 @@ spec:
                         type: string
               awsApiSecret:
                 type: object
+                description: API Secret to interact with the Amazon Kinesis API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -493,14 +547,19 @@ spec:
                       name:
                         type: string
               arn:
+                description: ARN of the Kinesis stream that will receive events. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkinesis.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:kinesis:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:stream/.+$
               partition:
+                description: A Kinesis partition name is required for the target to know where to stream the events to.
                 type: string
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from the Kinesis invocation.
                 type: boolean
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer
@@ -585,12 +644,17 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: An event target that can stream events into an AWS S3 bucket.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               awsApiKey:
                 type: object
+                description: API Key to interact with the Amazon S3 API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -601,6 +665,9 @@ spec:
                         type: string
               awsApiSecret:
                 type: object
+                description: API Secret to interact with the Amazon S3 API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 properties:
                   secretKeyRef:
                     type: object
@@ -611,11 +678,15 @@ spec:
                         type: string
               arn:
                 type: string
+                description: ARN of the S3 bucket that will receive events. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
                 pattern: ^arn:aws(-cn|-us-gov)?:s3:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from the Kinesis invocation.
                 type: boolean
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-awscomprehend-crd.yaml
+++ b/config/300-awscomprehend-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright (c) 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,11 +46,16 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: An event targte for sending messages to the AWS Comprehend API.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               awsApiKey:
+                description: API Key to interact with the Comprehend API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   secretKeyRef:
@@ -61,6 +66,9 @@ spec:
                       name:
                         type: string
               awsApiSecret:
+                description: API Secret to interact with the Comprehend API. For more information about AWS
+                  security credentials, please refer to the AWS General Reference at
+                  https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
                 type: object
                 properties:
                   secretKeyRef:
@@ -71,8 +79,11 @@ spec:
                       name:
                         type: string
               region:
+                description: Code of the AWS region to use for the Comprehend API. Available region codes are documented in the
+                  AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
                 type: string
               language:
+                description: Language code to use for Comprehend. Available languages can be found at https://docs.aws.amazon.com/comprehend/latest/dg/supported-languages.html
                 type: string
             required:
             - region
@@ -81,6 +92,7 @@ spec:
             - awsApiKey
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-awscomprehend-crd.yaml
+++ b/config/300-awscomprehend-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-confluent-crd.yaml
+++ b/config/300-confluent-crd.yaml
@@ -40,14 +40,18 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Confluent Kafka.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               username:
+                description: Confluent account username when using SASL.
                 type: string
                 minLength: 1
               password:
+                description: Confluent account password when using SASL.
                 type: object
                 properties:
                   secretKeyRef:
@@ -58,22 +62,31 @@ spec:
                       name:
                         type: string
               topic:
+                description: Topic name to stream the target events to.
                 type: string
                 minLength: 1
               topicReplicationFactor:
+                description: The number of replicas required to stream to the topic.
                 type: integer
               topicPartitions:
+                description: The number of partitions used by the topic to stream an event to.
                 type: integer
               bootstrapServers:
+                description: Array of Confluent Kafka servers used to bootstrap the connection.
                 type: array
                 items:
                   type: string
                   minLength: 1
               securityProtocol:
+                description: Encryption protocol to use for connecting to Confluent Kafka.
+                  This can be "Plaintext", "SslPlaintext", "SaslSsl", or "Ssl". Additional information can be found at https://docs.confluent.io/platform/current/connect/security.html
                 type: string
               saslMechanism:
+                description: When using the "saslSsl" securityProtocol attribute, indicate which
+                  mechanism to use. This can be "Gssapi", "OAuthBearer", "Plain", "ScramSha256", and "ScramSha512".
                 type: string
               discardCloudEventContext:
+                description: Produce a new cloud event based on the response from calling Kafka.
                 type: boolean
             required:
             - username
@@ -82,6 +95,7 @@ spec:
             - bootstrapServers
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-datadog-crd.yaml
+++ b/config/300-datadog-crd.yaml
@@ -51,12 +51,15 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Datadog.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               apiKey:
                 type: object
+                description: Datadog API Key with access to receive metrics.
                 properties:
                   secretKeyRef:
                     type: object
@@ -66,6 +69,7 @@ spec:
                       name:
                         type: string
               eventOptions:
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 type: object
                 properties:
                   payloadPolicy:
@@ -75,6 +79,7 @@ spec:
             - apiKey
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-elasticsearch-crd.yaml
+++ b/config/300-elasticsearch-crd.yaml
@@ -49,25 +49,32 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Elasticsearch.
         properties:
           spec:
             type: object
             properties:
               indexName:
+                description: Elasticsearch index to stream the events to.
                 type: string
               connection:
                 type: object
+                description: Attributes for connecting to a private Elasticsearch instance or Elastic cloud.
                 properties:
                   addresses:
+                    description: Hostname/IP Address of the Elasticsearch instance to stream events to.
                     type: array
                     items:
                       type: string
                       minLength: 1
                   skipVerify:
+                    description: Skip verification of SSL/TLS certificates.
                     type: boolean
                   username:
+                    description: Elasticsearch instance username.
                     type: string
                   password:
+                    description: Elasticsearch instance password.
                     type: object
                     properties:
                       secretKeyRef:
@@ -78,6 +85,7 @@ spec:
                           name:
                             type: string
                   apiKey:
+                    description: API Key to connect to the Elasticsearch instance.
                     type: object
                     properties:
                       secretKeyRef:
@@ -95,17 +103,20 @@ spec:
 
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
                     enum: [always, error, never]
               discardCloudEventContext:
+                description: Discard cloud event metadata from payload being sent to Elasticsearch.
                 type: boolean
             required:
             - connection
             - indexName
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-googlecloudstorage-crd.yaml
+++ b/config/300-googlecloudstorage-crd.yaml
@@ -50,13 +50,17 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Google Cloud Storage.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               bucketName:
+                description: GCP Storage bucket to stream events to.
                 type: string
               credentialsJson:
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information, refer to https://cloud.google.com/docs/authentication/production
                 type: object
                 properties:
                   secretKeyRef:
@@ -68,6 +72,7 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
@@ -77,6 +82,7 @@ spec:
             - bucketName
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-googlecloudworkflows-crd.yaml
+++ b/config/300-googlecloudworkflows-crd.yaml
@@ -49,11 +49,14 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Google Cloud Workflows.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               credentialsJson:
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information, refer to https://cloud.google.com/docs/authentication/production
                 type: object
                 properties:
                   secretKeyRef:
@@ -65,6 +68,7 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
@@ -73,6 +77,7 @@ spec:
             - credentialsJson
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-googlefirestore-crd.yaml
+++ b/config/300-googlefirestore-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright (c) 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,18 +55,24 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Google Cloud Firestore.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               defaultCollection:
+                description: Default firestore collection to stream events into.
                 type: string
               projectID:
+                description: Google Cloud Project ID associated with the firestore database.
                 type: string
               discardCloudEventContext:
+                description: Indicate whether the full cloud event payload should be sent to the target, or the data component only.
                 type: boolean
               credentialsJson:
                 type: object
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information, refer to https://cloud.google.com/docs/authentication/production
                 properties:
                   secretKeyRef:
                     type: object
@@ -77,6 +83,7 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string

--- a/config/300-googlefirestore-crd.yaml
+++ b/config/300-googlefirestore-crd.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TriggerMesh Inc.
+# Copyright 2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlesheet-crd.yaml
+++ b/config/300-googlesheet-crd.yaml
@@ -50,17 +50,22 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for appending or updating a Googlesheet.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               id:
                 type: string
+                description: Googlesheet ID associated with the document being targeted.
                 minLength: 1
               defaultPrefix:
                 type: string
+                description: A prefix to be used when creating a new sheet inside a document.
                 minLength: 1
               googleServiceAccount:
+                description: Google service account token used to authenticate access to the Googlesheet document.
                 type: object
                 properties:
                   secretKeyRef:
@@ -78,6 +83,7 @@ spec:
             - defaultPrefix
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-hasura-crd.yaml
+++ b/config/300-hasura-crd.yaml
@@ -49,22 +49,30 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event target for GraphQL based systems such as Hasura.
         type: object
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               endpoint:
+                description: REST endpoint for the GraphQL instance.
                 type: string
                 minLength: 1
               defaultRole:
+                description: The default role a query from this target should assume when it is not specified in the event payload.
                 type: string
               queries:
                 type: object
+                description: Preload GraphQL queries the target can respond to.
+                  When used, the queries are given a unique name that is referenced
+                  as a part of the cloudevent type 'io.triggermesh.graphql.query'.
                 additionalProperties:
                   type: string
               jwt:
                 type: object
+                description: A JavaScript Web Token (JWT) containing the credentials required to connect to Hasura.
                 properties:
                   secretKeyRef:
                     type: object
@@ -75,6 +83,7 @@ spec:
                         type: string
               admin:
                 type: object
+                description: An API token that acts as an alternative to the jwt token used to connect to Hasura.
                 properties:
                   secretKeyRef:
                     type: object
@@ -87,6 +96,7 @@ spec:
             - endpoint
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-http-crd.yaml
+++ b/config/300-http-crd.yaml
@@ -40,37 +40,45 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for generic HTTP endpoints.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               response:
                 type: object
                 properties:
                   eventType:
-                    description: EventType is required to set the Type for the ingested event
+                    description: EventType is required to set the Type for the ingested event.
                     type: string
                     minLength: 1
                   eventSource:
-                    description: EventSource is an optional but recommended field for identifying the instance producing the events
+                    description: EventSource is an optional but recommended field for identifying the instance producing the events.
                     type: string
                 required:
                 - eventType
               endpoint:
+                description: An HTTP based REST endpoint to stream events to.
                 type: string
                 format: url
                 pattern: ^https?:\/\/.+$
               method:
+                description: The HTTP method to use for the request.
                 type: string
                 enum: [GET, POST, PUT, PATCH, DELETE]
               skipVerify:
+                description: Skip validation and verification of the SSL/TLS certificate.
                 type: boolean
                 default: false
               caCertificate:
+                description: The CA certificate used to sign the certificated used by the target server.
                 type: string
               basicAuthUsername:
+                description: When using HTTP Basic authentication, the username to connect to the target service.
                 type: string
               basicAuthPassword:
+                description: When using HTTP Basic authentication, the password to connect to the target service.
                 type: object
                 properties:
                   secretKeyRef:
@@ -81,8 +89,10 @@ spec:
                       name:
                         type: string
               oauthClientID:
+                description: When using OAuth, the client id used to authenticate against the target service.
                 type: string
               oauthClientSecret:
+                description: When using OAuth, the client secret used to authenticate against the target service
                 type: object
                 properties:
                   secretKeyRef:
@@ -93,12 +103,15 @@ spec:
                       name:
                         type: string
               oauthTokenURL:
+                description: When using OAuth, the Token URL used to sign the request against.
                 type: string
               oauthScopes:
+                description: When using OAuth, the scopes required by the target to use the service.
                 type: array
                 items:
                   type: string
               headers:
+                description: Additional headers required to be set when communicating wiht the target service.
                 type: object
                 additionalProperties:
                   type: string
@@ -107,6 +120,7 @@ spec:
             - method
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-infra-crd.yaml
+++ b/config/300-infra-crd.yaml
@@ -39,12 +39,16 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event target to manipulate cloud events using JavaScript.
+          An event is consumed by the target, and a new event is produced in the response.
         type: object
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               script:
+                description: JavaScript code to invoke when an event comes in.
                 type: object
                 properties:
                   code:
@@ -55,6 +59,7 @@ spec:
                 - code
               state:
                 type: object
+                description: Indicate whether stateful headers should be created (ensure), propagated (propagate), or dropped (none).
                 properties:
                   headersPolicy:
                     type: string
@@ -62,12 +67,14 @@ spec:
                   bridge:
                     type: string
               typeLoopProtection:
+                description: Prevent the InfraTarget from consuming events it just produced.
                 type: boolean
             anyOf:
             - required: [script]
             - required: [state]
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-jira-crd.yaml
+++ b/config/300-jira-crd.yaml
@@ -52,17 +52,22 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Jira.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               auth:
                 type: object
+                description: Credentials to authenticate against the Jira instance.
                 properties:
                   user:
+                    description: Jira username for the target to use.
                     type: string
                     minLength: 1
                   token:
+                    description: Jira API token associated with the Jira user.
                     type: object
                     properties:
                       secretKeyRef:
@@ -76,10 +81,12 @@ spec:
                 - user
                 - token
               url:
+                description: Jira instance url.
                 type: string
                 format: url
                 pattern: ^https?:\/\/.+$
               eventOptions:
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 type: object
                 properties:
                   payloadPolicy:
@@ -90,6 +97,7 @@ spec:
             - url
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-logz-crd.yaml
+++ b/config/300-logz-crd.yaml
@@ -46,11 +46,14 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Logz.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:               
               shippingToken:
+                description: API token used to authenticate the event being streamed.
                 type: object
                 properties:
                   secretKeyRef:
@@ -62,12 +65,14 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
                     enum: [always, error, never]
               logsListenerURL:
                 type: string
+                description: Logz listener host to stream events to.
                 properties:
                   payloadPolicy:
                     type: string
@@ -77,6 +82,7 @@ spec:
             - logsListenerURL
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-oracle-crd.yaml
+++ b/config/300-oracle-crd.yaml
@@ -40,12 +40,16 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Oracle Cloud (OCI).
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               oracleApiPrivateKey:
                 type: object
+                description: Oracle API Private Key to sign each request to the Oracle Cloud.
+                  For details on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm
                 properties:
                   secretKeyRef:
                     type: object
@@ -56,6 +60,8 @@ spec:
                         type: string
               oracleApiPrivateKeyPassphrase:
                 type: object
+                description: Passphrase to unlock the private key used to sign each request to the Oracle Cloud.
+                  For details on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm
                 properties:
                   secretKeyRef:
                     type: object
@@ -66,6 +72,8 @@ spec:
                         type: string
               oracleApiPrivateKeyFingerprint:
                 type: object
+                description: MD5 fingerprint to identify the keypair associated with the key used to sign each request to the Oracle Cloud.
+                  For details on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm
                 properties:
                   secretKeyRef:
                     type: object
@@ -75,21 +83,26 @@ spec:
                       name:
                         type: string
               oracleTenancy:
+                description: The Oracle Cloud ID (OCID) of the tenant containing the service to be used on the Oracle Cloud.
                 type: string
               oracleUser:
+                description: The Oracle Cloud ID (OCID) of the user who owns the key used to interact with the Oracle Cloud.
                 type: string
               oracleRegion:
+                description: The Oracle Cloud region containing the service being executed. A full list of supported regions can be found at https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
               function:
                 type: object
+                description: Invoke a serverless function on the Oracle Cloud.
                 properties:
                   function:
+                    description: The Oracle Cloud ID (OCID) of the function being invoked.
                     type: string
-
             oneOf:
             - required: [function]
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-salesforce-crd.yaml
+++ b/config/300-salesforce-crd.yaml
@@ -49,25 +49,32 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Salesforce.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               auth:
                 type: object
+                description: Attributes required to setup OAuth authentication with Salesforce. To create the credentials, refer to https://help.salesforce.com/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm
                 properties:
                   clientID:
+                    description: OAuth Client ID used to identify the target.
                     type: string
                     minLength: 1
                   server:
+                    description: The Salesforce authentication URL associated with the instance being used.
                     type: string
                     format: uri
                     pattern: ^https?:\/\/.+$
                   user:
+                    description: Username associated with the Salesforce account.
                     type: string
                     minLength: 1
                   certKey:
                     type: object
+                    description: Salesforce requires a certificate to facilitate the authentication flow.
                     properties:
                       secretKeyRef:
                         type: object
@@ -83,9 +90,11 @@ spec:
                 - certKey
               apiVersion:
                 type: string
+                description: Salesforce API version to use for the target's integration with Salesforce.
                 pattern: v\d+\.\d+$
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
@@ -94,6 +103,7 @@ spec:
             - auth
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-sendgrid-crd.yaml
+++ b/config/300-sendgrid-crd.yaml
@@ -49,23 +49,32 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Sendgrid.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               defaultFromName:
+                description: Default name to use for the from field when sending email via Sendgrid.
                 type: string
               defaultToName:
+                description: Default name to use for the to field when sending email via Sendgrid.
                 type: string
               defaultToEmail:
+                description: Default email address to send mail to via Sendgrid.
                 type: string
               defaultFromEmail:
+                description: Default sender email address for sending mail via Sendgrid.
                 type: string
               defaultSubject:
+                description: Default subject to use for email sent via this target
                 type: string
               defaultMessage:
+                description: Default message to use for all email sent via this target.
                 type: string
               apiKey:
+                description: The Sendgrid API key used to authenticate access.
                 type: object
                 properties:
                   secretKeyRef:
@@ -77,6 +86,7 @@ spec:
                         type: string
               eventOptions:
                 type: object
+                description: "When should this target generate a response event for processing: always, on error, or never"
                 properties:
                   payloadPolicy:
                     type: string
@@ -85,6 +95,7 @@ spec:
             - apiKey
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-slack-crd.yaml
+++ b/config/300-slack-crd.yaml
@@ -49,12 +49,15 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Slack Web API.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               token:
                 type: object
+                description: Slack API token used to interface with Slack. Consult the Slack API documenation for details on how to setup an app for the target https://api.slack.com/web#authentication
                 properties:
                   secretKeyRef:
                     type: object
@@ -67,6 +70,7 @@ spec:
             - token
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-splunk-crd.yaml
+++ b/config/300-splunk-crd.yaml
@@ -40,16 +40,22 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Splunk.
         properties:
           spec:
             type: object
             properties:
               endpoint:
                 type: string
+                description: URL of the HTTP Event Collector (HEC). Only the
+                  scheme, hostname, and port (optionally) are evaluated, the URL path is trimmed if present.
+                  see https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector
                 format: url
                 pattern: ^https?:\/\/.+$
               token:
                 type: object
+                description: Token for authenticating requests against the HEC.
+                  See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#About_Event_Collector_tokens
                 properties:
                   value:
                     type: string
@@ -67,14 +73,17 @@ spec:
                 - required: [valueFromSecret]
               index:
                 type: string
+                description: Name of the index to send events to. When undefined, events are sent to the default index defined in the HEC token's configuration.
                 pattern: ^[\w-]+$
               skipTLSVerify:
+                description: Control whether the target should verify the SSL/TLS certificate used by the event collector.
                 type: boolean
             required:
             - endpoint
             - token
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-tekton-crd.yaml
+++ b/config/300-tekton-crd.yaml
@@ -49,12 +49,15 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Tekton.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               reapPolicy:
                 type: object
+                description: Specify when successful or failed jobs should remain before being cleand out.
                 properties:
                   success:
                     description: Minimum age of a successfully completed run object before automatic purging
@@ -66,6 +69,7 @@ spec:
                     pattern: ^\d+[mhd]$
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-twilio-crd.yaml
+++ b/config/300-twilio-crd.yaml
@@ -49,18 +49,21 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Twilio.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
-              topic:
-                type: string
               defaultPhoneFrom:
+                description: Default phone number to send the message from.
                 type: string
               defaultPhoneTo:
+                description: Default phone number to send the message to.
                 type: string
               sid:
                 type: object
+                description: Twilio account service ID (SID)
                 properties:
                   secretKeyRef:
                     type: object
@@ -71,6 +74,7 @@ spec:
                         type: string
               token:
                 type: object
+                description: Twilio API Token.
                 properties:
                   secretKeyRef:
                     type: object
@@ -84,6 +88,7 @@ spec:
             - token
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/config/300-uipath-crd.yaml
+++ b/config/300-uipath-crd.yaml
@@ -50,11 +50,14 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for UiPath.
         properties:
           spec:
+            description: Desired state of event target.
             type: object
             properties:
               userKey:
+                description: UiPath user refresh token to support OAuth based authentication. For additional details, refer to https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps
                 type: object
                 properties:
                   secretKeyRef:
@@ -65,16 +68,22 @@ spec:
                       name:
                         type: string
               robotName:
+                description: Robot to invoke. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-robots
                 type: string
               processName:
+                description: UiProccess encompassing the robot. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-processes
                 type: string
               tenantName:
+                description: UiPath tenant name. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-tenants
                 type: string
               accountLogicalName:
+                description: The unique site URL used to identify the UiPath tenant.
                 type: string
               clientID:
+                description: OAuth ClientID registered by UiPath to identify the target. For details on registering a new client, please see https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps
                 type: string
               organizationUnitID:
+                description: A grouping of orchestrator components within a tenant. For additional details, please see https://docs.uipath.com/orchestrator/docs/about-organization-units
                 type: string
             required:
             - organizationUnitID
@@ -86,6 +95,7 @@ spec:
             - userKey
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               observedGeneration:
                 type: integer

--- a/config/300-zendesk-crd.yaml
+++ b/config/300-zendesk-crd.yaml
@@ -50,18 +50,24 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: TriggerMesh event target for Zendesk.
         properties:
           spec:
             type: object
+            description: Desired state of event target.
             properties:
               subject:
+                description: Default subject line to use for tickets created using this target.
                 type: string
               subdomain:
+                description: User's subdomain on zendesk being targeted.
                 type: string
               email:
+                description: Default registered email address for interacting with Zendesk.
                 type: string
               token:
                 type: object
+                description: Zendesk API token for interacting with Zendesk.
                 properties:
                   secretKeyRef:
                     type: object
@@ -75,6 +81,7 @@ spec:
             - email
           status:
             type: object
+            description: Reported status of the event target.
             properties:
               acceptedEventTypes:
                 type: array

--- a/pkg/apis/targets/v1alpha1/alibabaoss_types.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,12 +49,20 @@ var (
 
 // AlibabaOSSTargetSpec holds the desired state of the AlibabaOSSTarget.
 type AlibabaOSSTargetSpec struct {
+	// Alibaba SDK access key id as registered. For more information on how to
+	// create an access key pair, please refer to
+	// https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
 	AccessKeyID SecretValueFromSource `json:"accessKeyID"`
 
+	// Alibaba SDK access key secret as registered.
 	AccessKeySecret SecretValueFromSource `json:"accessKeySecret"`
 
+	// The domain name used to access the OSS. For more information, please refer
+	// to the region and endpoint guide at
+	// https://www.alibabacloud.com/help/doc-detail/31837.htm?spm=a2c63.p38356.879954.8.23bc7d91ARN6Hy#concept-zt4-cvy-5db
 	Endpoint string `json:"endpoint"`
 
+	// The unique container to store objects in OSS.
 	Bucket string `json:"bucket"`
 
 	// EventOptions for targets

--- a/pkg/apis/targets/v1alpha1/alibabaoss_types.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,18 +51,19 @@ var (
 )
 
 type AWSComprehendTargetSpec struct {
-	// AWS account Key
+	// AWS account Key.
 	AWSApiKey SecretValueFromSource `json:"awsApiKey"`
 
-	// AWS account secret key
+	// AWS account secret key.
 	AWSApiSecret SecretValueFromSource `json:"awsApiSecret"`
 
-	// Region
+	// Region to use for calling into Comprehend API.
 	Region string `json:"region"`
 
-	// EventOptions for targets
+	// EventOptions for targets.
 	EventOptions *EventOptions `json:"eventOptions,omitempty"`
 
+	// Language code to use to interact with Comprehend. The supported list can be found at: https://docs.aws.amazon.com/comprehend/latest/dg/supported-languages.html
 	Language string `json:"language"`
 }
 

--- a/pkg/apis/targets/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,11 +53,11 @@ var (
 
 // ElasticsearchTargetSpec holds the desired state of the ElasticsearchTarget.
 type ElasticsearchTargetSpec struct {
-	// Connection information to elasticsearch
+	// Connection information to elasticsearch.
 	// +optional
 	Connection Connection `json:"connection"`
 
-	// IndexName to write to
+	// IndexName to write to.
 	IndexName string `json:"indexName"`
 
 	// Whether to omit CloudEvent context attributes in created documents.
@@ -65,20 +65,25 @@ type ElasticsearchTargetSpec struct {
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`
 
-	// EventOptions for targets
+	// EventOptions for targets.
 	EventOptions *EventOptions `json:"eventOptions,omitempty"`
 }
 
 // Connection contains connection and configuration parameters
 type Connection struct {
-	Addresses  []string `json:"addresses,omitempty"`
-	CACert     *string  `json:"caCert,omitempty"`
-	SkipVerify *bool    `json:"skipVerify,omitempty"`
+	// Array of hostnames or IP addresses to connect the target to.
+	Addresses []string `json:"addresses,omitempty"`
+	// CA Certificate used to verify connection with the Elasticsearch instance.
+	CACert *string `json:"caCert,omitempty"`
+	// Skip verification of the SSL certificate during the connection.
+	SkipVerify *bool `json:"skipVerify,omitempty"`
 
-	Username *string                `json:"username,omitempty"`
+	// Elasticsearch account username.
+	Username *string `json:"username,omitempty"`
+	// Elasticsearch account password.
 	Password *SecretValueFromSource `json:"password,omitempty"`
 
-	// When informed supersedes username and password
+	// When informed supersedes username and password.
 	APIKey *SecretValueFromSource `json:"apiKey,omitempty"`
 }
 

--- a/pkg/apis/targets/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_types.go
+++ b/pkg/apis/targets/v1alpha1/hasura_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_types.go
+++ b/pkg/apis/targets/v1alpha1/hasura_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,11 +50,20 @@ var (
 
 // HasuraTargetSpec defines the desired state of the event target.
 type HasuraTargetSpec struct {
-	Endpoint    string                 `json:"endpoint"`
-	JwtToken    *SecretValueFromSource `json:"jwt,omitempty"`
-	AdminToken  *SecretValueFromSource `json:"admin,omitempty"`
-	DefaultRole *string                `json:"defaultRole,omitempty"`
-	Queries     *map[string]string     `json:"queries,omitempty"`
+	// The GraphQL server endpoint.
+	Endpoint string `json:"endpoint"`
+	// A user token for interfacing with Hasura.
+	// +optional
+	JwtToken *SecretValueFromSource `json:"jwt,omitempty"`
+	// An alternate token for interfacing with Hasura using admin privileges.
+	// +optional
+	AdminToken *SecretValueFromSource `json:"admin,omitempty"`
+	// A default role that the queries should use when running the query.
+	// +optional
+	DefaultRole *string `json:"defaultRole,omitempty"`
+	// A predefined list of queries that an event can specify in the io.triggermesh.graphql.query event type.
+	// +optional
+	Queries *map[string]string `json:"queries,omitempty"`
 }
 
 // HasuraTargetStatus defines the observed state of the event target.

--- a/pkg/apis/targets/v1alpha1/infra_types.go
+++ b/pkg/apis/targets/v1alpha1/infra_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/infra_types.go
+++ b/pkg/apis/targets/v1alpha1/infra_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,9 +49,10 @@ type InfraTargetSpec struct {
 	// Script to be executed at every request.
 	Script *InfraTargetScript `json:"script,omitempty"`
 
-	// State actions and options
+	// State actions and options.
 	State *InfraTargetState `json:"state,omitempty"`
 
+	// TypeLoopProtection protect against infinite loops when the cloudevent type does not change.
 	TypeLoopProtection *bool `json:"typeLoopProtection,omitempty"`
 }
 

--- a/pkg/apis/targets/v1alpha1/jira_types.go
+++ b/pkg/apis/targets/v1alpha1/jira_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,13 +49,15 @@ type JiraTargetSpec struct {
 	// Authentication to interact with the Salesforce API.
 	Auth JiraAuth `json:"auth"`
 
-	// URL for Jira service
+	// URL for Jira service.
 	URL string `json:"url"`
 }
 
 // JiraAuth contains Jira credentials.
 type JiraAuth struct {
-	User  string                `json:"user"`
+	// Jira username to connect to the instance as.
+	User string `json:"user"`
+	// Jira API token bound to the user.
 	Token SecretValueFromSource `json:"token"`
 }
 

--- a/pkg/apis/targets/v1alpha1/jira_types.go
+++ b/pkg/apis/targets/v1alpha1/jira_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/oracle_types.go
+++ b/pkg/apis/targets/v1alpha1/oracle_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,28 +49,29 @@ var (
 )
 
 type OracleTargetSpec struct {
-	// Oracle User API private key
+	// Oracle User API private key.
 	OracleApiPrivateKey SecretValueFromSource `json:"oracleApiPrivateKey"`
 
-	// Oracle User API private key passphrase
+	// Oracle User API private key passphrase.
 	OracleApiPrivateKeyPassphrase SecretValueFromSource `json:"oracleApiPrivateKeyPassphrase"`
 
-	// Oracle User API cert fingerprint
+	// Oracle User API cert fingerprint.
 	OracleApiPrivateKeyFingerprint SecretValueFromSource `json:"oracleApiPrivateKeyFingerprint"`
 
-	// Oracle Tenancy OCID
+	// Oracle Tenancy OCID.
 	Tenancy string `json:"oracleTenancy"`
 
-	// Oracle User OCID associated with the API key
+	// Oracle User OCID associated with the API key.
 	User string `json:"oracleUser"`
 
-	// Oracle Cloud Region
+	// Oracle Cloud Region.
 	Region string `json:"oracleRegion"`
 
 	OracleFunctionSpec *OracleFunctionSpecSpec `json:"function,omitempty"`
 }
 
 type OracleFunctionSpecSpec struct {
+	// Oracle Cloud ID of the function to invoke.
 	Function string `json:"function,inline"`
 }
 

--- a/pkg/apis/targets/v1alpha1/oracle_types.go
+++ b/pkg/apis/targets/v1alpha1/oracle_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/salesforce_types.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,10 +63,14 @@ type SalesforceTargetSpec struct {
 
 // SalesforceAuth contains Salesforce credentials.
 type SalesforceAuth struct {
-	ClientID string                `json:"clientID"`
-	Server   string                `json:"server"`
-	User     string                `json:"user"`
-	CertKey  SecretValueFromSource `json:"certKey"`
+	// ClientID The OAuth ClientID used to identify the target integrating with Salesforce.
+	ClientID string `json:"clientID"`
+	// Server is the Salesforce instance used to integrate.
+	Server string `json:"server"`
+	// User is the username who the target will masquerade as when interacting with Salesforce.
+	User string `json:"user"`
+	// CertKey is the private key used to sign requests from the target.
+	CertKey SecretValueFromSource `json:"certKey"`
 }
 
 // SalesforceTargetStatus communicates the observed state of the SalesforceTarget (from the controller).

--- a/pkg/apis/targets/v1alpha1/salesforce_types.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/uipath_types.go
+++ b/pkg/apis/targets/v1alpha1/uipath_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,13 +50,20 @@ var (
 
 // UiPathTargetSpec defines the desired state of the event target.
 type UiPathTargetSpec struct {
-	UserKey            *SecretValueFromSource `json:"userKey"`
-	RobotName          string                 `json:"robotName"`
-	ProcessName        string                 `json:"processName"`
-	TenantName         string                 `json:"tenantName"`
-	AccountLogicalName string                 `json:"accountLogicalName"`
-	ClientID           string                 `json:"clientID"`
-	OrganizationUnitID string                 `json:"organizationUnitID"`
+	// UserKey An OAuth token used to obtain an access key.
+	UserKey *SecretValueFromSource `json:"userKey"`
+	// RobotName is the robot to invoke with this target.
+	RobotName string `json:"robotName"`
+	// ProccessName is the process name that will be used by UiPath for the target.
+	ProcessName string `json:"processName"`
+	// TenantName is the tenant that contains the components that will be invoked by the target.
+	TenantName string `json:"tenantName"`
+	// AccountLogicalName is the unique site URL used to identif the UiPath tenant.
+	AccountLogicalName string `json:"accountLogicalName"`
+	// ClientID is the OAuth id registered to this target.
+	ClientID string `json:"clientID"`
+	// OrganizationUnitID is the organization unit within the tenant that the UiPath proccess will run under.
+	OrganizationUnitID string `json:"organizationUnitID"`
 }
 
 // UiPathTargetStatus defines the observed state of the event target.

--- a/pkg/apis/targets/v1alpha1/uipath_types.go
+++ b/pkg/apis/targets/v1alpha1/uipath_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/zendesk_types.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,13 +53,13 @@ var (
 // ZendeskTargetSpec holds the desired state of the ZendeskTarget.
 type ZendeskTargetSpec struct {
 
-	// Token contains the Zendesk account Token
+	// Token contains the Zendesk account Token.
 	Token SecretValueFromSource `json:"token"`
 
-	// Subdomain the Zendesk subdomain
+	// Subdomain the Zendesk subdomain.
 	Subdomain string `json:"subdomain"`
 
-	// Email the regestierd Zendesk email account
+	// Email the registered Zendesk email account.
 	Email string `json:"email"`
 
 	// Subject a static subject assignemnt for every ticket.
@@ -79,7 +79,7 @@ type ZendeskTargetStatus struct {
 	// AddressStatus fulfills the Addressable contract.
 	duckv1.AddressStatus `json:",inline"`
 
-	// Accepted/emitted CloudEvent attributes
+	// Accepted/emitted CloudEvent attributes.
 	CloudEventStatus `json:",inline"`
 }
 

--- a/pkg/apis/targets/v1alpha1/zendesk_types.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 TriggerMesh Inc.
+Copyright 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Port updates made to the Knative Targets CRDs to enable `kubectl explain` to provide details on the spec attributes expected.