### PR TITLE
Functions, Transformations, Routing CRDs improved and documented

### DIFF
--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -39,31 +39,33 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh content-based events filter.
         type: object
         properties:
           spec:
+            description: Desired state of the filter.
             type: object
             required:
             - expression
             - sink
             properties:
               expression:
-                description: 'Google CEL-like expression string.'
+                description: Google CEL-like expression string.
                 type: string
               sink:
-                description: 'Sink is a reference to an object that will resolve to
-                    a uri to use as the sink.'
+                description: Sink is a reference to an object that will resolve to
+                    a uri to use as the sink.
                 type: object
                 oneOf:
                 - required: ["ref"]
                 - required: ["uri"]
                 properties:
                   ref:
-                    description: 'Ref points to an Addressable.'
+                    description: Ref points to an Addressable.
                     type: object
                     properties:
                       apiVersion:
-                        description: 'API version of the referent.'
+                        description: API version of the referent.
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -78,10 +80,10 @@ spec:
                           object holding it if left out.'
                         type: string
                   uri:
-                    description: 'URI can be an absolute URL(non-empty scheme and
+                    description: URI can be an absolute URL(non-empty scheme and
                       non-empty host) pointing to the target or a relative URI.
                       Relative URIs will be resolved using the base URI retrieved
-                      from Ref.'
+                      from Ref.
                     type: string
           status:
             type: object

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -39,9 +39,11 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh content-based events splitter.
         type: object
         properties:
           spec:
+            description: Desired state of the splitter.
             type: object
             required:
             - ceContext
@@ -69,19 +71,19 @@ spec:
                     additionalProperties:
                       type: string
               sink:
-                description: 'Sink is a reference to an object that will resolve to
-                    a uri to use as the sink.'
+                description: Sink is a reference to an object that will resolve to
+                    a uri to use as the sink.
                 type: object
                 oneOf:
                 - required: ["ref"]
                 - required: ["uri"]
                 properties:
                   ref:
-                    description: 'Ref points to an Addressable.'
+                    description: Ref points to an Addressable.
                     type: object
                     properties:
                       apiVersion:
-                        description: 'API version of the referent.'
+                        description: API version of the referent.
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -96,10 +98,10 @@ spec:
                           object holding it if left out.'
                         type: string
                   uri:
-                    description: 'URI can be an absolute URL(non-empty scheme and
+                    description: URI can be an absolute URL(non-empty scheme and
                       non-empty host) pointing to the target or a relative URI.
                       Relative URIs will be resolved using the base URI retrieved
-                      from Ref.'
+                      from Ref.
                     type: string
           status:
             type: object

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -39,9 +39,11 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh Function.
         type: object
         properties:
           spec:
+            description: Desired state of the function.
             type: object
             required:
             - runtime
@@ -49,29 +51,32 @@ spec:
             - code
             properties:
               runtime:
-                description: 'Function runtime name.'
+                description: Function runtime name. Python, Ruby or Node runtimes are currently supported.
                 type: string
+                enum: ["python", "ruby", "node"]
               code:
-                description: 'Function code.'
+                description: Function code.
                 type: string
               entrypoint:
-                description: 'Function name to use as an entrypoint.'
+                description: Function name to use as an entrypoint.
                 type: string
               public:
-                description: 'Should the function be publicly available.'
+                description: Should the function be publicly available.
                 type: boolean
-              responseMode:
-                description: 'Whether function responds with CE payload only or with full event.'
-                type: string
+              responseIsEvent:
+                description: Whether function responds with CE payload only or with full event.
+                type: boolean
               eventStore:
+                description: EventStore service connection string.
                 type: object
-                description: 'EventStore service connection string.'
                 properties:
                   uri:
                     type: string
+                required:
+                  - uri
               ceOverrides:
                 type: object
-                description: "Defines overrides to control modifications of the event attributes."
+                description: Defines overrides to control modifications of the event attributes.
                 properties:
                   extensions:
                     type: object
@@ -85,19 +90,19 @@ spec:
                 required:
                 - extensions
               sink:
-                description: 'Sink is a reference to an object that will resolve to
-                    a uri to use as the sink.'
+                description: Sink is a reference to an object that will resolve to
+                    a uri to use as the sink.
                 type: object
                 oneOf:
                 - required: ["ref"]
                 - required: ["uri"]
                 properties:
                   ref:
-                    description: 'Ref points to an Addressable.'
+                    description: Ref points to an Addressable.
                     type: object
                     properties:
                       apiVersion:
-                        description: 'API version of the referent.'
+                        description: API version of the referent.
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -112,10 +117,10 @@ spec:
                           object holding it if left out.'
                         type: string
                   uri:
-                    description: 'URI can be an absolute URL(non-empty scheme and
+                    description: URI can be an absolute URL(non-empty scheme and
                       non-empty host) pointing to the target or a relative URI.
                       Relative URIs will be resolved using the base URI retrieved
-                      from Ref.'
+                      from Ref.
                     type: string
           status:
             type: object

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -37,55 +37,73 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh CloudEvents transformation engine.
         type: object
         properties:
           spec:
+            description: Desired state of the transformation object.
             type: object
             properties:
               context:
+                description: CloudEvents Context attributes transformation spec.
                 type: array
-                items: 
+                items:
+                  description: The list of transformation operations executed on the event context sequentially.
                   type: object
                   properties:
                     operation:
+                      description: Name of the transformation operation.
                       type: string
+                      enum: ['add', 'delete', 'shift', 'store']
                     paths:
+                      description: Key-value event pairs to apply the transformations on.
                       type: array
                       items:
                         type: object
                         properties:
                           key:
+                            description: JSON path or variable name. Depends on the operation type.
                             nullable: true
                             type: string
                           value:
+                            description: JSON path or variable name. Depends on the operation type.
                             nullable: true
                             type: string
                   required:
                   - operation
               data:
+                description: CloudEvents Data transformation spec.
                 type: array
-                items: 
+                items:
+                  description: The list of transformation operations executed on the event data sequentially.
                   type: object
                   properties:
                     operation:
+                      description: Name of the transformation operation.
                       type: string
+                      enum: ['add', 'delete', 'shift', 'store']
                     paths:
+                      description: Key-value event pairs to apply the transformations on.
                       type: array
-                      items:
+                      items: 
                         type: object
                         properties:
                           key:
+                            description: JSON path or variable name. Depends on the operation type.
                             nullable: true
                             type: string
                           value:
+                            description: JSON path or variable name. Depends on the operation type.
                             nullable: true
                             type: string
                   required:
                   - operation
               sink:
+                description: The destination of events sourced from the transformation object.
                 type: object
                 properties:
                   ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
@@ -101,18 +119,22 @@ spec:
                     - kind
                     - name
                   uri:
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
                 - required: ['ref']
                 - required: ['uri']
           status:
+            description: Reported status of Transformation.
             type: object
             properties:
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:
+                description: CloudEvents context attributes overrides.
                 type: array
                 items:
                   type: object
@@ -148,6 +170,7 @@ spec:
                   - type
                   - status
               address:
+                description: Address of the HTTP/S endpoint where Transformation is serving incoming CloudEvents.
                 type: object
                 properties:
                   url:

--- a/config/samples/functions/python.yaml
+++ b/config/samples/functions/python.yaml
@@ -18,7 +18,7 @@ metadata:
   name: inline-python-function
 spec:
   runtime: python
-  responseMode: event
+  responseIsEvent: true
   public: true
   ceOverrides:
     extensions:

--- a/pkg/apis/extensions/v1alpha1/function_types.go
+++ b/pkg/apis/extensions/v1alpha1/function_types.go
@@ -55,7 +55,7 @@ type FunctionSpec struct {
 	Entrypoint          string                      `json:"entrypoint"`
 	Public              bool                        `json:"public,omitempty"`
 	Code                string                      `json:"code"`
-	ResponseMode        string                      `json:"responseMode,omitempty"`
+	ResponseIsEvent     bool                        `json:"responseIsEvent,omitempty"`
 	EventStore          EventStoreConnection        `json:"eventStore,omitempty"`
 	CloudEventOverrides *duckv1.CloudEventOverrides `json:"ceOverrides"`
 	Sink                *duckv1.Destination         `json:"sink"`

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -217,6 +217,11 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *v1alpha1.Functio
 		}
 	}
 
+	var responseMode string
+	if f.Spec.ResponseIsEvent {
+		responseMode = "event"
+	}
+
 	expectedKsvc := resources.NewKnService(f.Name+"-"+rand.String(6), f.Namespace,
 		resources.KnSvcImage(image),
 		resources.KnSvcMountCm(cm.Name, filename),
@@ -225,7 +230,7 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *v1alpha1.Functio
 		resources.KnSvcEnvVar("K_SINK", sink.String()),
 		resources.KnSvcEnvVar("_HANDLER", handler),
 		resources.KnSvcEnvVar("RESPONSE_FORMAT", "CLOUDEVENTS"),
-		resources.KnSvcEnvVar("CE_FUNCTION_RESPONSE_MODE", f.Spec.ResponseMode),
+		resources.KnSvcEnvVar("CE_FUNCTION_RESPONSE_MODE", responseMode),
 		resources.KnSvcEnvFromMap("CE_OVERRIDES_", overrides),
 		resources.KnSvcAnnotation("extensions.triggermesh.io/codeVersion", cm.ResourceVersion),
 		resources.KnSvcVisibility(f.Spec.Public),


### PR DESCRIPTION
Function, Transformation, and Routing CRDs updates:
- added missing field descriptions,
- added a couple of enum lists,
- removed quote marks to match the common style.

API changes:
- Function's `responseMode <string>` replaced with `responseIsEvent <bool>`. The field name can be discussed.