### PR TITLE
Selectively enable cgo for Confluent target in ko

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,6 +1,10 @@
 # The Confluent target adapter requires cgo (CGO_ENABLED=1) and compiles to a
-# dynamic binary with a dependency on glibc. Defining a baseImageOverride for
-# just that component wouldn't work because we can't enable cgo selectively
-# when executing `ko apply`. Therefore, we must use a default base image that
-# contains glibc, even though most components don't need it.
-defaultBaseImage: gcr.io/distroless/base:nonroot
+# dynamic binary with a dependency on glibc.
+baseImageOverrides:
+  github.com/triggermesh/triggermesh/cmd/confluenttarget-adapter: gcr.io/distroless/base:nonroot
+
+builds:
+- id: confluenttarget-adapter
+  main: ./cmd/confluenttarget-adapter
+  env:
+  - CGO_ENABLED=1

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ confluenttarget-adapter:
 	CGO_ENABLED=1 $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN_OUTPUT_DIR)/$@ ./cmd/$@
 
 deploy: ## Deploy TriggerMesh stack to default Kubernetes cluster using ko
-	CGO_ENABLED=1 $(KO) apply -f $(BASE_DIR)/config
+	$(KO) apply -f $(BASE_DIR)/config
 
 undeploy: ## Remove TriggerMesh stack from default Kubernetes cluster using ko
 	$(KO) delete -f $(BASE_DIR)/config

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ kubectl create ns triggermesh
 
 The current codebase can be built and deployed locally using [ko][ko] as:
 ```shell
-$ CGO_ENABLED=1 ko apply -f config/
+$ ko apply -f config/
 ```
 
 Make can used to build all of the TriggerMesh binaries. By default, Make will


### PR DESCRIPTION
Turns out `ko` supports passing environment variables to selected builds now, so we can `ko publish`, `ko apply`, etc. without having to use tricks 🎉 

---

The binary is dynamically linked, as we would expect:

```console
$ file confluenttarget-adapter
confluenttarget-adapter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=5fe0575fc999a7836f0e2ea44e4fed9e3407758d, for GNU/Linux 3.2.0, not stripped
```

```console
$ ldd confluenttarget-adapter
        linux-vdso.so.1 (0x00007ffcdd7e4000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fd13bdcd000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fd13bdc7000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fd13bda4000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd13bbb2000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fd13bf27000)
```

And it runs:

```console
$ ./confluenttarget-adapter
{"severity":"INFO","timestamp":"2021-10-09T12:32:23.6685405+02:00","caller":"logging/config.go:116","message":"Successfully created the logger."}
{"severity":"INFO","timestamp":"2021-10-09T12:32:23.6686378+02:00","caller":"logging/config.go:117","message":"Logging level set to: info"}
...
```