### PR TITLE
Enable CodeQL analysis in CI

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  schedule:
+  - cron: '0 0 * * 0'  # At 00:00 every Sunday
+
+jobs:
+
+  codeql:
+    name: Code Analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-go-
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: go
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # This step follows the three-step extraction process described at
+    # https://lgtm.com/help/lgtm/go-extraction
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ LDFLAGS            = -extldflags=-static -w -s
 HAS_GOTESTSUM     := $(shell command -v gotestsum;)
 HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)
 
-.PHONY: help build release vm-images test lint fmt fmt-test images clean install-gotestsum install-golangci-lint deploy undeploy
+.PHONY: help all build release vm-images test lint fmt fmt-test images clean install-gotestsum install-golangci-lint deploy undeploy
+
+.DEFAULT_GOAL := build
 
 all: codegen build test lint
 


### PR DESCRIPTION
A code analysis tool offered by GitHub, which is free for research and open source projects. It claims to be focused on security.

More info:
- https://codeql.github.com/
- https://lgtm.com

---

Update: The analysis completed in 40 min.

The results are visible at https://github.com/triggermesh/triggermesh/security/code-scanning?query=is%3Aopen+pr%3A198 (accessible to maintainers only).

Due to the long execution time of the checks, I'm moving this job to its own workflow, which I set to execute **weekly** instead of on push/PRs.