### PR TITLE
Restore saved Go module cache in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - go/load-cache
       - restore_cache:
           name: Restoring Go build cache
           # Multi-key caching strategy, as documented at https://circleci.com/docs/2.0/caching/.
@@ -120,6 +121,7 @@ jobs:
       - run:
           name: Installing ko
           command: go install github.com/google/ko@v0.9.3
+      - go/load-cache
       - restore_cache:
           name: Restoring Go build cache
           keys:


### PR DESCRIPTION
I omitted something in #145 🙈 

We save the Go **module** cache in the `checkout` job, and never restore it again, leading to Go modules being downloaded three times over the course of our pipeline (see [CI logs](https://app.circleci.com/pipelines/github/triggermesh/triggermesh/250/workflows/4ddcecea-bf13-4db6-a052-8d8627ee9a70/jobs/586?invite=true#step-103-4)).

It was barely noticeable because the build cache is more important, but since we save that cache, let's use it.