### PR TITLE
ci: set no_output_timeout to 45m while building AMI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
           environment:
             AWS_AMI_GROUPS: all
             AWS_AMI_REGIONS: us-east-1,us-east-2,us-west-1,us-west-2,ap-southeast-1,ap-southeast-2,ap-northeast-1,eu-central-1,eu-west-1,eu-west-2
+          no_output_timeout: 45m
 
 workflows:
   test-and-publish:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,7 @@ linters:
   - stylecheck
 
 run:
-  timeout: 5m
+  timeout: 10m
 
 linters-settings:
   stylecheck:


### PR DESCRIPTION
building the AMI for various regions takes a while and has long periods during the build without any output.