### PR TITLE
Enable Dependabot for dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot configuration
+#
+# For more information, please refer to:
+#   https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
+
+version: 2
+
+updates:
+
+# Maintain Go modules
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
I would like to give Dependabot a try (an auto-update bot that's built into GitHub ), at least as a signal that some of our dependencies could be updated.

This is the file that gets generated when you navigate to https://github.com/triggermesh/triggermesh/network/updates and click "Create config file".

I don't know yet how smart it is with Go modules, so if it gets too annoying we can [disable it](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates#disabling-dependabot-version-updates) or simply revert part of this PR.

I purposely set the check interval to `weekly` for the time being.