### PR TITLE
clusterroles: fix rbac role for openshift

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -386,6 +386,7 @@ rules:
   - ''
   resources:
   - serviceaccounts
+  - serviceaccounts/finalizers
   verbs:
   - list
   - watch


### PR DESCRIPTION
fixes 

```
{"severity":"ERROR","timestamp":"2021-11-09T09:58:42.118506786Z","logger":"aws-event-sources-controller","caller":"controller/controller.go:548","message":"Reconcile error","commit":"c498a3a","knative.dev/controller":"github.com.triggermesh.aws-event-sources.pkg.reconciler.awssqssource.Reconciler","knative.dev/kind":"sources.triggermesh.io.AWSSQSSource","duration":"67.232789ms","error":"failed to reconcile adapter: reconciling RBAC objects: Failed to create adapter RoleBinding \"awssqssource-adapter\": rolebindings.rbac.authorization.k8s.io \"awssqssource-adapter\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\t/go/pkg/mod/knative.dev/pkg@v0.0.0-20210331065221-952fdd90dbb0/controller/controller.go:548\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\t/go/pkg/mod/knative.dev/pkg@v0.0.0-20210331065221-952fdd90dbb0/controller/controller.go:531\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\t/go/pkg/mod/knative.dev/pkg@v0.0.0-20210331065221-952fdd90dbb0/controller/controller.go:468"}
```