### PR TITLE
 Use consistent doc for source adapters constructors

### DIFF
--- a/pkg/routing/adapter/filter/adapter.go
+++ b/pkg/routing/adapter/filter/adapter.go
@@ -59,14 +59,12 @@ type Handler struct {
 	expressions *expressionStorage
 }
 
-// NewEnvConfig satisfies env.ConfigConstructor.
-// Returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &pkgadapter.EnvConfig{}
 }
 
-// NewAdapter creates a new Handler and its associated MessageReceiver. The caller is responsible for
-// Start()ing the returned Handler.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/routing/adapter/splitter/adapter.go
+++ b/pkg/routing/adapter/splitter/adapter.go
@@ -54,14 +54,12 @@ type Handler struct {
 	logger         *zap.SugaredLogger
 }
 
-// NewEnvConfig satisfies env.ConfigConstructor.
-// Returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() env.ConfigAccessor {
 	return &env.Config{}
 }
 
-// NewAdapter creates a new Handler and its associated MessageReceiver. The caller is responsible for
-// Start()ing the returned Handler.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(component string) pkgadapter.AdapterConstructor {
 	return func(ctx context.Context, _ pkgadapter.EnvConfigAccessor,
 		ceClient cloudevents.Client) pkgadapter.Adapter {

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -62,12 +62,12 @@ type adapter struct {
 	logStream       string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	var err error
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -60,12 +60,12 @@ type adapter struct {
 	pollingInterval time.Duration
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	var err error
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/awscodecommitsource/adapter.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter.go
@@ -71,12 +71,12 @@ type adapter struct {
 	gitEvents string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter.go
@@ -59,12 +59,12 @@ type adapter struct {
 	identityPoolID string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
@@ -59,12 +59,12 @@ type adapter struct {
 	userPoolID string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -80,12 +80,12 @@ type adapter struct {
 	lastStreamStatus *string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/awskinesissource/adapter.go
+++ b/pkg/sources/adapter/awskinesissource/adapter.go
@@ -58,12 +58,12 @@ type adapter struct {
 	stream string
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -70,12 +70,12 @@ type event struct {
 	Value  float64 `json:"value"`
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	var err error
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/awssnssource/adapter.go
+++ b/pkg/sources/adapter/awssnssource/adapter.go
@@ -64,7 +64,6 @@ var (
 )
 
 // NewEnvConfig satisfies env.ConfigConstructor.
-// Returns an accessor for the source's adapter envConfig.
 func NewEnvConfig() env.ConfigAccessor {
 	return &env.Config{}
 }

--- a/pkg/sources/adapter/awssqssource/adapter.go
+++ b/pkg/sources/adapter/awssqssource/adapter.go
@@ -88,12 +88,12 @@ type adapter struct {
 	deletePeriod time.Duration
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/azureeventhubsource/adapter.go
+++ b/pkg/sources/adapter/azureeventhubsource/adapter.go
@@ -68,12 +68,12 @@ type adapter struct {
 	msgPrcsr MessageProcessor
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/azureiothubsource/adapter.go
+++ b/pkg/sources/adapter/azureiothubsource/adapter.go
@@ -51,12 +51,12 @@ type adapter struct {
 
 var _ pkgadapter.Adapter = (*adapter)(nil)
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 	env := envAcc.(*envConfig)

--- a/pkg/sources/adapter/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/adapter/azurequeuestoragesource/adapter.go
@@ -42,7 +42,7 @@ type envConfig struct {
 	QueueName   string `envconfig:"AZURE_QUEUE_NAME"`
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
@@ -59,7 +59,7 @@ type adapter struct {
 	logger      *zap.SugaredLogger
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	env := envAcc.(*envConfig)
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/azureservicebusqueuesource/adapter.go
+++ b/pkg/sources/adapter/azureservicebusqueuesource/adapter.go
@@ -58,12 +58,12 @@ type MessageWithRawData struct {
 
 var _ pkgadapter.Adapter = (*adapter)(nil)
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 	env := envAcc.(*envConfig)

--- a/pkg/sources/adapter/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/adapter.go
@@ -60,12 +60,12 @@ type adapter struct {
 
 var _ pkgadapter.Adapter = (*adapter)(nil)
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/sources/adapter/httppollersource/adapter.go
+++ b/pkg/sources/adapter/httppollersource/adapter.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// NewAdapter implementation
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	env := aEnv.(*envAccessor)
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/httppollersource/env.go
+++ b/pkg/sources/adapter/httppollersource/env.go
@@ -22,7 +22,7 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// NewEnvConfig for configuration parameters
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }

--- a/pkg/sources/adapter/ocimetricssource/adapter.go
+++ b/pkg/sources/adapter/ocimetricssource/adapter.go
@@ -33,7 +33,7 @@ type ociMetricsAdapter struct {
 	logger  *zap.SugaredLogger
 }
 
-// NewAdapter constructs a source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	env := aEnv.(*envAccessor)
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/ocimetricssource/env.go
+++ b/pkg/sources/adapter/ocimetricssource/env.go
@@ -22,7 +22,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 )
 
-// NewEnvConfig for configuration parameters
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }

--- a/pkg/sources/adapter/salesforcesource/adapter.go
+++ b/pkg/sources/adapter/salesforcesource/adapter.go
@@ -55,7 +55,7 @@ type eventDispatcher struct {
 var _ adapter.Adapter = (*salesforceAdapter)(nil)
 var _ sfclient.EventDispatcher = (*eventDispatcher)(nil)
 
-// NewAdapter implementation
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	env := aEnv.(*envAccessor)
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/salesforcesource/env.go
+++ b/pkg/sources/adapter/salesforcesource/env.go
@@ -18,7 +18,7 @@ package salesforcesource
 
 import "knative.dev/eventing/pkg/adapter/v2"
 
-// NewEnvConfig for configuration parameters
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }

--- a/pkg/sources/adapter/slacksource/adapter.go
+++ b/pkg/sources/adapter/slacksource/adapter.go
@@ -28,7 +28,7 @@ import (
 
 const defaultListenPort = 8080
 
-// NewAdapter adapter implementation
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	env := aEnv.(*envAccessor)
 	logger := logging.FromContext(ctx)

--- a/pkg/sources/adapter/slacksource/env.go
+++ b/pkg/sources/adapter/slacksource/env.go
@@ -20,7 +20,7 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// NewEnvConfig for configuration parameters
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }

--- a/pkg/sources/adapter/twiliosource/adapter.go
+++ b/pkg/sources/adapter/twiliosource/adapter.go
@@ -43,12 +43,12 @@ type adapter struct {
 	logger      *zap.SugaredLogger
 }
 
-// NewEnvConfig returns an accessor for the source's adapter envConfig.
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &pkgadapter.EnvConfig{}
 }
 
-// NewAdapter returns a constructor for the source's adapter.
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, env pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	return &adapter{
 		ceClient:    ceClient,

--- a/pkg/sources/adapter/webhooksource/adapter.go
+++ b/pkg/sources/adapter/webhooksource/adapter.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// NewAdapter implementation
+// NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	env := aEnv.(*envAccessor)
 

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -20,7 +20,7 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// NewEnvConfig for configuration parameters
+// NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
 func NewEnvConfig() adapter.EnvConfigAccessor {
 	return &envAccessor{}
 }

--- a/pkg/sources/adapter/zendesksource/adapter.go
+++ b/pkg/sources/adapter/zendesksource/adapter.go
@@ -59,7 +59,6 @@ var (
 )
 
 // NewEnvConfig satisfies env.ConfigConstructor.
-// Returns an accessor for the source's adapter envConfig.
 func NewEnvConfig() env.ConfigAccessor {
 	return &env.Config{}
 }


### PR DESCRIPTION
A small PR that aims at improving the consistency of functions' descriptions in sources adapters.

### Context

All sources implement 2 constructors which are passed to [`adapter.Main()`](https://pkg.go.dev/knative.dev/eventing/pkg/adapter/v2#Main) in order to initialize the source's adapter:
- `EnvConfigConstructor`: a function that provides an accessor to various environment variables
- `AdapterConstructor`: a function that returns an implementation of adapter.Adapter.

Across our sources, we've been using different descriptions for the same constructors, including some that aren't correct. 

### Examples

> _NewAdapter returns a constructor for the source's adapter._

Not true. NewAdapter **is** the constructor.

> _NewAdapter adapter implementation_

Not the best documentation, doesn't contain any verb, and is pretty vague.

> _NewEnvConfig for configuration parameters_

Is also very vague.

### Proposed descriptions

I took a very boring route and used the same descriptions everywhere.
Because these constructors are something we _implement_, and not our own invention, I simply used:

> _NewEnvConfig satisfies pkgadapter.EnvConfigConstructor._

> _NewAdapter satisfies pkgadapter.AdapterConstructor._

I think the name of these constructors speaks for itself.
The description will always remain true, won't lead to bad copy-pastas, and people can always refer to the constructor func's definition to know more about what it does.