### PR TITLE
Enable CodeQL build tracing to speed up analysis

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,12 @@ jobs:
   codeql:
     name: Code Analysis
     runs-on: ubuntu-latest
+    env:
+      # Force CodeQL to run the extraction on the files compiled by our custom
+      # build command, as opposed to letting the autobuilder figure it out.
+      # This approach is more efficient because TriggerMesh is composed of
+      # multiple small programs.
+      CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
 
     permissions:
       security-events: write
@@ -36,8 +42,11 @@ jobs:
       with:
         languages: go
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    # The code compiled in this step is also the one being analyzed in the next
+    # step, due to build tracing being enabled via the CODEQL_EXTRACTOR_GO_BUILD_TRACING
+    # environment variable.
+    - name: Build Go code
+      run: go build ./cmd/...
 
     # This step follows the three-step extraction process described at
     # https://lgtm.com/help/lgtm/go-extraction


### PR DESCRIPTION
TriggerMesh is composed of a multitude of small programs. The CodeQL "autobuilder" is rather inefficient for this kind of projects and the analysis currently takes 40 min to complete.

In https://github.com/github/codeql-action/issues/783, a developer recommended that we enable "build tracing", and run a custom build command that builds the entire code base instead of building executables one by one.

I don't have evidence yet that this makes the analysis much faster (edit: my [test run](https://github.com/antoineco/triggermesh/runs/4588041884?check_suite_focus=true), was ~10 min faster), but I'm willing to take their advice if this is the more "correct" approach for our case.

Also relevant:
- https://github.com/github/codeql/pull/5898
- https://github.com/github/codeql/issues/6321