### PR TITLE
release: publish triggermesh CRDs as seperate assets

### DIFF
--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: transformations.flow.triggermesh.io
+  labels:
+    triggermesh.io/crd-install: 'true'
 spec:
   group: flow.triggermesh.io
   scope: Namespaced
@@ -29,7 +31,7 @@ spec:
     - transformations
     shortNames:
     - trn
-  versions: 
+  versions:
   - name: v1alpha1
     served: true
     storage: true
@@ -85,7 +87,7 @@ spec:
                     paths:
                       description: Key-value event pairs to apply the transformations on.
                       type: array
-                      items: 
+                      items:
                         type: object
                         properties:
                           key:


### PR DESCRIPTION
Seperating the CRDs from rest of the resources would be useful when we have the helm chart, enabling users to manually update the CRDs on upgrades as Helm does not do it.