### PR TITLE
Read adapter's Image from implicit env var name

### DIFF
--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -40,7 +40,7 @@ const (
 // These are automatically populated by envconfig.
 type adapterConfig struct {
 	// Container image
-	Image string `envconfig:"AZUREIOTHUBSOURCE_IMAGE"  default:"gcr.io/triggermesh/azureiothubsource-adapter"`
+	Image string `default:"gcr.io/triggermesh/azureiothubsource-adapter"`
 	// Configuration accessor for logging/metrics/tracing
 	configs source.ConfigAccessor
 }

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -36,7 +36,7 @@ import (
 // These are automatically populated by envconfig.
 type adapterConfig struct {
 	// Container image
-	Image string `envconfig:"AZUREQUEUESTORAGESOURCE_IMAGE"  default:"gcr.io/triggermesh/azurequeuestoragesource-adapter"`
+	Image string `default:"gcr.io/triggermesh/azurequeuestoragesource-adapter"`
 	// Configuration accessor for logging/metrics/tracing
 	configs source.ConfigAccessor
 }

--- a/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
@@ -40,7 +40,7 @@ const (
 // These are automatically populated by envconfig.
 type adapterConfig struct {
 	// Container image
-	Image string `envconfig:"AZURESERVICEBUSQUEUESOURCE_IMAGE"  default:"gcr.io/triggermesh/azureservicebusqueuesource-adapter"`
+	Image string `default:"gcr.io/triggermesh/azureservicebusqueuesource-adapter"`
 	// Configuration accessor for logging/metrics/tracing
 	configs source.ConfigAccessor
 }


### PR DESCRIPTION
The kind of the Source reconciled by the controller is passed to `envconfig.MustProcess()`, which automatically resolves Image variables to `<KIND>_IMAGE`. Overriding this implicit name by hand in every reconciler is error prone and should be avoided.

This PR removes the only three occurrences where the implicit variable name was being overridden.