### PR TITLE
Deploy TriggerMesh in KinD cluster in preparation for automating E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,9 +49,6 @@ jobs:
         # use for a container registry.
         registry: 'false'
 
-    - name: Apply Knative Eventing ClusterRoles for addressable-resolver
-      run: kubectl apply -f https://raw.githubusercontent.com/knative/eventing/knative-v1.1.0/config/core/roles/addressable-resolvers-clusterrole.yaml
-
     - name: Install ko
       run: go install github.com/google/ko@v0.9.3
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,69 @@
+name: End-to-End Testing
+
+on:
+  push:
+    # NOTE(antoineco): To avoid exposing repository secrets to user supplied
+    # code in pull requests, we only allow this workflow to run on the 'main'
+    # branch, where all code changes are expected to have been reviewed by
+    # maintainers.
+    #
+    # We may want to relax this in the future, on condition that safeguards are
+    # added to prevent the workflow from running automatically when an external
+    # contributor submits code changes inside the .github/workflows/ or
+    # test/e2e/ directories.
+    #
+    # Ref. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    branches: [ main ]
+
+jobs:
+
+  e2e-triggermesh:
+    name: Test TriggerMesh components
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Go caches
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-go-
+
+    - name: KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        knative_serving: v1.0.0
+        knative_kourier: v1.0.0
+        # ko loads images directly into KinD's container runtime when
+        # KO_DOCKER_REPO is set to the rogue value "kind.local", so we have no
+        # use for a container registry.
+        registry: 'false'
+
+    - name: Apply Knative Eventing ClusterRoles for addressable-resolver
+      run: kubectl apply -f https://raw.githubusercontent.com/knative/eventing/knative-v1.1.0/config/core/roles/addressable-resolvers-clusterrole.yaml
+
+    - name: Install ko
+      run: go install github.com/google/ko@v0.9.3
+
+    - name: Deploy TriggerMesh
+      env:
+        KO_DOCKER_REPO: kind.local
+      run: |
+        ko apply -f ./config/namespace/
+        ko apply -f ./config/
+        kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-controller
+        kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-webhook
+
+    - name: Run e2e tests
+      run: |
+        true

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -748,8 +748,30 @@ rules:
 
 ---
 
+# This aggregated role grants read-only access to Addressables.
+# It is intended mainly to allow sink resolvers to resolve URLs from object references.
+#
+# NOTE: This same role can also be found in Knative Eventing. It is duplicated here to allow running TriggerMesh in a
+# cluster which doesn't have Knative Eventing deployed.
+# Source:
+#   https://github.com/knative/eventing/blob/knative-v1.1.0/config/core/roles/addressable-resolvers-clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: addressable-resolver
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/addressable: 'true'
+rules: []  # Rules are automatically filled in by the Kubernetes controller manager.
+
+---
+
 # This role provides readonly access to "Addressable" duck types.
-# All the rules it contains get aggregated into the "addressable-resolver" ClusterRole provided by Knative Eventing.
+# All the rules it contains get aggregated into the "addressable-resolver" ClusterRole.
 # https://github.com/knative/eventing/blob/release-0.26/config/core/roles/addressable-resolvers-clusterrole.yaml#L15-L28
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -823,6 +845,24 @@ rules:
   resources:
   - filters
   - splitters
+  verbs:
+  - get
+  - list
+  - watch
+# Allow resolving URLs of a few additional common types which are not supplied by TriggerMesh.
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - services
   verbs:
   - get
   - list


### PR DESCRIPTION
Part of #339

In preparation for running e2e tests as part of the standard CI checks, add a GitHub Actions workflow that provisions a local KinD cluster and deploys TriggerMesh in it using `ko`.

I decided to run this workflow on a GitHub Actions runner instead of CircleCI for the time being because [this action](https://github.com/marketplace/actions/kubernetes-kind-cluster) from the GitHub marketplace allows us to provision a KinD cluster **with Knative pre-installed**, which simplifies the setup a lot.

In case we decide to use runners with more resources in the future, we can always switch to CircleCI by creating our own [CircleCI Orb](https://circleci.com/docs/2.0/creating-orbs/) for KinD + Knative. I'm not too worried about resources for the time being though, because even on modest GitHub Actions runners it takes "only" 6 min to `ko apply` TriggerMesh with a warm Go build cache (versus 14 min with a cold cache):

![image](https://user-images.githubusercontent.com/3299086/147358807-8b2d0574-4961-4dac-801b-d80f8fd8324b.png)