### PR TITLE
Escape user input in HTTP responses to avoid reflected XSS

### DIFF
--- a/pkg/sources/adapter/awssnssource/handler/handler.go
+++ b/pkg/sources/adapter/awssnssource/handler/handler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"net/http"
 
@@ -154,7 +155,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.logger.Debug("Successfully confirmed SNS subscription: ", *resp)
 
 	default:
-		http.Error(w, "Unrecognized message type "+msgType, http.StatusBadRequest)
+		http.Error(w, "Unrecognized message type "+html.EscapeString(msgType), http.StatusBadRequest)
 	}
 }
 

--- a/pkg/sources/adapter/common/router/router.go
+++ b/pkg/sources/adapter/common/router/router.go
@@ -17,6 +17,7 @@ limitations under the License.
 package router
 
 import (
+	"html"
 	"net/http"
 	"sync"
 )
@@ -45,7 +46,7 @@ func (r *Router) DeregisterPath(urlPath string) {
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h, ok := r.handlers.Load(req.URL.Path)
 	if !ok {
-		http.Error(w, "No handler for path "+req.URL.Path, http.StatusNotFound)
+		http.Error(w, "No handler for path "+html.EscapeString(req.URL.Path), http.StatusNotFound)
 		return
 	}
 

--- a/pkg/sources/adapter/zendesksource/handler/handler.go
+++ b/pkg/sources/adapter/zendesksource/handler/handler.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -87,7 +88,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// handle semicolon-separated header value (e.g. "application/json; charset=utf-8")
 	ctHeader := r.Header.Get(headerContentTypeKey)
 	if strings.TrimSpace(strings.SplitN(ctHeader, ";", 2)[0]) != headerContentTypeJSON {
-		http.Error(w, "Unsupported media type "+ctHeader, http.StatusUnsupportedMediaType)
+		http.Error(w, "Unsupported media type "+html.EscapeString(ctHeader), http.StatusUnsupportedMediaType)
 		return
 	}
 


### PR DESCRIPTION
Addresses a potential vulnerability found by CodeQL.

![image](https://user-images.githubusercontent.com/3299086/138348046-c65e9b0b-f471-4330-ad1b-aef5477b25aa.png)


> Directly writing user input (for example, an HTTP request parameter) to an HTTP response without properly sanitizing the input first, allows for a cross-site scripting vulnerability.
>
> This kind of vulnerability is also called _reflected_ cross-site scripting, to distinguish it from other types of cross-site scripting.
>
> **Recommendation**
>
> To guard against cross-site scripting, consider using contextual output encoding/escaping before writing user input to the response, or one of the other solutions that are mentioned in the references.
>
> **References**
>
> -  OWASP: [XSS (Cross Site Scripting) Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).
> -  OWASP: [Types of Cross-Site Scripting](https://www.owasp.org/index.php/Types_of_Cross-Site_Scripting).
> -  Wikipedia: [Cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting).
> -  Common Weakness Enumeration: [CWE-79](https://cwe.mitre.org/data/definitions/79.html).
> -  Common Weakness Enumeration: [CWE-116](https://cwe.mitre.org/data/definitions/116.html).