### PR TITLE
Fix Tekton Target's Cryptic Logs

### DIFF
--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -60,7 +60,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 		for _, ns := range nsl.Items {
 			targets, err := r.targetLister(ns.Name).List(labels.Everything())
 			if err != nil {
-				log.Warnw("unable to retrieve target adapters", zap.Error(err), zap.String("namespace",ns.Name))
+				log.Warnw("unable to retrieve target adapters", zap.Error(err), zap.String("namespace", ns.Name))
 				continue
 			}
 

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -40,12 +40,12 @@ func reaperThread(ctx context.Context, r *reconciler) {
 
 	p, err := cloudevents.NewHTTP()
 	if err != nil {
-		log.Fatalw("Failed to create new HTTP based Cloudevent: ", zap.Error(err))
+		log.Fatalw("Failed to create new HTTP based Cloudevent ", zap.Error(err))
 	}
 
 	client, err := cloudevents.NewClient(p)
 	if err != nil {
-		log.Fatalw("Unable to create Cloudevent client: ", zap.Error(err))
+		log.Fatalw("Unable to create Cloudevent client ", zap.Error(err))
 	}
 
 	for {
@@ -53,7 +53,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 		log.Debug("executing reaping")
 		nsl, err := k8sclient.Get(ctx).CoreV1().Namespaces().List(ctx, v1.ListOptions{})
 		if err != nil {
-			log.Fatalw("Unable to retrieve namespaces: ", zap.Error(err))
+			log.Fatalw("Unable to retrieve namespaces ", zap.Error(err))
 		}
 
 		// search for tektontargets across all namespaces
@@ -71,7 +71,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 					continue
 				}
 
-				log.Info("Found target: " + t.Namespace + "." + t.Name)
+				log.Info("Found target " + t.Namespace + "." + t.Name)
 				// Send the reap cloudevent
 				cloudCtx := cloudevents.ContextWithTarget(ctx, t.Status.Address.URL.String())
 
@@ -87,7 +87,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 				_ = newEvent.SetData(cloudevents.ApplicationJSON, nil)
 
 				result := client.Send(cloudCtx, newEvent)
-				log.Infow("event sending results: ", zap.Error(result))
+				log.Infow("event sending results ", zap.Error(result))
 			}
 		}
 	}

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -40,12 +40,12 @@ func reaperThread(ctx context.Context, r *reconciler) {
 
 	p, err := cloudevents.NewHTTP()
 	if err != nil {
-		log.Fatalw("failed to create new HTTP based cloudevent: ", zap.Error(err))
+		log.Fatalw("Failed to create new HTTP based Cloudevent: ", zap.Error(err))
 	}
 
 	client, err := cloudevents.NewClient(p)
 	if err != nil {
-		log.Fatalw("Unable to create cloudevent client: ", zap.Error(err))
+		log.Fatalw("Unable to create Cloudevent client: ", zap.Error(err))
 	}
 
 	for {

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -71,7 +71,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 					continue
 				}
 
-				log.Infow("Found target: " + t.Namespace + "." + t.Name)
+				log.Info("Found target: " + t.Namespace + "." + t.Name)
 				// Send the reap cloudevent
 				cloudCtx := cloudevents.ContextWithTarget(ctx, t.Status.Address.URL.String())
 

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -60,7 +60,7 @@ func reaperThread(ctx context.Context, r *reconciler) {
 		for _, ns := range nsl.Items {
 			targets, err := r.targetLister(ns.Name).List(labels.Everything())
 			if err != nil {
-				log.Warnw("unable to retrieve targets for #{ns.Name}: ", zap.Error(err))
+				log.Warnw("unable to retrieve target adapters", zap.Error(err), zap.String("namespace",ns.Name))
 				continue
 			}
 


### PR DESCRIPTION
By using `Infow` and `Fatalw` to correctly print the logs. 

closes #242 