### PR TITLE
Update Dockerfile for azureservicebusqueuesource-adapter

### DIFF
--- a/cmd/azurequeuestoragesource-adapter/Dockerfile
+++ b/cmd/azurequeuestoragesource-adapter/Dockerfile
@@ -32,7 +32,7 @@ RUN BIN_OUTPUT_DIR=/bin make azurequeuestoragesource-adapter && \
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name "TriggerMesh Azure Queue Storage  Source"
+LABEL name "TriggerMesh Azure Queue Storage Source"
 LABEL vendor "TriggerMesh"
 LABEL version "v0.1.0"
 LABEL release "1"

--- a/cmd/azureservicebusqueuesource-adapter/Dockerfile
+++ b/cmd/azureservicebusqueuesource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-buster AS builder
+FROM golang:1.17-bullseye AS builder
 
 ENV CGO_ENABLED 0
 ENV GOOS linux
@@ -45,6 +45,6 @@ ENV KO_DATA_PATH /kodata
 
 COPY --from=builder /kodata/ ${KO_DATA_PATH}/
 COPY --from=builder /bin/azureservicebusqueuesource-adapter /
-COPY licenses/ /licenses/
+COPY LICENSE EULA.pdf /licenses/
 
 ENTRYPOINT ["/azureservicebusqueuesource-adapter"]


### PR DESCRIPTION
- Use the same base image as other components
- Fix the COPY instruction for license and EULA

Should have been done in #61 but I forgot to check the Dockerfile.