### PR TITLE
Add linting of Kubernetes manifests to "Static Analysis" pipeline

### DIFF
--- a/.github/workflows/config/yamllint-k8s.yaml
+++ b/.github/workflows/config/yamllint-k8s.yaml
@@ -1,0 +1,27 @@
+# yamllint configuration for Kubernetes manifests.
+#
+# For a list of all available configuration options with their default values, see:
+#   https://yamllint.readthedocs.io/en/stable/configuration.html
+
+extends: default
+
+rules:
+  # Use the same indentation rules as Kubernetes' marshaler. It avoids friction
+  # while diff-ing local manifests with in-cluster objects.
+  indentation:
+    spaces: 2
+    indent-sequences: false
+
+  # The default value of 80 is too low for OpenAPI schemas with deeply nested
+  # attributes inside CustomResourceDefinitions.
+  # Long words, such as URLs, tokens and some identifiers, are non-breakable
+  # and should not trigger errors.
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true
+
+  # Our manifests don't include directives, so we don't use the "---" marker to
+  # start the first document inside a file.
+  #  - https://yaml.org/spec/1.2.2/#directives
+  #  - https://yaml.org/spec/1.2.2/#structures
+  document-start: disable

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  lint:
+  lint-code:
     name: Code linting
     runs-on: ubuntu-latest
 
@@ -22,12 +22,26 @@ jobs:
 
     # This action takes care of caching/restoring pkg and build caches.
     # It needs to be the first step executed after the Go setup.
-    - name: Lint
+    - name: Lint Go code
       uses: golangci/golangci-lint-action@v2
       with:
         skip-go-installation: true
 
-    - name: RBAC check
+  lint-config:
+    name: Configuration linting
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Lint Kubernetes manifests
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        file_or_dir: config/
+        config_file: .github/workflows/config/yamllint-k8s.yaml
+        format: github
+
+    - name: RBAC rules consistency
       run: |
         pushd hack/rbac-check
         go install .


### PR DESCRIPTION
Depends on #176, which addresses the reported warnings which are currently blocking this PR (see "Files changes" tab).

Enable a linter for YAML files, run it against the `config/` directory.
Configure it with sane settings for Kubernetes manifests.