### PR TITLE
Determine S3 region and bucket owner if not provided

### DIFF
--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -58,15 +58,18 @@ spec:
             type: object
             properties:
               arn:
-                description: ARN of the S3 bucket to receive notifications from. The expected format is
-                  'arn:${Partition}:s3:${Region}:${Account}:${BucketName}'. Although not technically required by S3, we
-                  enforce that bucket ARNs include a region and an account ID, because this information is required by
-                  the source to operate properly. See also
+                description: |-
+                  ARN of the S3 bucket to receive notifications from. The expected format is documented at
                   https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-resources-for-iam-policies.
+
+                  Although not technically supported by S3, the ARN provided via this attribute may include a region and
+                  an account ID. When this information is provided, it is used to set an accurate identity-based access
+                  policy between the S3 bucket and the reconciled SQS queue, unless an existing queue is provided via
+                  the queueARN attribute.
                 type: string
                 # Bucket naming rules
                 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-                pattern: ^arn:aws(-cn|-us-gov)?:s3:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:[0-9a-z][0-9a-z.-]{2,62}$
+                pattern: ^arn:aws(-cn|-us-gov)?:s3:([a-z]{2}(-gov)?-[a-z]+-\d)?:(\d{12})?:[0-9a-z][0-9a-z.-]{2,62}$
               eventTypes:
                 description: List of event types that the source should subscribe to. Accepted values are listed at
                   https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html.

--- a/config/samples/sources/awss3source.yaml
+++ b/config/samples/sources/awss3source.yaml
@@ -24,7 +24,7 @@ kind: AWSS3Source
 metadata:
   name: sample
 spec:
-  arn: arn:aws:s3:us-west-2:123456789012:triggermeshtest
+  arn: arn:aws:s3:::triggermeshtest
 
   eventTypes:
   - s3:ObjectCreated:*

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -51,9 +51,12 @@ type AWSS3SourceSpec struct {
 	// Bucket ARN
 	// https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-resources-for-iam-policies
 	//
-	// Although not technically required by S3, we enforce that bucket ARNs
-	// include a region and an account ID, because this information is
-	// required by the reconciler to operate properly.
+	// Although not technically supported by S3, the ARN provided via this
+	// attribute may include a region and an account ID. When this
+	// information is provided, it is used to set an accurate
+	// identity-based access policy between the S3 bucket and the
+	// reconciled SQS queue, unless an existing queue is provided via the
+	// QueueARN attribute.
 	ARN apis.ARN `json:"arn"`
 
 	// List of event types that the source should subscribe to.

--- a/pkg/sources/aws/s3/s3.go
+++ b/pkg/sources/aws/s3/s3.go
@@ -23,13 +23,12 @@ import "github.com/triggermesh/triggermesh/pkg/apis"
 // which matches the official format defined by AWS.
 // https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#amazons3-resources-for-iam-policies
 //
-// This is necessary because our AWSS3Source API enforces that bucket ARNs
+// This is necessary because our AWSS3Source API accepts that bucket ARNs
 // include a region and an account ID, which are both absent from the public
 // ARN.
 func RealBucketARN(arn apis.ARN) string {
-	arnCpy := arn
-	arnCpy.Region = ""
-	arnCpy.AccountID = ""
+	arn.Region = ""
+	arn.AccountID = ""
 
-	return arnCpy.String()
+	return arn.String()
 }


### PR DESCRIPTION
Closes #33

We currently require users to "augment" the ARN of their S3 bucket with a region and account ID, although this information isn't part of the official ARN of a bucket:

```diff
-  arn: arn:aws:s3:::triggermeshtest
+  arn: arn:aws:s3:us-west-2:123456789012:triggermeshtest
```

This is a bit confusing because:
1. People expect to be able to use the ARN given to them by AWS, and not a modified version specific to TriggerMesh
2. We only need that information to wire some IAM policy _if_ the user didn't provide a SQS queue in the spec

With this change, users are able to pass the _official_ ARN of their S3 bucket (no region, no account ID) and, if needed, we retrieve the missing information using:
- [s3.GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) for the bucket's region
- [sts.GetCallerIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html) for the account ID (permission-less API)

---

### Demo

Create a source with an official ARN (no region, no account ID):

```yaml
apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSS3Source
metadata:
  name: sample
spec:
  arn: arn:aws:s3:::mybucket

  eventTypes:
  - s3:ObjectCreated:*
  - s3:ObjectRemoved:*

  credentials:
    accessKeyID:
      value: AKIAIOSFODNN7EXAMPLE
    secretAccessKey:
      value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

  sink:
    uri: http://event-display
```

The reconciler successfully determines the region and account ID, and uses it to reconcile the SQS queue:

```console
$ kubectl get awss3sources/sample
NAME     READY   REASON   QUEUE                                                   SINK                   AGE
sample   True             arn:aws:sqs:us-west-2:123456789012:s3-events_mybucket   http://event-display   1m

```