### PR TITLE
Use `t.Setenv()` helper in tests that set environment variables

### DIFF
--- a/pkg/sources/reconciler/testing/controller.go
+++ b/pkg/sources/reconciler/testing/controller.go
@@ -48,7 +48,7 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 	}
 
 	// updateAdapterMetricsConfig panics when METRICS_DOMAIN is unset
-	defer SetEnvVar(t, metrics.DomainEnv, "testing")()
+	t.Setenv(metrics.DomainEnv, "testing")
 
 	cmw := configmap.NewStaticWatcher(
 		NewConfigMap(metrics.ConfigMapName(), nil),

--- a/pkg/sources/reconciler/testing/utils.go
+++ b/pkg/sources/reconciler/testing/utils.go
@@ -17,28 +17,9 @@ limitations under the License.
 package testing
 
 import (
-	"os"
-	"testing"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// SetEnvVar sets the value of an env var and returns a function that can be
-// deferred to unset that variable.
-func SetEnvVar(t *testing.T, name, val string) (unset func()) {
-	t.Helper()
-
-	if err := os.Setenv(name, val); err != nil {
-		t.Errorf("Failed to set env var %s: %v", name, err)
-	}
-
-	return func() {
-		if err := os.Unsetenv(name); err != nil {
-			t.Logf("Failed to unset env var %q: %s", name, err)
-		}
-	}
-}
 
 // NewConfigMap returns a ConfigMap object.
 func NewConfigMap(name string, data map[string]string) *corev1.ConfigMap {

--- a/pkg/targets/adapter/elasticsearchtarget/config_test.go
+++ b/pkg/targets/adapter/elasticsearchtarget/config_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"testing"
 
@@ -130,15 +129,11 @@ func TestEnvironment(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			for k, v := range tc.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			env := EnvAccessorCtor().(*envAccessor)
 			err := envconfig.Process("", env)
-			// clean up for next test case
-			for k := range tc.env {
-				os.Unsetenv(k)
-			}
 
 			if err != nil {
 				t.Fatalf("Error parsing environment: %s", err)

--- a/pkg/targets/reconciler/testing/controller.go
+++ b/pkg/targets/reconciler/testing/controller.go
@@ -70,7 +70,7 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 	}
 
 	// updateAdapterMetricsConfig panics when METRICS_DOMAIN is unset
-	defer SetEnvVar(t, metrics.DomainEnv, "testing")()
+	t.Setenv(metrics.DomainEnv, "testing")
 
 	cmw := configmap.NewStaticWatcher(
 		NewConfigMap(logging.ConfigMapName(), nil),

--- a/pkg/targets/reconciler/testing/utils.go
+++ b/pkg/targets/reconciler/testing/utils.go
@@ -18,45 +18,10 @@ package testing
 
 import (
 	"fmt"
-	"os"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// SetEnvVar sets the value of an env var and returns a function that can be
-// deferred to unset that variable.
-func SetEnvVar(t *testing.T, name, val string) (unset func()) {
-	t.Helper()
-
-	if err := os.Setenv(name, val); err != nil {
-		t.Errorf("Failed to set env var %s: %v", name, err)
-	}
-
-	return func() {
-		if err := os.Unsetenv(name); err != nil {
-			t.Logf("Failed to unset env var %q: %s", name, err)
-		}
-	}
-}
-
-// UnsetEnvVar unsets the value of an env var and returns a function that can be
-// deferred to reset that variable to its original value.
-func UnsetEnvVar(t *testing.T, name string) (unset func()) {
-	t.Helper()
-
-	val, set := os.LookupEnv(name)
-	if !set {
-		return func() {}
-	}
-
-	return func() {
-		if err := os.Setenv(name, val); err != nil {
-			t.Logf("Failed to set env var %q: %s", name, err)
-		}
-	}
-}
 
 // Eventf returns the attributes of an API event in the format returned by
 // Kubernetes' FakeRecorder.


### PR DESCRIPTION
This nifty helper was added in Go 1.17: https://pkg.go.dev/testing#T.Setenv