### PR TITLE
Retire `go get` for installing Go commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
             DIST_DIR: /tmp/dist/
       - run:
           name: Installing github-release tool
-          command: go get github.com/meterup/github-release
+          command: go install github.com/meterup/github-release@latest
       - run:
           name: Creating github release
           command: |

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -24,10 +24,8 @@ jobs:
       uses: reviewdog/action-setup@v1
 
     - name: Install boilerplate-check
-      env:
-        GO111MODULE: 'off'
       run: |
-        go get github.com/mattmoor/boilerplate-check/cmd/boilerplate-check
+        go install github.com/mattmoor/boilerplate-check/cmd/boilerplate-check@latest
 
     - name: Check license boilerplate
       env:
@@ -57,10 +55,8 @@ jobs:
         go-version: '1.17'
 
     - name: Install go-licenses
-      env:
-        GO111MODULE: 'off'
       run: |
-        go get github.com/google/go-licenses
+        go install github.com/google/go-licenses@latest
 
     - name: Check third-party licenses
       run: |


### PR DESCRIPTION
From the Go 1.17 help:

>  Building and installing packages with get is deprecated. In a future release,
  the -d flag will be enabled by default, and 'go get' will be only be used to
  adjust dependencies of the current module. To install a package using
  dependencies from the current module, use 'go install'. To install a package
  ignoring the current module, use 'go install' with an @​version suffix like
  "@​latest" after each argument.