### PR TITLE
Several improvements to Azure packages for sources

### DIFF
--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
@@ -72,24 +72,24 @@ func (*AzureServiceBusTopicSource) GetEventTypes() []string {
 
 // Status conditions
 const (
-	// AzureServiceBusTopicSubscribed has status True when the source has subscribed to a topic.
-	AzureServiceBusTopicSubscribed apis.ConditionType = "Subscribed"
+	// AzureServiceBusTopicConditionSubscribed has status True when the source has subscribed to a topic.
+	AzureServiceBusTopicConditionSubscribed apis.ConditionType = "Subscribed"
 )
 
 // azureServiceBusTopicSourceConditionSet is a set of conditions for
 // AzureServiceBusTopicSource objects.
 var azureServiceBusTopicSourceConditionSet = NewEventSourceConditionSet(
-	AzureServiceBusTopicSubscribed,
+	AzureServiceBusTopicConditionSubscribed,
 )
 
 // MarkSubscribed sets the Subscribed condition to True.
 func (s *AzureServiceBusTopicSourceStatus) MarkSubscribed() {
-	azureServiceBusTopicSourceConditionSet.Manage(s).MarkTrue(AzureServiceBusTopicSubscribed)
+	azureServiceBusTopicSourceConditionSet.Manage(s).MarkTrue(AzureServiceBusTopicConditionSubscribed)
 }
 
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *AzureServiceBusTopicSourceStatus) MarkNotSubscribed(reason, msg string) {
 	s.SubscriptionID = nil
-	azureServiceBusTopicSourceConditionSet.Manage(s).MarkFalse(AzureServiceBusTopicSubscribed, reason, msg)
+	azureServiceBusTopicSourceConditionSet.Manage(s).MarkFalse(AzureServiceBusTopicConditionSubscribed, reason, msg)
 }

--- a/pkg/sources/auth/errors.go
+++ b/pkg/sources/auth/errors.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+// PermanentCredentialsError is an error behaviour which signals that the
+// interaction with an external service shouldn't be retried, due to
+// credentials which are either invalid, expired, or missing permissions.
+//
+// This allows callers to handle that special case if required, especially when
+// the original error can not be asserted any other way because it is untyped.
+// For example, Kubernetes finalizers are unlikely to be able to proceed when
+// credentials can not be determined.
+//
+// Examples of assertion:
+//
+//   _, ok := err.(PermanentCredentialsError)
+//
+//   permErr := (PermanentCredentialsError)(nil)
+//   ok := errors.As(err, &permErr)
+//
+type PermanentCredentialsError interface {
+	error
+	IsPermanent()
+}
+
+// NewPermanentCredentialsError marks an auth-related error as permanent (non retryable).
+func NewPermanentCredentialsError(err error) error {
+	return permanentCredentialsError{e: err}
+}
+
+var _ PermanentCredentialsError = (*permanentCredentialsError)(nil)
+
+// permanentCredentialsError is an opaque error type that wraps another error
+// and implements the PermanentCredentialsError error behaviour.
+type permanentCredentialsError struct {
+	e error
+}
+
+// IsFatal implements FatalCredentialsError.
+func (permanentCredentialsError) IsPermanent() {}
+
+// Error implements the error interface.
+func (e permanentCredentialsError) Error() string {
+	if e.e == nil {
+		return ""
+	}
+	return e.e.Error()
+}
+
+// Unwrap implements errors.Unwrap.
+func (e permanentCredentialsError) Unwrap() error {
+	return e.e
+}

--- a/pkg/sources/auth/errors_test.go
+++ b/pkg/sources/auth/errors_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package azure
+package auth_test
 
 import (
 	"errors"
@@ -22,22 +22,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	. "github.com/triggermesh/triggermesh/pkg/sources/auth"
 )
 
-func TestEmptyCredentialsError(t *testing.T) {
+func TestPermanentCredentialsError(t *testing.T) {
 	genericErr := assert.AnError
-	ecErr := emptyCredentialsError{e: genericErr}
+	permErr := NewPermanentCredentialsError(genericErr)
 
-	assert.False(t, isEmptyCreds(genericErr))
-	assert.False(t, isEmptyCreds(fmt.Errorf("wrapped: %w", genericErr)))
+	assert.False(t, isPermanent(genericErr))
+	assert.False(t, isPermanent(fmt.Errorf("wrapped: %w", genericErr)))
 
-	assert.True(t, isEmptyCreds(ecErr))
-	assert.True(t, isEmptyCreds(fmt.Errorf("wrapped: %w", ecErr)))
+	assert.True(t, isPermanent(permErr))
+	assert.True(t, isPermanent(fmt.Errorf("wrapped: %w", permErr)))
 
 }
 
-// isEmptyCreds returns whether err implements the IsEmptyCredentials error behaviour.
-func isEmptyCreds(err error) bool {
-	ecErr := (interface{ IsEmptyCredentials() })(nil)
-	return errors.As(err, &ecErr)
+// isPermanent returns whether err implements PermanentCredentialsError.
+func isPermanent(err error) bool {
+	permErr := (PermanentCredentialsError)(nil)
+	return errors.As(err, &permErr)
 }

--- a/pkg/sources/client/azure/eventgrid/client.go
+++ b/pkg/sources/client/azure/eventgrid/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/eventhub/mgmt/eventhub/eventhubapi"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/triggermesh/pkg/sources/azure"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth/azure"
 )
 
 // EventSubscriptionsClient is an alias for the EventSubscriptionsClientAPI interface.
@@ -62,7 +62,7 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.AzureEventGridSource) (EventSubscriptionsClient, EventHubsClient, error) {
-	authorizer, err := azure.Authorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
+	authorizer, err := azure.NewAADAuthorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
 	if err != nil {
 		return nil, nil, fmt.Errorf("retrieving Azure service principal credentials: %w", err)
 	}

--- a/pkg/sources/client/azure/insights/client.go
+++ b/pkg/sources/client/azure/insights/client.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights/insightsapi"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/triggermesh/pkg/sources/azure"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth/azure"
 )
 
 // EventCategoriesClient is an alias for the EventCategoriesClientAPI interface.
@@ -60,7 +60,7 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.AzureActivityLogsSource) (EventCategoriesClient, DiagnosticSettingsClient, error) {
-	authorizer, err := azure.Authorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
+	authorizer, err := azure.NewAADAuthorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
 	if err != nil {
 		return nil, nil, fmt.Errorf("retrieving Azure service principal credentials: %w", err)
 	}

--- a/pkg/sources/client/azure/servicebustopics/client.go
+++ b/pkg/sources/client/azure/servicebustopics/client.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus/servicebusapi"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/triggermesh/pkg/sources/azure"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth/azure"
 )
 
 // SubscriptionsClient is an alias for the SubscriptionsClientAPI interface.
@@ -57,7 +57,7 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.AzureServiceBusTopicSource) (SubscriptionsClient, error) {
-	authorizer, err := azure.Authorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
+	authorizer, err := azure.NewAADAuthorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Azure service principal credentials: %w", err)
 	}

--- a/pkg/sources/client/azure/storage/client.go
+++ b/pkg/sources/client/azure/storage/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/eventhub/mgmt/eventhub/eventhubapi"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/triggermesh/pkg/sources/azure"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth/azure"
 )
 
 // EventSubscriptionsClient is an alias for the EventSubscriptionsClientAPI interface.
@@ -62,7 +62,7 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.AzureBlobStorageSource) (EventSubscriptionsClient, EventHubsClient, error) {
-	authorizer, err := azure.Authorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
+	authorizer, err := azure.NewAADAuthorizer(g.sg(src.Namespace), src.Spec.Auth.ServicePrincipal)
 	if err != nil {
 		return nil, nil, fmt.Errorf("retrieving Azure service principal credentials: %w", err)
 	}

--- a/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources"
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/event"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/skip"
 )
@@ -360,7 +361,7 @@ func isNoCredentials(err error) bool {
 	if k8sErr := apierrors.APIStatus(nil); errors.As(err, &k8sErr) {
 		return k8sErr.Status().Reason == metav1.StatusReasonNotFound
 	}
-	if ecErr := (interface{ IsEmptyCredentials() })(nil); errors.As(err, &ecErr) {
+	if permErr := (auth.PermanentCredentialsError)(nil); errors.As(err, &permErr) {
 		return true
 	}
 	return false

--- a/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
@@ -240,7 +240,7 @@ func recursErrMsg(errMsg string, err error) string {
 		// the object's status conditions.
 		// Instead of resorting to over-engineered error parsing techniques to get around the verbosity of the
 		// message, we simply return a short and generic error description.
-		return errMsg + "Invalid client secret"
+		return errMsg + "failed to refresh token: the provided secret is either invalid or expired"
 	}
 
 	return errMsg + err.Error()

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/injection/reconciler/sources/v1alpha1/azureblobstoragesource"
 	listersv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/listers/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth"
 	"github.com/triggermesh/triggermesh/pkg/sources/client/azure/storage"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/event"
@@ -120,7 +121,7 @@ func isNoCredentials(err error) bool {
 	if k8sErr := apierrors.APIStatus(nil); errors.As(err, &k8sErr) {
 		return k8sErr.Status().Reason == metav1.StatusReasonNotFound
 	}
-	if ecErr := (interface{ IsEmptyCredentials() })(nil); errors.As(err, &ecErr) {
+	if permErr := (auth.PermanentCredentialsError)(nil); errors.As(err, &permErr) {
 		return true
 	}
 	return false

--- a/pkg/sources/reconciler/azureeventgridsource/event_subs.go
+++ b/pkg/sources/reconciler/azureeventgridsource/event_subs.go
@@ -244,7 +244,7 @@ func recursErrMsg(errMsg string, err error) string {
 		// the object's status conditions.
 		// Instead of resorting to over-engineered error parsing techniques to get around the verbosity of the
 		// message, we simply return a short and generic error description.
-		return errMsg + "Invalid client secret"
+		return errMsg + "failed to refresh token: the provided secret is either invalid or expired"
 	}
 
 	return errMsg + err.Error()

--- a/pkg/sources/reconciler/azureeventgridsource/reconciler.go
+++ b/pkg/sources/reconciler/azureeventgridsource/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/injection/reconciler/sources/v1alpha1/azureeventgridsource"
 	listersv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/listers/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth"
 	"github.com/triggermesh/triggermesh/pkg/sources/client/azure/eventgrid"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/event"
@@ -120,7 +121,7 @@ func isNoCredentials(err error) bool {
 	if k8sErr := apierrors.APIStatus(nil); errors.As(err, &k8sErr) {
 		return k8sErr.Status().Reason == metav1.StatusReasonNotFound
 	}
-	if ecErr := (interface{ IsEmptyCredentials() })(nil); errors.As(err, &ecErr) {
+	if permErr := (auth.PermanentCredentialsError)(nil); errors.As(err, &permErr) {
 		return true
 	}
 	return false

--- a/pkg/sources/reconciler/azureservicebustopicsource/reconciler.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/injection/reconciler/sources/v1alpha1/azureservicebustopicsource"
 	listersv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/listers/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/auth"
 	"github.com/triggermesh/triggermesh/pkg/sources/client/azure/servicebustopics"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/event"
@@ -111,7 +112,7 @@ func isNoCredentials(err error) bool {
 	if k8sErr := apierrors.APIStatus(nil); errors.As(err, &k8sErr) {
 		return k8sErr.Status().Reason == metav1.StatusReasonNotFound
 	}
-	if ecErr := (interface{ IsEmptyCredentials() })(nil); errors.As(err, &ecErr) {
+	if permErr := (auth.PermanentCredentialsError)(nil); errors.As(err, &permErr) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Port the few bits which I found interesting from #256, without the migration to the new SDK (which is not mature enough for us to use, see PR).

- Move `sources/azure` to `sources/auth/azure`
- Move Permanent error behaviour to `sources/auth` package
- Rename `azure.Authorizer()` to `azure.NewAADAuthorizer()`
- Remove Subscription comparison from Service Bus Topics source