### PR TITLE
Save/restore Go caches in GitHub Actions

### DIFF
--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -20,6 +20,16 @@ jobs:
       with:
         go-version: '1.17'
 
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Check modules requirements
       run: |
         go mod tidy
@@ -42,6 +52,16 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.17'
+
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Kubernetes code generation
       run: |

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -20,6 +20,16 @@ jobs:
       with:
         go-version: '1.17'
 
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Install reviewdog
       uses: reviewdog/action-setup@v1
 
@@ -52,6 +62,16 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.17'
+
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Install go-licenses
       run: go install github.com/google/go-licenses@latest

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -20,12 +20,22 @@ jobs:
       with:
         go-version: '1.17'
 
-    # This action takes care of caching/restoring pkg and build caches.
-    # It needs to be the first step executed after the Go setup.
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Lint Go code
       uses: golangci/golangci-lint-action@v2
       with:
         skip-go-installation: true
+        skip-pkg-cache: true
+        skip-build-cache: true
 
   lint-config:
     name: Configuration Linting
@@ -38,6 +48,16 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.17'
+
+    - name: Restore Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Lint Kubernetes manifests
       uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
Similarly to what we do in CircleCI
- Restore the _modules_ and _build_ caches at the beginning of jobs
- Save them at the end of jobs

Unlike CircleCI, it is not necessary to define separate steps for _restore_ and _save_. The _save_ is automatically deferred to the end of the job.

Ref. https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows