### PR TITLE
Add Support for CORS Headers to the Webhook Source

### DIFF
--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -57,6 +57,9 @@ spec:
                   context in which an event happened. Must be expressed as a URI-reference. Please refer to the
                   CloudEvents specification for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
                 type: string
+              corsOrigin:
+                description: "Value of the CORS 'Access-Control-Allow-Origin' header to set on ingested requests."
+                type: string
               basicAuthUsername:
                 description: User name HTTP clients must set to authenticate with the webhook using HTTP Basic
                   authentication.

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -57,7 +57,7 @@ spec:
                   context in which an event happened. Must be expressed as a URI-reference. Please refer to the
                   CloudEvents specification for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
                 type: string
-              corsOrigin:
+              corsAllowOrigin:
                 description: "Value of the CORS 'Access-Control-Allow-Origin' header to set on ingested requests."
                 type: string
               basicAuthUsername:

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -3637,8 +3637,8 @@ func (in *WebhookSourceSpec) DeepCopyInto(out *WebhookSourceSpec) {
 		*out = new(ValueFromField)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CORSOrigin != nil {
-		in, out := &in.CORSOrigin, &out.CORSOrigin
+	if in.CORSAllowOrigin != nil {
+		in, out := &in.CORSAllowOrigin, &out.CORSAllowOrigin
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -3637,6 +3637,11 @@ func (in *WebhookSourceSpec) DeepCopyInto(out *WebhookSourceSpec) {
 		*out = new(ValueFromField)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CORSOrigin != nil {
+		in, out := &in.CORSOrigin, &out.CORSOrigin
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/sources/v1alpha1/webhooksource_types.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_types.go
@@ -70,7 +70,7 @@ type WebhookSourceSpec struct {
 
 	// Specifies the CORS Origin to use in pre-flight headers.
 	// +optional
-	CORSOrigin *string `json:"corsOrigin,omitempty"`
+	CORSAllowOrigin *string `json:"corsAllowOrigin,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/sources/v1alpha1/webhooksource_types.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_types.go
@@ -67,6 +67,10 @@ type WebhookSourceSpec struct {
 	// Password HTTP clients must set to authenticate with the webhook using HTTP Basic authentication.
 	// +optional
 	BasicAuthPassword *ValueFromField `json:"basicAuthPassword,omitempty"`
+
+	// Specifies the CORS Origin to use in pre-flight headers.
+	// +optional
+	CORSOrigin *string `json:"corsOrigin,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/sources/adapter/webhooksource/adapter.go
+++ b/pkg/sources/adapter/webhooksource/adapter.go
@@ -32,9 +32,10 @@ func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cl
 	return &webhookHandler{
 		eventType:   env.EventType,
 		eventSource: env.EventSource,
+		username:    env.BasicAuthUsername,
+		password:    env.BasicAuthPassword,
+		corsOrigin:  env.CORSOrigin,
 
-		username: env.BasicAuthUsername,
-		password: env.BasicAuthPassword,
 		ceClient: ceClient,
 		logger:   logging.FromContext(ctx),
 	}

--- a/pkg/sources/adapter/webhooksource/adapter.go
+++ b/pkg/sources/adapter/webhooksource/adapter.go
@@ -30,11 +30,11 @@ func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cl
 	env := aEnv.(*envAccessor)
 
 	return &webhookHandler{
-		eventType:   env.EventType,
-		eventSource: env.EventSource,
-		username:    env.BasicAuthUsername,
-		password:    env.BasicAuthPassword,
-		corsOrigin:  env.CORSOrigin,
+		eventType:       env.EventType,
+		eventSource:     env.EventSource,
+		username:        env.BasicAuthUsername,
+		password:        env.BasicAuthPassword,
+		corsAllowOrigin: env.CORSAllowOrigin,
 
 		ceClient: ceClient,
 		logger:   logging.FromContext(ctx),

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -32,5 +32,5 @@ type envAccessor struct {
 	EventSource       string `envconfig:"WEBHOOK_EVENT_SOURCE" required:"true"`
 	BasicAuthUsername string `envconfig:"WEBHOOK_BASICAUTH_USERNAME"`
 	BasicAuthPassword string `envconfig:"WEBHOOK_BASICAUTH_PASSWORD"`
-	CORSOrigin        string `envconfig:"WEBHOOK_CORS_ORIGIN"`
+	CORSAllowOrigin   string `envconfig:"WEBHOOK_CORS_ORIGIN"`
 }

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -32,4 +32,5 @@ type envAccessor struct {
 	EventSource       string `envconfig:"WEBHOOK_EVENT_SOURCE" required:"true"`
 	BasicAuthUsername string `envconfig:"WEBHOOK_BASICAUTH_USERNAME"`
 	BasicAuthPassword string `envconfig:"WEBHOOK_BASICAUTH_PASSWORD"`
+	CORSOrigin        string `envconfig:"HTTPPOLLER_CORS_ORIGIN"`
 }

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -32,5 +32,5 @@ type envAccessor struct {
 	EventSource       string `envconfig:"WEBHOOK_EVENT_SOURCE" required:"true"`
 	BasicAuthUsername string `envconfig:"WEBHOOK_BASICAUTH_USERNAME"`
 	BasicAuthPassword string `envconfig:"WEBHOOK_BASICAUTH_PASSWORD"`
-	CORSOrigin        string `envconfig:"HTTPPOLLER_CORS_ORIGIN"`
+	CORSOrigin        string `envconfig:"WEBHOOK_CORS_ORIGIN"`
 }

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -32,5 +32,5 @@ type envAccessor struct {
 	EventSource       string `envconfig:"WEBHOOK_EVENT_SOURCE" required:"true"`
 	BasicAuthUsername string `envconfig:"WEBHOOK_BASICAUTH_USERNAME"`
 	BasicAuthPassword string `envconfig:"WEBHOOK_BASICAUTH_PASSWORD"`
-	CORSAllowOrigin   string `envconfig:"WEBHOOK_CORS_ORIGIN"`
+	CORSAllowOrigin   string `envconfig:"WEBHOOK_CORS_ALLOW_ORIGIN"`
 }

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -37,13 +37,12 @@ const (
 type webhookHandler struct {
 	eventType   string
 	eventSource string
-
-	username string
-	password string
+	username    string
+	password    string
+	corsOrigin  string
 
 	ceClient cloudevents.Client
-
-	logger *zap.SugaredLogger
+	logger   *zap.SugaredLogger
 }
 
 // Start implements adapter.Adapter.
@@ -98,6 +97,7 @@ func runHandler(ctx context.Context, s *http.Server) error {
 // handleAll receives all webhook events at a single resource, it
 // is up to this function to parse event wrapper and dispatch.
 func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
+	h.enableCors(&w)
 	if r.Body == nil {
 		h.handleError(errors.New("request without body not supported"), http.StatusBadRequest, w)
 		return
@@ -146,4 +146,10 @@ func (h *webhookHandler) handleError(err error, code int, w http.ResponseWriter)
 func healthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *webhookHandler) enableCors(w *http.ResponseWriter) {
+	if h.corsOrigin != "" {
+		(*w).Header().Set("Access-Control-Allow-Origin", h.corsOrigin)
+	}
 }

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -97,7 +97,10 @@ func runHandler(ctx context.Context, s *http.Server) error {
 // handleAll receives all webhook events at a single resource, it
 // is up to this function to parse event wrapper and dispatch.
 func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
-	h.enableCors(&w)
+	if h.corsOrigin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", h.corsOrigin)
+	}
+
 	if r.Body == nil {
 		h.handleError(errors.New("request without body not supported"), http.StatusBadRequest, w)
 		return
@@ -146,10 +149,4 @@ func (h *webhookHandler) handleError(err error, code int, w http.ResponseWriter)
 func healthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-}
-
-func (h *webhookHandler) enableCors(w *http.ResponseWriter) {
-	if h.corsOrigin != "" {
-		(*w).Header().Set("Access-Control-Allow-Origin", h.corsOrigin)
-	}
 }

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -35,11 +35,11 @@ const (
 )
 
 type webhookHandler struct {
-	eventType   string
-	eventSource string
-	username    string
-	password    string
-	corsOrigin  string
+	eventType       string
+	eventSource     string
+	username        string
+	password        string
+	corsAllowOrigin string
 
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
@@ -97,8 +97,8 @@ func runHandler(ctx context.Context, s *http.Server) error {
 // handleAll receives all webhook events at a single resource, it
 // is up to this function to parse event wrapper and dispatch.
 func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
-	if h.corsOrigin != "" {
-		w.Header().Set("Access-Control-Allow-Origin", h.corsOrigin)
+	if h.corsAllowOrigin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", h.corsAllowOrigin)
 	}
 
 	if r.Body == nil {

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -37,7 +37,7 @@ const (
 	envWebhookEventSource       = "WEBHOOK_EVENT_SOURCE"
 	envWebhookBasicAuthUsername = "WEBHOOK_BASICAUTH_USERNAME"
 	envWebhookBasicAuthPassword = "WEBHOOK_BASICAUTH_PASSWORD"
-	envCorsAllowOrigin          = "WEBHOOK_CORS_ORIGIN"
+	envCorsAllowOrigin          = "WEBHOOK_CORS_ALLOW_ORIGIN"
 )
 
 // adapterConfig contains properties used to configure the adapter.

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -37,7 +37,7 @@ const (
 	envWebhookEventSource       = "WEBHOOK_EVENT_SOURCE"
 	envWebhookBasicAuthUsername = "WEBHOOK_BASICAUTH_USERNAME"
 	envWebhookBasicAuthPassword = "WEBHOOK_BASICAUTH_PASSWORD"
-	envCorsOrigin               = "WEBHOOK_CORS_ORIGIN"
+	envCorsAllowOrigin          = "WEBHOOK_CORS_ORIGIN"
 )
 
 // adapterConfig contains properties used to configure the adapter.
@@ -89,9 +89,9 @@ func makeWebhookEnvs(src *v1alpha1.WebhookSource) []corev1.EnvVar {
 		Value: src.AsEventSource(),
 	}}
 
-	if origin := src.Spec.CORSOrigin; origin != nil {
+	if origin := src.Spec.CORSAllowOrigin; origin != nil {
 		envs = append(envs, corev1.EnvVar{
-			Name:  envCorsOrigin,
+			Name:  envCorsAllowOrigin,
 			Value: *origin,
 		})
 	}

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -87,10 +87,14 @@ func makeWebhookEnvs(src *v1alpha1.WebhookSource) []corev1.EnvVar {
 	}, {
 		Name:  envWebhookEventSource,
 		Value: src.AsEventSource(),
-	}, {
-		Name:  envCorsOrigin,
-		Value: *src.Spec.CORSOrigin,
 	}}
+
+	if origin := src.Spec.CORSOrigin; origin != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  envCorsOrigin,
+			Value: *origin,
+		})
+	}
 
 	if user := src.Spec.BasicAuthUsername; user != nil {
 		envs = append(envs, corev1.EnvVar{

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -37,6 +37,7 @@ const (
 	envWebhookEventSource       = "WEBHOOK_EVENT_SOURCE"
 	envWebhookBasicAuthUsername = "WEBHOOK_BASICAUTH_USERNAME"
 	envWebhookBasicAuthPassword = "WEBHOOK_BASICAUTH_PASSWORD"
+	envCorsOrigin               = "WEBHOOK_CORS_ORIGIN"
 )
 
 // adapterConfig contains properties used to configure the adapter.
@@ -86,6 +87,9 @@ func makeWebhookEnvs(src *v1alpha1.WebhookSource) []corev1.EnvVar {
 	}, {
 		Name:  envWebhookEventSource,
 		Value: src.AsEventSource(),
+	}, {
+		Name:  envCorsOrigin,
+		Value: *src.Spec.CORSOrigin,
 	}}
 
 	if user := src.Spec.BasicAuthUsername; user != nil {


### PR DESCRIPTION
This PR attaches a CORS response header to the response of the incoming POST request. 

If the user specifies the `corsOrigin` option in the spec, upon every request we will now attach the following header parameter: 

```
"Access-Control-Allow-Origin" : <spec.corsOrigin>
```


Closes #41 