### PR TITLE
Add serviceAccountProvider interface to source kinds

### DIFF
--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
@@ -66,4 +67,14 @@ func (s *AWSSQSSource) GetEventTypes() []string {
 // AsEventSource implements EventSource.
 func (s *AWSSQSSource) AsEventSource() string {
 	return s.Spec.ARN.String()
+}
+
+// WantsOwnServiceAccount implements serviceAccountProvider.
+func (*AWSSQSSource) WantsOwnServiceAccount() bool {
+	return false
+}
+
+// ServiceAccountOptions implements serviceAccountProvider.
+func (*AWSSQSSource) ServiceAccountOptions() []func(*corev1.ServiceAccount) {
+	return nil
 }

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -40,8 +40,9 @@ type AWSSQSSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSSQSSource)(nil)
-	_ EventSource    = (*AWSSQSSource)(nil)
+	_ runtime.Object         = (*AWSSQSSource)(nil)
+	_ EventSource            = (*AWSSQSSource)(nil)
+	_ serviceAccountProvider = (*AWSSQSSource)(nil)
 )
 
 // AWSSQSSourceSpec defines the desired state of the event source.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -68,8 +68,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -82,8 +82,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/sources/reconciler/awscodecommitsource/adapter.go
@@ -65,8 +65,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -57,8 +57,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -62,8 +62,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -57,8 +57,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -57,8 +57,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -66,8 +66,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -85,8 +85,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -52,8 +52,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, _ *apis.URL) *servin
 }
 
 // RBACOwners implements common.AdapterServiceBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -79,8 +79,12 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	if v1alpha1.WantsOwnServiceAccount(src) {
+		return []kmeta.OwnerRefable{src}, nil
+	}
+
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureactivitylogssource/adapter.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureblobstoragesource/adapter.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/adapter.go
@@ -81,8 +81,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureeventgridsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventgridsource/adapter.go
@@ -81,8 +81,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureeventhubsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventhubsource/adapter.go
@@ -72,8 +72,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -63,8 +63,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -64,8 +64,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
@@ -63,8 +63,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
@@ -72,8 +72,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
@@ -76,8 +76,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudrepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudrepositoriessource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -87,8 +87,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/httppollersource/adapter.go
+++ b/pkg/sources/reconciler/httppollersource/adapter.go
@@ -70,8 +70,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/ocimetricssource/adapter.go
+++ b/pkg/sources/reconciler/ocimetricssource/adapter.go
@@ -71,8 +71,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/salesforcesource/adapter.go
+++ b/pkg/sources/reconciler/salesforcesource/adapter.go
@@ -105,8 +105,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -63,8 +63,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -54,8 +54,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -65,8 +65,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -52,8 +52,8 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, _ *apis.URL) *servin
 }
 
 // RBACOwners implements common.AdapterDeploymentBuilder.
-func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
-	srcs, err := r.srcLister(namespace).List(labels.Everything())
+func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(src.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}


### PR DESCRIPTION
Another incremental step towards #244.

Adds a `serviceAccountProvider` micro-interface which allows an instance of a Source kind to signal that it requires its **own** ServiceAccount instead of the default shared ServiceAccount.
E.g., instead of using the shared `foosource-adapter` ServiceAccount, a source instance can implement `WantsOwnServiceAccount()` and return `true`, and the adapter reconciler will sync a dedicated ServiceAccount for that particular object instead.

```console
$ kubectl get serviceaccount
NAME                      SECRETS   AGE
foosource-adapter         1         1m    <- shared
foosource-i-mysource      1         1m    <- object-specific
foosource-i-othersource   1         1m    <- object-specific
```

The immediate goal is to allow AWS sources to support "IAM role" authentication, which is a credential-less authentication mode that is enabled by annotating a ServiceAccount.
The actual implementation of the auth mechanism will follow in another PR, but I already added a dummy `nil` implementation of the required method to `awssqs_lifecycle.go`.