### PR TITLE
Salesforce Source: JWT Audience must be sent as string

### DIFF
--- a/cmd/salesforcesource-adapter/main.go
+++ b/cmd/salesforcesource-adapter/main.go
@@ -17,11 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"github.com/golang-jwt/jwt/v4"
+
 	"knative.dev/eventing/pkg/adapter/v2"
 
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/salesforcesource"
 )
 
 func main() {
+	// JWT package marshals Audience as array even if there is only one element in it. This does not
+	// seem to be supported by Salesforce. By setting the following option to false we tell the imported
+	// library to marshal single item Audience array as a string.
+	jwt.MarshalSingleStringAsArray = false
+
 	adapter.Main("salesforce", salesforcesource.NewEnvConfig, salesforcesource.NewAdapter)
 }

--- a/cmd/salesforcetarget-adapter/main.go
+++ b/cmd/salesforcetarget-adapter/main.go
@@ -17,11 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"github.com/golang-jwt/jwt/v4"
+
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 
 	"github.com/triggermesh/triggermesh/pkg/targets/adapter/salesforcetarget"
 )
 
 func main() {
+	// JWT package marshals Audience as array even if there is only one element in it. This does not
+	// seem to be supported by Salesforce. By setting the following option to false we tell the imported
+	// library to marshal single item Audience array as a string.
+	jwt.MarshalSingleStringAsArray = false
+
 	pkgadapter.Main("salesforcetarget-adapter", salesforcetarget.EnvAccessor, salesforcetarget.NewTarget)
 }

--- a/pkg/sources/adapter/salesforcesource/auth/jwt.go
+++ b/pkg/sources/adapter/salesforcesource/auth/jwt.go
@@ -58,6 +58,11 @@ type claims struct {
 
 // NewJWTAuthenticator creates an OAuth JWT authenticator for Salesforce.
 func NewJWTAuthenticator(certKey, clientID, user, server string, client *http.Client, logger *zap.SugaredLogger) (Authenticator, error) {
+	// JWT package marshals Audience as array even if there is only one element in it. This does not
+	// seem to be supported by Salesforce. By setting the following option to false we tell the imported
+	// library to marshal single item Audience array as a string.
+	jwt.MarshalSingleStringAsArray = false
+
 	audience := strings.TrimSuffix(server, "/")
 
 	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(certKey))

--- a/pkg/sources/adapter/salesforcesource/auth/jwt.go
+++ b/pkg/sources/adapter/salesforcesource/auth/jwt.go
@@ -58,11 +58,6 @@ type claims struct {
 
 // NewJWTAuthenticator creates an OAuth JWT authenticator for Salesforce.
 func NewJWTAuthenticator(certKey, clientID, user, server string, client *http.Client, logger *zap.SugaredLogger) (Authenticator, error) {
-	// JWT package marshals Audience as array even if there is only one element in it. This does not
-	// seem to be supported by Salesforce. By setting the following option to false we tell the imported
-	// library to marshal single item Audience array as a string.
-	jwt.MarshalSingleStringAsArray = false
-
 	audience := strings.TrimSuffix(server, "/")
 
 	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(certKey))


### PR DESCRIPTION
JWT Audience must be sent as string.

Audience field [interpretation is open to the implementer](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3), and in Salesforce case they require it to be a single string, not an array.

---

Also added a backoff mechanism to avoid flooding the Salesforce API on credential issues.
