### PR TITLE
Remove Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release](https://img.shields.io/github/v/release/triggermesh/triggermesh?label=release)](https://github.com/triggermesh/triggermesh/releases)
 [![CircleCI](https://circleci.com/gh/triggermesh/triggermesh/tree/main.svg?style=shield)](https://circleci.com/gh/triggermesh/triggermesh/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/triggermesh/triggermesh)](https://goreportcard.com/report/github.com/triggermesh/triggermesh)
-[![Slack](https://img.shields.io/badge/Slack-Join%20chat-4a154b?style=flat&logo=slack)](https://join.slack.com/t/triggermesh-community/shared_invite/zt-wk5axnac-79BoPtk~xLip9fFhGAYYhg)
+[![Slack](https://img.shields.io/badge/Slack-Join%20chat-4a154b?style=flat&logo=slack)](https://join.slack.com/t/triggermesh-community/shared_invite/zt-yaydoq0y-ULniSgpqndaUa90wPsdD5g)
 
 The TriggerMesh Cloud Native Integration Platform consists of a set of APIs which allows you to build event-driven
 applications. Implemented as a set of Kubernetes CRDs and a Kubernetes controller, it gives you a way to declaratively


### PR DESCRIPTION
The invitation link has expired, which makes this badge more misleading than anything else.

I suggest we remove it for now, and revert this commit once we have a new link to share.