### PR TITLE
Hint about using "kubectl explain" inside samples

### DIFF
--- a/config/samples/sources/azureactivitylogssource.yaml
+++ b/config/samples/sources/azureactivitylogssource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AzureActivityLogsSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azureactivitylogssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureActivityLogsSource

--- a/config/samples/sources/azureblobstoragesource.yaml
+++ b/config/samples/sources/azureblobstoragesource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AzureBlobStorageSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azureblobstoragesources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureBlobStorageSource

--- a/config/samples/sources/azureeventgridsource.yaml
+++ b/config/samples/sources/azureeventgridsource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AzureEventGridSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azureeventgridsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureEventGridSource

--- a/config/samples/sources/azureeventhubsource.yaml
+++ b/config/samples/sources/azureeventhubsource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AzureEventHubSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azureeventhubsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureEventHubSource
@@ -38,6 +43,6 @@ spec:
 
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default

--- a/config/samples/sources/azureiothubsource.yaml
+++ b/config/samples/sources/azureiothubsource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample AzureIOTHubSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azureiothubsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureIOTHubSource

--- a/config/samples/sources/azurequeuestoragesource.yaml
+++ b/config/samples/sources/azurequeuestoragesource.yaml
@@ -13,17 +13,11 @@
 # limitations under the License.
 
 # Sample AzureQueueStorageSource object.
-
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: azure
-type: Opaque
-stringData:
-  accountKey: 
-
----
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain azurequeuestoragesources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: AzureQueueStorageSource
@@ -32,24 +26,14 @@ metadata:
 spec:
   accountName: demoaccount
   queueName: testqueue
+
   accountKey:
     valueFromSecret:
-      name: azure
-      key: accountKey 
+      name: azure-queue-storage
+      key: account_key
+
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
----
-
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: event-display
-spec:
-  template:
-    spec:
-      containers:
-        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+      apiVersion: eventing.knative.dev/v1
+      kind: broker
+      name: default

--- a/config/samples/sources/googlecloudauditlogssource.yaml
+++ b/config/samples/sources/googlecloudauditlogssource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample GoogleCloudAuditLogsSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain googlecloudauditlogssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: GoogleCloudAuditLogsSource

--- a/config/samples/sources/googlecloudbillingsource.yaml
+++ b/config/samples/sources/googlecloudbillingsource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample GoogleCloudBillingSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain googlecloudbillingsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: GoogleCloudBillingSource

--- a/config/samples/sources/googlecloudpubsubsource.yaml
+++ b/config/samples/sources/googlecloudpubsubsource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample GoogleCloudPubSubSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain googlecloudpubsubsources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: GoogleCloudPubSubSource

--- a/config/samples/sources/googlecloudstoragesource.yaml
+++ b/config/samples/sources/googlecloudstoragesource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample GoogleCloudStorageSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain googlecloudstoragesources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: GoogleCloudStorageSource

--- a/config/samples/sources/ocimetricssource.yaml
+++ b/config/samples/sources/ocimetricssource.yaml
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 # Sample OCIMetricsSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain ocimetricssources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: OCIMetricsSource
 metadata:
-  name: metrics-test
+  name: sample
 spec:
   # required to interact with the Oracle Cloud API
   oracleApiPrivateKey:
@@ -46,18 +51,6 @@ spec:
 
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
-
----
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: event-display
-spec:
-  template:
-    spec:
-      containers:
-      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default

--- a/config/samples/sources/salesforcesource.yaml
+++ b/config/samples/sources/salesforcesource.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # Sample SalesforceSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain salesforcesources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: SalesforceSource
@@ -22,14 +27,16 @@ spec:
   subscription:
     channel: /data/ChangeEvents
     replayID: -2
+
   auth:
     clientID: salesforce.client_id
     server: https://login.salesforce.com
     user: woodford@example.com
     certKey:
       value: my-key
+
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default

--- a/config/samples/sources/twiliosource.yaml
+++ b/config/samples/sources/twiliosource.yaml
@@ -13,26 +13,19 @@
 # limitations under the License.
 
 # Sample TwilioSource object.
+#
+# For a list and description of all available attributes, execute the following command against a cluster where this
+# Custom Resource Definition has been registered:
+#
+#   kubectl explain twiliosources.sources.triggermesh.io
 
 apiVersion: sources.triggermesh.io/v1alpha1
 kind: TwilioSource
 metadata:
-  name: twilio-test
+  name: sample
 spec:
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
----
-
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: event-display
-spec:
-  template:
-    spec:
-      containers:
-        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+      apiVersion: eventing.knative.dev/v1
+      kind: broker
+      name: default


### PR DESCRIPTION
Most samples inside `config/samples/sources` include a note in their header which indicates how to access the full documentation using `kubectl explain`.

I forgot to add such header to the sources which originally came from the `triggermesh/event-sources` repo.

This PR fixes that.