### PR TITLE
Group RBAC rules related to reconciled resources

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -57,7 +57,7 @@ rules:
   - delete
   - patch
 
-# Read Source resources and update their statuses
+# Read reconciled TriggerMesh resources and update their statuses
 # +rbac-check
 - apiGroups:
   - sources.triggermesh.io
@@ -134,8 +134,6 @@ rules:
   - zendesksources/status
   verbs:
   - update
-
-# Read Target resources and update their statuses
 # +rbac-check
 - apiGroups:
   - targets.triggermesh.io
@@ -208,8 +206,6 @@ rules:
   - zendesktargets/status
   verbs:
   - update
-
-# Read Flow resources and update their statuses
 # +rbac-check
 - apiGroups:
   - flow.triggermesh.io
@@ -226,8 +222,6 @@ rules:
   - transformations/status
   verbs:
   - update
-
-# Read Extension resources and update their statuses
 # +rbac-check
 - apiGroups:
   - extensions.triggermesh.io
@@ -244,8 +238,6 @@ rules:
   - functions/status
   verbs:
   - update
-
-# Read Routing resources and update their statuses
 # +rbac-check
 - apiGroups:
   - routing.triggermesh.io


### PR DESCRIPTION
Purely cosmetic change.

Groups together the RBAC rules related to the reconciliation of resources owned by TriggerMesh, for two reasons:
- because they _are_ related (all of them grant "read-only but allow writing status")
- to be consistent with the rules below related to finalizers, which are also grouped in that way