### PR TITLE
Sanitize user input in log entries (CWE-117)

### DIFF
--- a/pkg/sources/adapter/awssnssource/handler/handler.go
+++ b/pkg/sources/adapter/awssnssource/handler/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.logger.Debug("Request body: ", string(body))
+		h.logger.Debugw("Received Notification request", zap.String("body", string(body)))
 
 		notif := &notification{}
 		if err := json.Unmarshal(body, notif); err != nil {
@@ -135,7 +135,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.logger.Debug("Request body: ", string(body))
+		h.logger.Debugw("Received SubscriptionConfirmation request", zap.String("body", string(body)))
 
 		subsConfirm := &subscriptionConfirmation{}
 		if err := json.Unmarshal(body, subsConfirm); err != nil {

--- a/pkg/sources/adapter/slacksource/signing.go
+++ b/pkg/sources/adapter/slacksource/signing.go
@@ -49,7 +49,7 @@ var _ timeWrap = (*standardTime)(nil)
 // verifySigning using signature headers and request body hash.
 // see: https://api.slack.com/authentication/verifying-requests-from-slack
 func (h *slackEventAPIHandler) verifySigning(header http.Header, body []byte) error {
-	signature := header.Get(signatureHeader)
+	signature := sanitizeUserInput(header.Get(signatureHeader))
 	if signature == "" {
 		return errors.New("empty signature header")
 	}


### PR DESCRIPTION
CodeQL brought to our attention that user input was being logged without sanitization in a few places, potentially allowing attackers to forge log entries, depending on the encoder ([CWE-117](https://cwe.mitre.org/data/definitions/117.html)).

The following Go playground very simply demonstrates the nature of the attack: https://play.golang.com/p/Fk_GxIM071r

This doesn't seem to be a concern when using `zap`'s structured logging (e.g. with `zap.String()`, `zap.Error()`, etc.), because as far as I can tell, both implementations of `zap`'s [Encoder](https://pkg.go.dev/go.uber.org/zap@v1.19.1/zapcore#Encoder) interface escape newline characters properly.