### PR TITLE
Revert "Increase Code Linting timeout to 3m"

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -26,4 +26,3 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         skip-go-installation: true
-        args: --timeout=3m


### PR DESCRIPTION
Reverts triggermesh/triggermesh#165

This change was undesired. It reduces the timeout from 5m to 3m and overrides our global default.

https://github.com/triggermesh/triggermesh/blob/e03028add9fca2f24593bef30eb0f9f287e92503/.golangci.yaml#L12-L13

vs.

https://github.com/triggermesh/triggermesh/blob/e03028add9fca2f24593bef30eb0f9f287e92503/.github/workflows/static.yaml#L29

cc. @sebgoa 