### PR TITLE
hotfix: Use Go 1.17 in config linting pipeline

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -34,6 +34,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
     - name: Lint Kubernetes manifests
       uses: ibiqlik/action-yamllint@v3
       with:


### PR DESCRIPTION
I overlooked an error related to the Go version in my previous PR (#175) 🙈 

`fs.go:20:2: package io/fs is not in GOROOT (/opt/hostedtoolcache/go/1.15.15/x64/src/io/fs)`

See full error: https://github.com/triggermesh/triggermesh/runs/3923468065