### PR TITLE
Insert the requesting HTTP method and route in the CE metadata

### DIFF
--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -125,7 +126,8 @@ func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetType(h.eventType)
 	event.SetSource(h.eventSource)
-	event.SetExtension("http.method", r.Method)
+	event.SetExtension("method", strings.ToLower(r.Method))
+	event.SetExtension("route", strings.ToLower(r.URL.String()))
 
 	if err := event.SetData(r.Header.Get("Content-Type"), body); err != nil {
 		h.handleError(fmt.Errorf("failed to set event data: %w", err), http.StatusInternalServerError, w)

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -125,6 +125,7 @@ func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetType(h.eventType)
 	event.SetSource(h.eventSource)
+	event.SetExtension("http.method", r.Method)
 
 	if err := event.SetData(r.Header.Get("Content-Type"), body); err != nil {
 		h.handleError(fmt.Errorf("failed to set event data: %w", err), http.StatusInternalServerError, w)


### PR DESCRIPTION
This PR updates webhook source to add the incoming request method to the `method` CE extension. and the requesting path in the `route` CE extension. This change is being made In order to route events based upon the incoming request method and route