### PR TITLE
Add GitHub Actions workflow for static code analysis

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,28 @@
+name: Static Code Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    name: Code linting
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    # This action takes care of caching/restoring pkg and build caches.
+    # It needs to be the first step executed after the Go setup.
+    - name: Lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+# golangci-lint configuration
+#
+# For a list of all available configuration options with their default values, see:
+#  - https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+#  - https://golangci-lint.run/usage/configuration/
+
+linters:
+  enable:
+  - gofmt
+  - stylecheck
+
+run:
+  timeout: 5m


### PR DESCRIPTION
Integrates with GitHub Actions to provide immediate feedback on PRs when issues are found via static code analysis.

The only "static analysis" performed right now is linting (which includes gofmt checks). I can imagine us adding more in the near future, e.g. checks for EOF without newline character at the end of Kubernetes manifests, Dockerfiles, etc.

I deliberately pushed a broken commit, which I will revert upon approval, to demonstrate what is reported when issues are found.