### PR TITLE
Updates Replier's Event Type Mapping Failure Logic

### DIFF
--- a/pkg/targets/adapter/cloudevents/doc.go
+++ b/pkg/targets/adapter/cloudevents/doc.go
@@ -98,6 +98,10 @@ Usage:
 
 	// Create replier that will use a different static type response
 	// depending on the incoming type.
+	// If the incoming event type is not mapped the response will be
+	// the same as the incoming event type with `.response` appended.
+	// ie. if the incoming event type is `com.example.myevent` the
+	// response will be `com.example.myevent.response`
 	mt = map[string]string{
 		"search.snowball.io": "list.snowball.io",
 		"update.snowball.io": "product.snowball.io",

--- a/pkg/targets/adapter/cloudevents/response_header.go
+++ b/pkg/targets/adapter/cloudevents/response_header.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cloudevents
 
 import (
-	"fmt"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
@@ -44,7 +42,7 @@ func MappedResponseType(eventTypes map[string]string) ResponseHeaderValue {
 		if ok {
 			return v, nil
 		}
-		return "", fmt.Errorf("incoming type %q cannot be mapped to an outgoing event type", event.Type())
+		return event.Type() + ".response", nil
 	}
 }
 


### PR DESCRIPTION
Previously we would fail when mapping event types. I think we should instead append the incoming event type 
 with ".response" and use this. So for example, if the incoming event type is `com.example.myevent` the response event type will be `com.example.myevent.response` 