### PR TITLE
Rename triggermesh-webhook container to just 'webhook'

### DIFF
--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       serviceAccountName: triggermesh-webhook
       containers:
-      - name: triggermesh-webhook
+      - name: webhook
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://github.com/triggermesh/triggermesh/cmd/triggermesh-webhook
         env:


### PR DESCRIPTION
Other containers are called either "controller" or "adapter", so we may as well remove the "triggermesh-" prefix from that one because that's clear from the `triggermesh-webhook` Pod name already.