### PR TITLE
Fix typo in CRD field validation

### DIFF
--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -82,7 +82,7 @@ spec:
                         description: Name of a SAS policy with Manage permissions inside the Event Hubs namespace
                           referenced by the 'namespaceID' field. Defaults to 'RootManageSharedAccessKey'.
                         type: string
-                        pattern: ^[\w.-]+$'
+                        pattern: ^[\w.-]+$
                     required:
                     - namespaceID
                 required:


### PR DESCRIPTION
Looks like at some point we had some single quotes around patterns in this CRD, and when I removed them I left a single quote behind 🤡 