### PR TITLE
Remove 'build' step from CircleCI flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,17 +19,6 @@ jobs:
             - go
             - project
 
-  build:
-    executor:
-      name: go/default
-      tag: '1.17'
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Building package
-          command: make build
-
   test:
     executor:
       name: go/default
@@ -90,16 +79,9 @@ jobs:
             for f in $(find /tmp/dist -type f); do github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f} ; done
 
 workflows:
-  build-test-and-publish:
+  test-and-publish:
     jobs:
       - checkout:
-          filters:
-            tags:
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
-      - build:
-          context: production
-          requires:
-            - checkout
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
@@ -112,7 +94,6 @@ workflows:
       - publish-image:
           context: production
           requires:
-            - build
             - test
           filters:
             tags:


### PR DESCRIPTION
@sameersbn this might be controversial so feel free to reject this PR and I won't insist 😛 

I'm proposing that we remove the `build` step (job) from the CircleCI flow, because
- the code is compiled in its entirety during static checks already (by `golangci-lint`)
- the code is also compiled during tests (the code that's being tested, at least)

That's at least 2 places where compilation errors would be caught.