### PR TITLE
Include job_id in GitHub Actions cache keys

### DIFF
--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -20,15 +20,14 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
+    - name: Go caches
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Check modules requirements
       run: |
@@ -53,15 +52,15 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
+    - name: Go caches
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Kubernetes code generation
       run: |

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -20,15 +20,15 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
+    - name: Go caches
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Install reviewdog
       uses: reviewdog/action-setup@v1
@@ -63,15 +63,15 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
+    - name: Go caches
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Install go-licenses
       run: go install github.com/google/go-licenses@latest

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -20,22 +20,13 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
+    # This action takes care of caching/restoring modules and build caches.
+    # Therefore, this step should remain the first one that is executed after
+    # the Go setup, in case other steps are added to this job in the future.
     - name: Lint Go code
       uses: golangci/golangci-lint-action@v2
       with:
         skip-go-installation: true
-        skip-pkg-cache: true
-        skip-build-cache: true
 
   lint-config:
     name: Configuration Linting
@@ -49,15 +40,15 @@ jobs:
       with:
         go-version: '1.17'
 
-    - name: Restore Go caches
+    - name: Go caches
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Lint Kubernetes manifests
       uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
Hotfix/perf improvement for #188.

Ensures a job that caches only a small amount of data (e.g. license checks) doesn't negatively impact other jobs (e.g. linters).
I noticed the issue because `golangci-lint` suddenly started failing.

In #188, I overlooked the fact that the _first_ job that's executed in the workflow would determine what data is made available to _all_ other jobs, since caches are immutable for a given `key`.

In CircleCI, we use a single cache for the whole test/release pipeline.
But in GitHub Actions, we tend to run multiple small checks in parallel, so we need a slightly different caching strategy.

This problem is solved by ensuring each `job` gets its own cache key. As a result:
- jobs that only pull a few modules will only save/restore small amounts of cached data
- jobs that pull everything and build the code finally leverage the full potential of caching