### PR TITLE
Function reconciliation fix

### DIFF
--- a/pkg/function/resources/knservice.go
+++ b/pkg/function/resources/knservice.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"path"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,17 +189,4 @@ func firstContainer(svc *servingv1.Service) *corev1.Container {
 		*containers = make([]corev1.Container, 1)
 	}
 	return &(*containers)[0]
-}
-
-// KnSvcEnvFromMap sets Kn service env variables from a map.
-func KnSvcEnvFromMap(prefix string, vars map[string]string) KnSvcOption {
-	return func(svc *servingv1.Service) {
-		svcEnvVars := envVarsFrom(svc)
-		for k, v := range vars {
-			*svcEnvVars = append(*svcEnvVars, corev1.EnvVar{
-				Name:  strings.ToUpper(prefix + k),
-				Value: v,
-			})
-		}
-	}
 }


### PR DESCRIPTION
In this PR we're replacing `KnSvcEnvFromMap` function that sets env variables from maps "as is" with `KnSvcEnvVars` that accepts an ordered list of items. Having env variables list randomly ordered caused `semantic.DeepEqual` to falsely report the changes in the reconciliation loop. 