### PR TITLE
Add CI workflow to ensure generated files are up-to-date

### DIFF
--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -1,0 +1,64 @@
+name: Generated Files
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  gomod:
+    name: Go Modules
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Check modules requirements
+      run: |
+        go mod tidy
+
+        git_status="$(git status --porcelain)"
+        if [[ ${git_status} ]]; then
+            echo -e "Go modules are out-of-date. Please run `go mod tidy`\n"
+            echo "${git_status}"
+            exit 1
+        fi
+
+  codegen:
+    name: Generated Code
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Kubernetes code generation
+      run: |
+        mod_path="$(go mod edit -json | jq -r '.Module.Path')"
+
+        tmp_gopath="$(mktemp -d)"
+        export GOPATH="$tmp_gopath"
+
+        tmp_repo_path="${tmp_gopath}/src/${mod_path}"
+        mkdir -p "${tmp_repo_path%/*}"
+        ln -s "$GITHUB_WORKSPACE" "$tmp_repo_path"
+
+        make codegen
+
+        git_status="$(git status --porcelain)"
+        if [[ ${git_status} ]]; then
+            echo -e "Generated Kubernetes code is out-of-date. Please run `make codegen`\n"
+            echo "${git_status}"
+            exit 1
+        fi

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -24,8 +24,7 @@ jobs:
       uses: reviewdog/action-setup@v1
 
     - name: Install boilerplate-check
-      run: |
-        go install github.com/mattmoor/boilerplate-check/cmd/boilerplate-check@latest
+      run: go install github.com/mattmoor/boilerplate-check/cmd/boilerplate-check@latest
 
     - name: Check license boilerplate
       env:
@@ -43,7 +42,7 @@ jobs:
           -fail-on-error=true
 
   vendor:
-    name: Third-party licenses
+    name: Third-Party Licenses
     runs-on: ubuntu-latest
 
     steps:
@@ -55,17 +54,15 @@ jobs:
         go-version: '1.17'
 
     - name: Install go-licenses
-      run: |
-        go install github.com/google/go-licenses@latest
+      run: go install github.com/google/go-licenses@latest
 
     - name: Check third-party licenses
       run: |
-        rm -rf LICENSES/vendor/
-        go-licenses save ./... --save_path LICENSES/vendor/
+        go-licenses save ./... --save_path LICENSES/vendor/ --force
 
         git_status="$(git status --porcelain)"
         if [[ ${git_status} ]]; then
-            echo -e "Third-party licenses are out-of-date. Please run go-licenses\n"
+            echo -e "Third-party licenses are out-of-date. Please run `go-licenses save`\n"
             echo "${git_status}"
             exit 1
         fi

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   lint-code:
-    name: Code linting
+    name: Code Linting
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         skip-go-installation: true
 
   lint-config:
-    name: Configuration linting
+    name: Configuration Linting
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
A small GitHub Actions workflow which fails if:
- `go.mod` / `go.sum` are outdated (solution: `go mod tidy`)
- the generated Kubernetes code is outdated (solution: `make codegen`)

Closes #183