### PR TITLE
Use consistent name for source adapters constructors

### DIFF
--- a/cmd/httppollersource-adapter/main.go
+++ b/cmd/httppollersource-adapter/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	adapter.Main("httppoller", httppollersource.EnvAccessor, httppollersource.NewAdapter)
+	adapter.Main("httppoller", httppollersource.NewEnvConfig, httppollersource.NewAdapter)
 }

--- a/cmd/ocimetricssource-adapter/main.go
+++ b/cmd/ocimetricssource-adapter/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	adapter.Main("ocimetrics", ocimetricssource.EnvAccessorCtor, ocimetricssource.NewAdapter)
+	adapter.Main("ocimetrics", ocimetricssource.NewEnvConfig, ocimetricssource.NewAdapter)
 }

--- a/cmd/salesforcesource-adapter/main.go
+++ b/cmd/salesforcesource-adapter/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	adapter.Main("salesforce", salesforcesource.EnvAccessor, salesforcesource.NewAdapter)
+	adapter.Main("salesforce", salesforcesource.NewEnvConfig, salesforcesource.NewAdapter)
 }

--- a/cmd/slacksource-adapter/main.go
+++ b/cmd/slacksource-adapter/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	adapter.Main("slack", slacksource.EnvAccessor, slacksource.NewAdapter)
+	adapter.Main("slack", slacksource.NewEnvConfig, slacksource.NewAdapter)
 }

--- a/cmd/twiliosource-adapter/main.go
+++ b/cmd/twiliosource-adapter/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	adapter.Main("twiliosource", twiliosource.EnvAccessor, twiliosource.NewAdapter)
+	adapter.Main("twiliosource", twiliosource.NewEnvConfig, twiliosource.NewAdapter)
 }

--- a/cmd/webhooksource-adapter/main.go
+++ b/cmd/webhooksource-adapter/main.go
@@ -23,5 +23,5 @@ import (
 )
 
 func main() {
-	adapter.Main("webhook", webhooksource.EnvAccessor, webhooksource.NewAdapter)
+	adapter.Main("webhook", webhooksource.NewEnvConfig, webhooksource.NewAdapter)
 }

--- a/pkg/sources/adapter/httppollersource/env.go
+++ b/pkg/sources/adapter/httppollersource/env.go
@@ -22,8 +22,8 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// EnvAccessor for configuration parameters
-func EnvAccessor() adapter.EnvConfigAccessor {
+// NewEnvConfig for configuration parameters
+func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 

--- a/pkg/sources/adapter/ocimetricssource/config.go
+++ b/pkg/sources/adapter/ocimetricssource/config.go
@@ -22,8 +22,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 )
 
-// EnvAccessorCtor for configuration parameters
-func EnvAccessorCtor() adapter.EnvConfigAccessor {
+// NewEnvConfig for configuration parameters
+func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 

--- a/pkg/sources/adapter/salesforcesource/env.go
+++ b/pkg/sources/adapter/salesforcesource/env.go
@@ -18,8 +18,8 @@ package salesforcesource
 
 import "knative.dev/eventing/pkg/adapter/v2"
 
-// EnvAccessor for configuration parameters
-func EnvAccessor() adapter.EnvConfigAccessor {
+// NewEnvConfig for configuration parameters
+func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 

--- a/pkg/sources/adapter/slacksource/env.go
+++ b/pkg/sources/adapter/slacksource/env.go
@@ -20,8 +20,8 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// EnvAccessor for configuration parameters
-func EnvAccessor() adapter.EnvConfigAccessor {
+// NewEnvConfig for configuration parameters
+func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 

--- a/pkg/sources/adapter/twiliosource/twilio.go
+++ b/pkg/sources/adapter/twiliosource/twilio.go
@@ -43,8 +43,8 @@ type adapter struct {
 	logger      *zap.SugaredLogger
 }
 
-// EnvAccessor returns an accessor for the source's adapter envConfig.
-func EnvAccessor() pkgadapter.EnvConfigAccessor {
+// NewEnvConfig returns an accessor for the source's adapter envConfig.
+func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &pkgadapter.EnvConfig{}
 }
 

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -20,8 +20,8 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// EnvAccessor for configuration parameters
-func EnvAccessor() adapter.EnvConfigAccessor {
+// NewEnvConfig for configuration parameters
+func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 


### PR DESCRIPTION
A small PR that aims at improving naming consistency.

6 sources (out of 22) were using the name `EnvAccessor` as parameter to [`adapter.Main()`](https://pkg.go.dev/knative.dev/eventing/pkg/adapter/v2#Main), while the rest called the same constructor `NewEnvConfig`.

I picked `NewEnvConfig` because:
- The majority was using it, including filter/splitter.
- It echoes `NewAdapter` better.
- It's a _constructor_.

I will also ensure the Godoc for these constructors is consistent, but will do that in a separate PR to avoid a scope creep, because it affects more that just these 6 sources.