### PR TITLE
Update Select AWS Source Adapters to Report Health-Check

### DIFF
--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 // envConfig is a set parameters sourced from the environment for the source's
@@ -123,7 +124,7 @@ func ExtractLogDetails(details string) (string, string) {
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
 	a.logger.Info("Enabling CloudWatchLog")
-
+	go health.Start(ctx)
 	// Setup polling to retrieve metrics
 	poll := time.NewTicker(a.pollingInterval)
 	defer poll.Stop()

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -35,7 +35,6 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
-	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 // envConfig is a set parameters sourced from the environment for the source's
@@ -160,7 +159,6 @@ func transformQuery(q *v1alpha1.AWSCloudWatchMetricStat) *cloudwatch.MetricStat 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
 	a.logger.Info("Enabling CloudWatch")
-	go health.Start(ctx)
 
 	// Setup polling to retrieve metrics
 	poll := time.NewTicker(a.pollingInterval)

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 // envConfig is a set parameters sourced from the environment for the source's
@@ -159,6 +160,7 @@ func transformQuery(q *v1alpha1.AWSCloudWatchMetricStat) *cloudwatch.MetricStat 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
 	a.logger.Info("Enabling CloudWatch")
+	go health.Start(ctx)
 
 	// Setup polling to retrieve metrics
 	poll := time.NewTicker(a.pollingInterval)

--- a/pkg/sources/adapter/awscodecommitsource/adapter.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 var (
@@ -103,6 +104,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
+	go health.Start(ctx)
 	if strings.Contains(a.gitEvents, pushEventType) {
 		a.logger.Info("Push events enabled")
 

--- a/pkg/sources/adapter/awskinesissource/adapter.go
+++ b/pkg/sources/adapter/awskinesissource/adapter.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 // envConfig is a set parameters sourced from the environment for the source's
@@ -90,6 +91,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
+	go health.Start(ctx)
 	// Get info about a particular stream
 	myStream, err := a.knsClient.DescribeStream(&kinesis.DescribeStreamInput{
 		StreamName: &a.stream,

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 const serviceType = "RDS"
@@ -130,7 +131,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
 	a.logger.Info("Enabling AWS Performance Insights Source")
-
+	go health.Start(ctx)
 	// Setup polling to retrieve metrics
 	poll := time.NewTicker(a.pollingInterval)
 	defer poll.Stop()


### PR DESCRIPTION
This PR intends to add health-check capabilities to a few of the AWS Source adapters in order for them to run properly within a Google Cloud Run instance. 

The  includes:
- AWS Code Commit
- AWS Performance Insights
- AWS CloudWatch Logs
- AWS Kinesis 

These were the only ones that I could get working/test. 
