### PR TITLE
Use CircleCI workspace to persist artifacts, not sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,20 @@ orbs:
   go: circleci/go@1
 
 jobs:
-  checkout:
+  gomod-cache:
     executor:
       name: go/default
       tag: '1.17'
     steps:
       - checkout
       - go/mod-download-cached
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - project
 
   test:
     executor:
       name: go/default
       tag: '1.17'
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - go/load-cache
       - restore_cache:
           name: Restoring Go build cache
@@ -75,8 +70,7 @@ jobs:
         type: string
         default: bot@triggermesh.com
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - add_ssh_keys:
           fingerprints:
             - "aa:03:46:c4:da:eb:da:02:ad:c0:3a:bc:5f:62:02:9c"
@@ -111,8 +105,7 @@ jobs:
       tag: '1.17'
     resource_class: large
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - gcp-cli/install
       - gcp-cli/initialize
       - run:
@@ -132,6 +125,13 @@ jobs:
           command: IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
           environment:
             KO_DOCKER_REPO: gcr.io/triggermesh
+            DIST_DIR: /tmp/dist/
+      - persist_to_workspace:
+          root: /tmp/
+          paths:
+            - dist/
+      - store_artifacts:
+          path: /tmp/dist/
 
   update-manifests:
     description: Patches target cluster configuration
@@ -148,8 +148,7 @@ jobs:
         type: string
         default: bot@triggermesh.com
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - add_ssh_keys:
           fingerprints:
             - "07:8f:e8:44:ce:54:16:26:00:98:e5:1c:a6:c6:00:34"
@@ -192,43 +191,36 @@ jobs:
       name: go/default
       tag: '1.17'
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: $AWS_CLUSTER_NAME
           aws-region: $AWS_REGION
           install-kubectl: true
       - run:
-          name: Installing ko
-          command: go install github.com/google/ko@v0.9.3
-      - run:
-          name: Publishing container images and generating release manifests
-          command: IMAGE_TAG=${CIRCLE_TAG:-latest} make release
-          environment:
-            KO_DOCKER_REPO: gcr.io/triggermesh
-            KOFLAGS: --push=false
-            DIST_DIR: /tmp/dist/
-      - run:
           name: Installing github-release tool
           command: go install github.com/meterup/github-release@latest
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
-          name: Creating github release
+          name: Creating GitHub release
           command: |
             PRE_RELEASE=${CIRCLE_TAG/${CIRCLE_TAG%-rc[0-9]*}/}
             github-release delete -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} 2>/dev/null ||:
             ./hack/release-notes.sh ${CIRCLE_TAG} | github-release release ${PRE_RELEASE:+-p} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d -
-            for f in $(find /tmp/dist -type f); do github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f} ; done
+            for f in $(find /tmp/workspace/dist/ -type f); do
+              github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f}
+            done
 
 workflows:
   test-and-publish:
     jobs:
-      - checkout:
+      - gomod-cache:
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
       - test:
           requires:
-            - checkout
+            - gomod-cache
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ release: ## Publish container images and generate release manifests
 	@mkdir -p $(DIST_DIR)
 	$(KO) resolve -f config/ -l 'triggermesh.io/crd-install' > $(DIST_DIR)/triggermesh-crds.yaml
 	@cp config/namespace/100-namespace.yaml $(DIST_DIR)/triggermesh.yaml
-	$(KO) resolve $(KOFLAGS) -B -t $(IMAGE_TAG),latest -f config/ -l '!triggermesh.io/crd-install' >> $(DIST_DIR)/triggermesh.yaml
+	$(KO) resolve $(KOFLAGS) -B -t latest -f config/ -l '!triggermesh.io/crd-install' > /dev/null
+	$(KO) resolve $(KOFLAGS) -B -t $(IMAGE_TAG) --tag-only -f config/ -l '!triggermesh.io/crd-install' >> $(DIST_DIR)/triggermesh.yaml
 
 gen-apidocs: ## Generate API docs
 	GOPATH="" OUTPUT_DIR=$(DOCS_OUTPUT_DIR) ./hack/gen-api-reference-docs.sh


### PR DESCRIPTION
Our release pipeline has a design flaw: it runs `ko resolve` twice, meaning all container images are **built twice** (so we need twice the resources). This is unnecessary, because the first run already generates the release artifacts.

Instead, we can simply persist release artifacts to the workflow's _workspace_, so they can be reused downstream in the following jobs. It's actually [what the CircleCI workspace is for](https://circleci.com/blog/deep-diving-into-circleci-workspaces/).

This PR repurposes the current usage of the workspace, using it to store artifacts, instead of the actual source code.
The source code is fetched using `checkout`, which is instant because CircleCI seems to cache the repo for the entire duration of the workflow.

---

I ran a simulation here: [workflow run 270](https://app.circleci.com/pipelines/github/triggermesh/triggermesh/270/workflows/13530273-3ee6-4991-9515-ab20b2be5c10)

Notice:
- The workspace populated in `publish-image` then attached in `release`
    ```console
    # publish-image
    Creating workspace archive...
    Uploading workspace archive...
    Total size uploaded: 31 KiB
    Workspace archive uploaded successfully.
    ```
    ```console
    # release
    Downloading workspace layers
      workflows/workspaces/ebf8afed-7f4b-4ae8-9694-b627b0e0a9a7/0/863f9a9f-ceb5-471b-9d6e-112413abaa9d/0/111.tar.gz - 32 kB
    Total size downloaded: 31 KiB
    Applying workspace layers
    ```
- The `Artifacts` tab, populated with release artifacts (just in case we want to inspect them ourselves)
    
    ![CircleCI artifacts](https://user-images.githubusercontent.com/3299086/136806645-7b55fcec-5dc4-4790-b1f2-83a00b58df87.png)
