### PR TITLE
Use single quotes in messages echoed from the CI

### DIFF
--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -35,7 +35,7 @@ jobs:
 
         git_status="$(git status --porcelain)"
         if [[ ${git_status} ]]; then
-            echo -e "Go modules are out-of-date. Please run `go mod tidy`\n"
+            echo -e 'Go modules are out-of-date. Please run `go mod tidy`\n'
             echo "${git_status}"
             exit 1
         fi
@@ -77,7 +77,7 @@ jobs:
 
         git_status="$(git status --porcelain)"
         if [[ ${git_status} ]]; then
-            echo -e "Generated Kubernetes code is out-of-date. Please run `make codegen`\n"
+            echo -e 'Generated Kubernetes code is out-of-date. Please run `make codegen`\n'
             echo "${git_status}"
             exit 1
         fi

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -82,7 +82,7 @@ jobs:
 
         git_status="$(git status --porcelain)"
         if [[ ${git_status} ]]; then
-            echo -e "Third-party licenses are out-of-date. Please run `go-licenses save`\n"
+            echo -e 'Third-party licenses are out-of-date. Please run `go-licenses save`\n'
             echo "${git_status}"
             exit 1
         fi


### PR DESCRIPTION
Avoids interpreting expressions between backticks.

Currently, those messages are being swallowed, because the expressions are being interpreted.