### PR TITLE
Skip bot updates of `knative.dev` and `k8s.io` imports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+  # We prefer to keep control over Knative module imports.
+  - dependency-name: knative.dev/*
+  # The version of Kubernetes module imports needs to be consistent across all
+  # modules. Besides, that version is determined by the current Knative version.
+  - dependency-name: k8s.io/*
 
 # Maintain dependencies for GitHub Actions
 - package-ecosystem: github-actions


### PR DESCRIPTION
In #200 and #202, Dependabot submitted PRs to update `k8s.io` module dependencies.

We want to ignore this type of updates because:

1. The bot is not smart enough to know that updating _one_ `k8s.io` import means we should update _all_ `k8s.io` imports.
1. These modules are a transitive dependency of `knative.dev` imports, so we don't actually want to bump them ourselves.