### PR TITLE
cloudbuild: set timeout to 1800s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - gcp-cli/initialize
       - run:
           name: Publishing docker image
-          command: IMAGE_SHA=${CIRCLE_SHA1} IMAGE_TAG=${CIRCLE_TAG:-latest} make -j6 cloudbuild
+          command: IMAGE_SHA=${CIRCLE_SHA1} IMAGE_TAG=${CIRCLE_TAG:-latest} make -j8 cloudbuild
 
   release:
     executor:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
   - ${_KANIKO_EXTRA_ARGS}
   waitFor: ['-']
 
-timeout: 1200s
+timeout: 1800s
 
 substitutions:
   _CMD:


### PR DESCRIPTION
Last two CI jobs failed as a result of build timeouts