### PR TITLE
Remove license card from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Release](https://img.shields.io/github/v/release/triggermesh/triggermesh?label=release)](https://github.com/triggermesh/triggermesh/releases)
 [![CircleCI](https://circleci.com/gh/triggermesh/triggermesh/tree/main.svg?style=shield)](https://circleci.com/gh/triggermesh/triggermesh/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/triggermesh/triggermesh)](https://goreportcard.com/report/github.com/triggermesh/triggermesh)
-[![License](https://img.shields.io/github/license/triggermesh/triggermesh?label=license)](LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-Join%20chat-4a154b?style=flat&logo=slack)](https://join.slack.com/t/triggermesh-community/shared_invite/zt-wk5axnac-79BoPtk~xLip9fFhGAYYhg)
 
 <!-- TODO: add repository description, docs, contribution guidelines, etc. -->


### PR DESCRIPTION
https://github.com/triggermesh/triggermesh/pull/147#issuecomment-939965933

> I don't think the license one is needed because it is already in the right gutter on github.