### PR TITLE
Clarify meaning of "endpoint" in Azure sources

### DIFF
--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -99,11 +99,12 @@ spec:
                   # the other Storage event types.
                   - Microsoft.Storage.BlobInventoryPolicyCompleted
               endpoint:
-                description: The destination of events subscribed via Event Grid.
+                description: The intermediate destination of events subscribed via Event Grid, before they are retrieved
+                  by TriggerMesh.
                 type: object
                 properties:
                   eventHubs:
-                    description: Properties of an Event Hubs namespace to use as destination of events.
+                    description: Properties of an Event Hubs namespace to use as intermediate destination of events.
                     type: object
                     properties:
                       namespaceID:

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -76,11 +76,12 @@ spec:
                 items:
                   type: string
               endpoint:
-                description: The destination of events subscribed via Event Grid.
+                description: The intermediate destination of events subscribed via Event Grid, before they are retrieved
+                  by TriggerMesh.
                 type: object
                 properties:
                   eventHubs:
-                    description: Properties of an Event Hubs namespace to use as destination of events.
+                    description: Properties of an Event Hubs namespace to use as intermediate destination of events.
                     type: object
                     properties:
                       namespaceID:

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
@@ -74,7 +74,8 @@ type AzureBlobStorageSourceSpec struct {
 	// +optional
 	EventTypes []string `json:"eventTypes,omitempty"`
 
-	// The destination of events subscribed via Event Grid.
+	// The intermediate destination of events subscribed via Event Grid,
+	// before they are retrieved by TriggerMesh.
 	Endpoint AzureEventGridSourceEndpoint `json:"endpoint"`
 
 	// Authentication method to interact with the Azure REST API.

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
@@ -68,7 +68,8 @@ type AzureEventGridSourceSpec struct {
 	// +optional
 	EventTypes []string `json:"eventTypes,omitempty"`
 
-	// The destination of events subscribed via Event Grid.
+	// The intermediate destination of events subscribed via Event Grid,
+	// before they are retrieved by TriggerMesh.
 	Endpoint AzureEventGridSourceEndpoint `json:"endpoint"`
 
 	// Authentication method to interact with the Azure REST API.
@@ -76,13 +77,13 @@ type AzureEventGridSourceSpec struct {
 	Auth AzureAuth `json:"auth"`
 }
 
-// AzureEventGridSourceEndpoint contains possible destinations for events.
+// AzureEventGridSourceEndpoint contains possible intermediate destinations for events.
 type AzureEventGridSourceEndpoint struct {
 	EventHubs AzureEventGridSourceDestinationEventHubs `json:"eventHubs"`
 }
 
 // AzureEventGridSourceDestinationEventHubs contains properties of an Event
-// Hubs namespace to use as destination for events.
+// Hubs namespace to use as intermediate destination for events.
 type AzureEventGridSourceDestinationEventHubs struct {
 	// Resource ID of the Event Hubs namespace.
 	//


### PR DESCRIPTION
Clarifies what we mean exactly by "destination of events" ( or "event endpoint") in sources backed by Azure Event Grid.

These sources send events to Event Hubs - instead of, for example, exposing an endpoint for TriggerMesh to pull data directly - so this PR emphasized that the "destination of events" is an **intermediate** destination for these events.