### PR TITLE
Refactor CloudEventOverrides in Google Cloud sources

### DIFF
--- a/pkg/sources/adapter/googlecloudpubsubsource/resource_name.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/resource_name.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package googlecloudpubsubsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/kelseyhightower/envconfig"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+)
+
+// GCloudResourceName is a fully qualified Google Cloud resource name which can
+// be decoded by envconfig.
+type GCloudResourceName v1alpha1.GCloudResourceName
+
+var (
+	_ fmt.Stringer      = (*GCloudResourceName)(nil)
+	_ envconfig.Decoder = (*GCloudResourceName)(nil)
+)
+
+// String implements fmt.Stringer.
+func (n *GCloudResourceName) String() string {
+	return (*v1alpha1.GCloudResourceName)(n).String()
+}
+
+// Decode implements envconfig.Decoder.
+func (n *GCloudResourceName) Decode(value string) error {
+	resName := (*v1alpha1.GCloudResourceName)(n)
+	return json.Unmarshal([]byte(strconv.Quote(value)), resName)
+}

--- a/pkg/sources/adapter/googlecloudpubsubsource/resource_name_test.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/resource_name_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package googlecloudpubsubsource_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/triggermesh/triggermesh/pkg/sources/adapter/googlecloudpubsubsource"
+)
+
+func TestStringerGCloudResourceName(t *testing.T) {
+	n := &GCloudResourceName{
+		Project:    "project",
+		Collection: "collection",
+		Resource:   "resource",
+	}
+
+	const expect = "projects/project/collection/resource"
+
+	assert.Equal(t, expect, n.String())
+}
+
+func TestDecodeGCloudResourceName(t *testing.T) {
+	n := &GCloudResourceName{}
+
+	err := n.Decode("invalid_resource_name")
+	assert.Error(t, err)
+
+	err = n.Decode("projects/project/collection/resource")
+	require.NoError(t, err)
+
+	assert.Equal(t, "project", n.Project)
+	assert.Equal(t, "collection", n.Collection)
+	assert.Equal(t, "resource", n.Resource)
+}

--- a/pkg/sources/cloudevents/overrides.go
+++ b/pkg/sources/cloudevents/overrides.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"encoding/json"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+const (
+	AttributeSource = "source"
+	AttributeType   = "type"
+)
+
+// OverridesJSON returns the JSON representation of a duckv1.CloudEventOverrides,
+// after applying some optional transformations to it.
+func OverridesJSON(ceo *duckv1.CloudEventOverrides, overrides ...ceOverrideOption) string {
+	for _, o := range overrides {
+		ceo = o(ceo)
+	}
+
+	var ceoStr string
+	if b, err := json.Marshal(ceo); err == nil {
+		ceoStr = string(b)
+	}
+
+	return ceoStr
+}
+
+// ceOverrideOption is a functional option that can alter a duckv1.CloudEventOverrides.
+type ceOverrideOption func(*duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides
+
+// SetExtension returns a ceOverrideOption which sets a given CloudEvents
+// extension to an arbitrary value, if this extension isn't already set.
+func SetExtension(key, value string) ceOverrideOption {
+	return func(ceo *duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides {
+		if ceo == nil {
+			ceo = &duckv1.CloudEventOverrides{}
+		}
+
+		ext := &ceo.Extensions
+		if *ext == nil {
+			*ext = make(map[string]string, 1)
+		}
+
+		if _, isSet := (*ext)[key]; !isSet {
+			(*ext)[key] = value
+		}
+
+		return ceo
+	}
+}

--- a/pkg/sources/cloudevents/overrides_test.go
+++ b/pkg/sources/cloudevents/overrides_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	. "github.com/triggermesh/triggermesh/pkg/sources/cloudevents"
+)
+
+func TestOverridesJSON(t *testing.T) {
+	var ceo *duckv1.CloudEventOverrides
+
+	output := OverridesJSON(ceo,
+		SetExtension("custom", "a value"),
+		SetExtension("source", "/my/event/source"),
+	)
+
+	// Map keys are sorted by json.Marshal, so the expected output is
+	// guaranteed to remain stable.
+	const expect = `{"extensions":{"custom":"a value","source":"/my/event/source"}}`
+
+	assert.Equal(t, expect, output)
+}

--- a/pkg/sources/reconciler/common/env.go
+++ b/pkg/sources/reconciler/common/env.go
@@ -46,6 +46,6 @@ const (
 	EnvHubResourceID = "EVENTHUB_RESOURCE_ID"
 
 	// Google Cloud
-	EnvGCloudProject = "GCLOUD_PROJECT"
-	EnvGCloudSAKey   = "GCLOUD_SERVICEACCOUNT_KEY"
+	EnvGCloudSAKey              = "GCLOUD_SERVICEACCOUNT_KEY"
+	EnvGCloudPubSubSubscription = "GCLOUD_PUBSUB_SUBSCRIPTION"
 )

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package googlecloudbillingsource
 
 import (
-	"encoding/json"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,17 +26,12 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/cloudevents"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
-)
-
-const (
-	envBillingSubscription = "GCLOUD_PUBSUB_SUBSCRIPTION"
-	envCloudEventSource    = "CE_SOURCE"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -58,30 +52,25 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	typedSrc := src.(*v1alpha1.GoogleCloudBillingSource)
 
 	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var pubsubProject string
-	var subsID string
+	var subsName string
 	if sn := typedSrc.Status.Subscription; sn != nil {
-		pubsubProject = sn.Project
-		subsID = sn.Resource
+		subsName = sn.String()
 	}
 
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := ceOverridesJSON(typedSrc.Spec.CloudEventOverrides)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
+		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
+		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudBillingGenericEventType),
+	)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		// TODO(antoineco): remove usage of CE_SOURCE / CE overrides
-		// and configure a message handler for Cloud Billing events in
-		// the adapter instead.
-		resource.EnvVar(envCloudEventSource, typedSrc.AsEventSource()),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
-
-		resource.EnvVar(common.EnvGCloudProject, pubsubProject),
-		resource.EnvVar(envBillingSubscription, subsID),
+		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }
@@ -99,35 +88,4 @@ func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable,
 	}
 
 	return ownerRefables, nil
-}
-
-// ceOverridesJSON returns the source's CloudEvent overrides as a JSON object.
-func ceOverridesJSON(ceo *duckv1.CloudEventOverrides) string {
-	ceo = setCETypeOverride(ceo)
-
-	var ceoStr string
-	if b, err := json.Marshal(ceo); err == nil {
-		ceoStr = string(b)
-	}
-
-	return ceoStr
-}
-
-// setCETypeOverride sets an override on the CloudEvent "type" attribute that
-// matches event payloads sent by Google Cloud Billing.
-func setCETypeOverride(ceo *duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides {
-	if ceo == nil {
-		ceo = &duckv1.CloudEventOverrides{}
-	}
-
-	ext := &ceo.Extensions
-	if *ext == nil {
-		*ext = make(map[string]string, 1)
-	}
-
-	if _, isSet := (*ext)["type"]; !isSet {
-		(*ext)["type"] = v1alpha1.GoogleCloudBillingGenericEventType
-	}
-
-	return ceo
 }

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package googlecloudiotsource
 
 import (
-	"encoding/json"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,17 +26,12 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/cloudevents"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
-)
-
-const (
-	envIoTSubscription  = "GCLOUD_PUBSUB_SUBSCRIPTION"
-	envCloudEventSource = "CE_SOURCE"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -58,30 +52,25 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	typedSrc := src.(*v1alpha1.GoogleCloudIoTSource)
 
 	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var pubsubProject string
-	var subsID string
+	var subsName string
 	if sn := typedSrc.Status.Subscription; sn != nil {
-		pubsubProject = sn.Project
-		subsID = sn.Resource
+		subsName = sn.String()
 	}
 
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := ceOverridesJSON(typedSrc.Spec.CloudEventOverrides)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
+		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
+		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudIoTGenericEventType),
+	)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		// TODO(antoineco): remove usage of CE_SOURCE / CE overrides
-		// and configure a message handler for Cloud IoT events in
-		// the adapter instead.
-		resource.EnvVar(envCloudEventSource, typedSrc.AsEventSource()),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
-
-		resource.EnvVar(common.EnvGCloudProject, pubsubProject),
-		resource.EnvVar(envIoTSubscription, subsID),
+		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }
@@ -99,35 +88,4 @@ func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable,
 	}
 
 	return ownerRefables, nil
-}
-
-// ceOverridesJSON returns the source's CloudEvent overrides as a JSON object.
-func ceOverridesJSON(ceo *duckv1.CloudEventOverrides) string {
-	ceo = setCETypeOverride(ceo)
-
-	var ceoStr string
-	if b, err := json.Marshal(ceo); err == nil {
-		ceoStr = string(b)
-	}
-
-	return ceoStr
-}
-
-// setCETypeOverride sets an override on the CloudEvent "type" attribute that
-// matches event payloads sent by Google Cloud Source IoT.
-func setCETypeOverride(ceo *duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides {
-	if ceo == nil {
-		ceo = &duckv1.CloudEventOverrides{}
-	}
-
-	ext := &ceo.Extensions
-	if *ext == nil {
-		*ext = make(map[string]string, 1)
-	}
-
-	if _, isSet := (*ext)["type"]; !isSet {
-		(*ext)["type"] = v1alpha1.GoogleCloudIoTGenericEventType
-	}
-
-	return ceo
 }

--- a/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
@@ -32,11 +32,6 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
-const (
-	envPubSubSubscription = "GCLOUD_PUBSUB_SUBSCRIPTION"
-	envCloudEventSource   = "CE_SOURCE"
-)
-
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -56,9 +51,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	// the user may or may not provide a Pub/Sub subscription ID in the
 	// source's spec, so the source's status is unfortunately our only
 	// source of truth here
-	var subsID string
+	var subsName string
 	if sn := typedSrc.Status.Subscription; sn != nil {
-		subsID = sn.Resource
+		subsName = sn.String()
 	}
 
 	var authEnvs []corev1.EnvVar
@@ -67,9 +62,7 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(envCloudEventSource, typedSrc.Spec.Topic.String()),
-		resource.EnvVar(common.EnvGCloudProject, typedSrc.Spec.Topic.Project),
-		resource.EnvVar(envPubSubSubscription, subsID),
+		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)

--- a/pkg/sources/reconciler/googlecloudrepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudrepositoriessource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package googlecloudrepositoriessource
 
 import (
-	"encoding/json"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,17 +26,12 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/cloudevents"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
-)
-
-const (
-	envRepositoriesSubscription = "GCLOUD_PUBSUB_SUBSCRIPTION"
-	envCloudEventSource         = "CE_SOURCE"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -58,30 +52,25 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	typedSrc := src.(*v1alpha1.GoogleCloudRepositoriesSource)
 
 	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var pubsubProject string
-	var subsID string
+	var subsName string
 	if sn := typedSrc.Status.Subscription; sn != nil {
-		pubsubProject = sn.Project
-		subsID = sn.Resource
+		subsName = sn.String()
 	}
 
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := ceOverridesJSON(typedSrc.Spec.CloudEventOverrides)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
+		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
+		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudRepositoriesGenericEventType),
+	)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		// TODO(antoineco): remove usage of CE_SOURCE / CE overrides
-		// and configure a message handler for Cloud Repositories events in
-		// the adapter instead.
-		resource.EnvVar(envCloudEventSource, typedSrc.AsEventSource()),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
-
-		resource.EnvVar(common.EnvGCloudProject, pubsubProject),
-		resource.EnvVar(envRepositoriesSubscription, subsID),
+		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }
@@ -99,35 +88,4 @@ func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable,
 	}
 
 	return ownerRefables, nil
-}
-
-// ceOverridesJSON returns the source's CloudEvent overrides as a JSON object.
-func ceOverridesJSON(ceo *duckv1.CloudEventOverrides) string {
-	ceo = setCETypeOverride(ceo)
-
-	var ceoStr string
-	if b, err := json.Marshal(ceo); err == nil {
-		ceoStr = string(b)
-	}
-
-	return ceoStr
-}
-
-// setCETypeOverride sets an override on the CloudEvent "type" attribute that
-// matches event payloads sent by Google Cloud Source Repositories.
-func setCETypeOverride(ceo *duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides {
-	if ceo == nil {
-		ceo = &duckv1.CloudEventOverrides{}
-	}
-
-	ext := &ceo.Extensions
-	if *ext == nil {
-		*ext = make(map[string]string, 1)
-	}
-
-	if _, isSet := (*ext)["type"]; !isSet {
-		(*ext)["type"] = v1alpha1.GoogleCloudRepositoriesGenericEventType
-	}
-
-	return ceo
 }

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package googlecloudstoragesource
 
 import (
-	"encoding/json"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,17 +26,12 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/cloudevents"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
-)
-
-const (
-	envStorageSubscription = "GCLOUD_PUBSUB_SUBSCRIPTION"
-	envCloudEventSource    = "CE_SOURCE"
 )
 
 // adapterConfig contains properties used to configure the source's adapter.
@@ -58,30 +52,25 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	typedSrc := src.(*v1alpha1.GoogleCloudStorageSource)
 
 	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var pubsubProject string
-	var subsID string
+	var subsName string
 	if sn := typedSrc.Status.Subscription; sn != nil {
-		pubsubProject = sn.Project
-		subsID = sn.Resource
+		subsName = sn.String()
 	}
 
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := ceOverridesJSON(typedSrc.Spec.CloudEventOverrides)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
+		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
+		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudStorageGenericEventType),
+	)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		// TODO(antoineco): remove usage of CE_SOURCE / CE overrides
-		// and configure a message handler for Cloud Storage events in
-		// the adapter instead.
-		resource.EnvVar(envCloudEventSource, typedSrc.AsEventSource()),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
-
-		resource.EnvVar(common.EnvGCloudProject, pubsubProject),
-		resource.EnvVar(envStorageSubscription, subsID),
+		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }
@@ -99,35 +88,4 @@ func (r *Reconciler) RBACOwners(src v1alpha1.EventSource) ([]kmeta.OwnerRefable,
 	}
 
 	return ownerRefables, nil
-}
-
-// ceOverridesJSON returns the source's CloudEvent overrides as a JSON object.
-func ceOverridesJSON(ceo *duckv1.CloudEventOverrides) string {
-	ceo = setCETypeOverride(ceo)
-
-	var ceoStr string
-	if b, err := json.Marshal(ceo); err == nil {
-		ceoStr = string(b)
-	}
-
-	return ceoStr
-}
-
-// setCETypeOverride sets an override on the CloudEvent "type" attribute that
-// matches event payloads sent by Google Cloud Storage.
-func setCETypeOverride(ceo *duckv1.CloudEventOverrides) *duckv1.CloudEventOverrides {
-	if ceo == nil {
-		ceo = &duckv1.CloudEventOverrides{}
-	}
-
-	ext := &ceo.Extensions
-	if *ext == nil {
-		*ext = make(map[string]string, 1)
-	}
-
-	if _, isSet := (*ext)["type"]; !isSet {
-		(*ext)["type"] = v1alpha1.GoogleCloudStorageGenericEventType
-	}
-
-	return ceo
 }


### PR DESCRIPTION
A first step towards consolidating the code duplicated inside our multiple Google Cloud sources.

- **Consolidate repeated `ceOverridesJSON` functions inside new `sources/cloudevents` package.**
    We now have a global `cloudevents.OverridesJSON()` helper to achieve this.

- **Use this new helper to set the CloudEvents `source` attribute via overrides.**
    By default, the Pub/Sub adapter uses the resource name of the Pub/Sub topic as event source. For some sources, such as Cloud Storage, it makes sense to override that value (e.g. with the bucket's URL).

- **Pass a single fully-qualified Subscription name to adapters, instead of a project and a subscription ID separately.**
    Sources backed by Pub/Sub report the full resource name of their active Subscription inside their status (in the format `projects/{project}/subscriptions/{subscription}`). We don't need to multiply our env vars by splitting this resource name into two, we can instead pass it as-is and let the adapter deal with the parsing/validation.

- Add various tests related to the additions above.