### PR TITLE
Migrate E2E tests for AWS SQS from test-infra

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -61,6 +61,15 @@ jobs:
         kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-controller
         kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-webhook
 
+    - name: Install Ginkgo
+      run: go install github.com/onsi/ginkgo/ginkgo
+
+    - name: Export KUBECONFIG path
+      run: echo "KUBECONFIG=${HOME}/.kube/config" >> $GITHUB_ENV
+
     - name: Run e2e tests
-      run: |
-        true
+      env:
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: ginkgo -nodes=4 -slowSpecThreshold=60 -randomizeAllSpecs ./test/e2e/

--- a/LICENSES/vendor/github.com/fsnotify/fsnotify/LICENSE
+++ b/LICENSES/vendor/github.com/fsnotify/fsnotify/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/vendor/github.com/nxadm/tail/LICENSE
+++ b/LICENSES/vendor/github.com/nxadm/tail/LICENSE
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+# © Copyright 2015 Hewlett Packard Enterprise Development LP
+Copyright (c) 2014 ActiveState
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/vendor/github.com/nxadm/tail/ratelimiter/Licence
+++ b/LICENSES/vendor/github.com/nxadm/tail/ratelimiter/Licence
@@ -1,0 +1,7 @@
+Copyright (C) 2013 99designs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/vendor/github.com/onsi/ginkgo/LICENSE
+++ b/LICENSES/vendor/github.com/onsi/ginkgo/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
+++ b/LICENSES/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/vendor/github.com/onsi/gomega/LICENSE
+++ b/LICENSES/vendor/github.com/onsi/gomega/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/vendor/gopkg.in/tomb.v1/LICENSE
+++ b/LICENSES/vendor/gopkg.in/tomb.v1/LICENSE
@@ -1,0 +1,29 @@
+tomb - support for clean goroutine termination in Go.
+
+Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,8 @@ require (
 	github.com/kevinburke/twilio-go v0.0.0-20200203063821-378e630e02da
 	github.com/logzio/logzio-go v0.0.0-20200316143903-ac8fc0e2910e
 	github.com/nukosuke/go-zendesk v0.10.1
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.10.4
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible
 	github.com/robertkrimen/otto v0.0.0-20211019175142-5b0d97091c6f
 	github.com/sendgrid/sendgrid-go v3.10.4+incompatible
@@ -112,6 +114,7 @@ require (
 	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.5.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-gonic/gin v1.7.4 // indirect
 	github.com/go-kit/log v0.1.0 // indirect
@@ -123,6 +126,7 @@ require (
 	github.com/go-openapi/spec v0.20.2 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gobuffalo/flect v0.2.3 // indirect
 	github.com/gofrs/uuid v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -158,6 +162,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/openzipkin/zipkin-go v0.2.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -200,6 +205,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.21.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,8 @@ github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7a
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.3 h1:f/ZukRnSNA/DUpSNDadko7Qc0PhGvsew35p/2tu+CRY=
 github.com/gobuffalo/flect v0.2.3/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
@@ -907,8 +909,9 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nukosuke/go-zendesk v0.10.1 h1:yr5AJh3eqKq4M1r7LJK+OZvZUtsdX4m8o5S5iV3wRvY=
 github.com/nukosuke/go-zendesk v0.10.1/go.mod h1:FMC25ZV0/fo2kP9c0jleOmSoKsKmTdnycPkyQCkiykI=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -920,8 +923,9 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1472,6 +1476,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1584,6 +1589,7 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,376 @@
+# End-to-end test suite
+
+This is the entry point of the TriggerMesh E2E test suite.
+
+## Contents
+
+1. [Overview](#overview)
+1. [Running tests](#running-tests)
+   * [Execution](#execution)
+   * [Inputs](#inputs)
+   * [Troubleshooting](#troubleshooting)
+1. [Package organization](#package-organization)
+1. [Writing tests](#writing-tests)
+   * [Structure](#structure)
+   * [Best practices](#best-practices)
+
+## Overview
+
+This package contains a single Go test called `TestE2e` which runs all the test specs contained in its sub-packages.
+
+Each test is written using the [Ginkgo][ginkgo-docs] testing framework using Behavior-Driven Development style ("BDD").
+
+The [`framework.Famework`](./framework/) abstraction, heavily inspired by [Kubernetes' E2E tests][k8s-e2e], offers a
+convenient way for each test spec to run against its own short-lived Kubernetes namespace, with common setup and cleanup
+tasks executed automatically before and after each of these specs.
+
+## Running tests
+
+### Execution
+
+| :warning: Do not ever interrupt running tests with `Ctrl-C`. When interrupted, Ginkgo only triggers the global `AfterSuite` logic and skips all the individual `AfterEach` blocks declared in running tests. This can leave dangling resources behind that are tedious to clean up manually and can become costly if not terminated quickly. Ref. [onsi/ginkgo#222][ginkgo-issue222].
+| :--- |
+
+While it is possible to run tests using `go test` like standard unit tests, it is recommended to use the `ginkgo` CLI
+tool for running Ginkgo test suites, which offers better control over Gingko-specific parameters, such as the
+parallelism of test specs, the format and verbosity of the reporter's output, etc.
+
+```sh
+# Using the Ginkgo version pinned inside `go.mod`
+go run github.com/onsi/ginkgo/ginkgo
+
+# Or using an executable installed via `go get`
+ginkgo
+```
+
+### Inputs
+
+All tests require a `kubeconfig` file containing credentials of a user or service account with elevated permissions to
+interact with a Kubernetes cluster, unless tests run in a Kubernetes pod, in which case the pod's service account is
+used as a fallback. The path to this file can be set using the `-e2e.kubeconfig` flag, which defaults to the value of
+the `KUBECONFIG` environment variable.
+
+Some tests require more specific input, such as access tokens to interact with third-party APIs (AWS, GitHub, etc.). The
+input method for those tests varies depending on the client that is used. For example, the Go client for AWS reads
+security credentials from the environment and falls back to the standard location of a local file containing shared
+credentials ([ref.][aws-go-session]), while the GitHub client expects an OAuth2 access token to be exported in the
+environment ([ref.][gh-client]). Please refer to documentation of each test for a description of the required inputs.
+Below is an example of such documentation:
+
+```go
+/* This test suite requires:
+
+   - AWS credentials in whichever form (https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Sessions_options_from_Shared_Config)
+   - The name of an AWS region exported in the environment as AWS_REGION
+*/
+```
+
+### Troubleshooting
+
+Kubernetes namespaces created in the context of E2E tests are labeled with `e2e-framework`, and can therefore be listed
+with the following command while tests are being executed:
+
+```sh
+kubectl get namespaces -l e2e-framework
+```
+
+Please beware that all namespaces are ephemeral by default, and likely to be terminated quickly after the execution of a
+given test.
+
+## Package organization
+
+Each subdirectory of the `test/e2e` package contains a series of tests organized by category (e.g. _Sources_, _Targets_,
+...), with the exception of the `framework` package which contains the test framework itself, along with all the test
+helpers imported by actual tests.
+
+```
+test/e2e
+├── sources
+│   ├── somesource
+│   ├── othersource
+│   └── ...
+├── targets
+│   ├── sometarget
+│   ├── othertarget
+│   └── ...
+└── framework
+    ├── aws
+    ├── ducktypes
+    └── ...
+```
+
+We favour creating sub-packages within those top-level category packages whenever a given test may have helper functions
+which natural name could conflict with other tests. For instance, tests for an event source _"foo"_ may declare a
+`createSource` helper which name potentially conflicts with a similar helper declared in the tests for an event source
+_"bar"_. Requiring the developer to avoid that situation by creating each helper function with a differentiator in the
+name, such as `createFooSource` or `createBarSource`, would be verbose and counter-productive.
+
+Whenever multiple tests could benefit from shared helpers and those can be written generically, it is recommended to
+move those helpers to a suitable sub-package of `framework`.
+
+## Writing tests
+
+### Structure
+
+The Ginkgo documentation contains good examples for [Structuring Your Specs][ginkgo-struct] in an expressive manner.
+
+Ginkgo spec blocks can be nested in many different ways and developers are free to organize them however they please.
+One golden rule is that **the hierarchy of spec blocks should read as naturally as possible**.
+
+Here are a few tips that can help achieve the above goal:
+
+* The name of `Describe` blocks should be brief and describe _what_ is being tested.
+
+    ```go
+    Describe("Amazon S3 event target", func() {
+        Describe("status conditions", func() {
+        })
+    })
+    ```
+
+* `Context` and `When` blocks describe under what circumstances the _what_ is being tested, and are generally nested
+  under `Describe` blocks.
+
+    ```go
+    Describe("Integration bridge", func() {
+        When("all components becomes ready", func() {
+        })
+
+        Context("an event is sent to the broker", func() {
+        })
+    })
+    ```
+
+    Those blocks _should not_ contain any code besides variable declarations, if relevant to the context.
+
+* `It` blocks contain the actual assertions.
+
+    ```go
+    Describe("Slack source", func() {
+        When("someone writes in the #music channel", func() {
+            It("should play a loud sound", func() {
+                Expect(volume).To(BeLoud())
+            })
+
+            It("should notify Pablo", func() {
+                msg := slackBotMessagesToUser("pablo")
+                Expect(msg).To(Contain("some cool jam for you"))
+            })
+
+            It("should report a copyright infringement", func() {
+            })
+        })
+    })
+    ```
+
+    Those blocks can be located within any of the blocks described above, including directly under a `Describe` when the
+    description of the `It` block contains enough context on its own.
+
+    ```go
+    Describe("GitHub source webhook", func() {
+        It(`should set "main" as the default branch`, func() {
+        })
+    })
+    ```
+
+* `By` blocks are purely cosmetic but help splitting some complex logic into multiple, easy to identify steps. This is
+  particularly useful in `BeforeEach` blocks.
+
+    ```go
+    BeforeEach(func() {
+        By("creating a client", func() {
+            client = NewClient()
+        })
+
+        By("initializing something", func() {
+            client.DoSomething()
+        })
+    })
+    ```
+
+* While it is possible to create multiple levels of nesting of `Describe`, `Context` and `When` blocks with no technical
+  restriction, the aim should be to keep all assertions within at most **3** levels of nesting for optimal readability.
+
+### Best practices
+
+The best practices outlined in the [Writing good e2e tests for Kubernetes][sigtesting-howto] document apply to our own
+tests.
+
+A few more recommendations and pitfalls that can be easily avoided are described below.
+
+#### Scoped variables
+
+One of the most important concepts of Ginkgo tests is the scoping of variables.
+
+All variables declared within a `Describe`, `Context` or `When` block are cloned during the execution of an `It` block,
+meaning that the value of a closure variable set in a given `It` will not affect the state of another `It`, regardless
+of the order in which those blocks execute, or whether they execute in parallel.
+
+```go
+Describe("Variable scope", func() {
+    var text string
+
+    When(`two "It" modify the "text" closure variable`, func() {
+        It("writes some value", func() {
+            text = "foo"
+        })
+
+        It("writes another value", func() {
+            text = "bar"
+        })
+
+        It("reads the value", func() {
+            framework.Logf(text) // always prints ""
+        })
+    })
+})
+```
+
+This is particularly useful to share state between `BeforeEach` and `It` blocks. Typically, `BeforeEach` blocks
+initialize the value of closure variables, while `It` blocks are responsible for performing assertions on/using those
+initialized variables.
+
+```go
+Describe("Variable scope", func() {
+    var jsonInput string
+
+    When("input is invalid", func() {
+        BeforeEach(func() {
+            jsonInput = "oops this is invalid"
+        })
+
+        It("fails to parse", func() {
+            err := json.Parse(jsonInput)
+            Expect(err).To(HaveOccured())
+        })
+    })
+
+    When("input is valid", func() {
+        BeforeEach(func() {
+            jsonInput = `{"valid": true}`
+        })
+
+        It("parses successfully", func() {
+            err := json.Parse(jsonInput)
+            Expect(err).ToNot(HaveOccured())
+        })
+    })
+})
+```
+
+Closure variables are typically defined at the top of the most relevant `Describe`, `Context` or `When` block.
+
+#### Scoped setup with `BeforeEach`
+
+The logic contained in a `BeforeEach` block is executed **once per `It` block** contained within the same `Describe`,
+`Context` or `When` block, including at lower levels of `Describe`, `Context` and `When`.
+
+This can influence the way tests are structured. For instance, if tests within a given `Context` block require the
+initialization of a dependency while other tests within a different `Context` do not require that dependency, it is wise
+to avoid placing initialization steps (and variables) specific to the former directly under the global `Describe`.
+
+```go
+Describe("Greeting", func() {
+    // available to the current "Describe" and *all* its sub-blocks
+    var name string
+
+    // executed in "It"s of the current "Describe" and *all** its sub-blocks
+    BeforeEach(func() {
+        name = os.User()
+    })
+
+    When("no weather forecast is available", func() {
+        It("greets without the weather", func() {
+            Expect(Greet(nil)).To(Equal("Hello " + name))
+        })
+    })
+
+    When("a weather forecast is available", func() {
+        // available only to the current "When" and its sub-blocks
+        var forecast *weather.Forecast
+
+        // executed only in "It"s of the current "When" and its sub-blocks
+        BeforeEach(func() {
+            forecast = weather.GetWeather
+        })
+
+        It("greets with the weather", func() {
+            Expect(Greet(forecast)).To(Equal(
+                fmt.Sprintf("Hello %s, the weather will be %s today", name, forecast)
+            ))
+        })
+    })
+})
+```
+
+Similarly to closure variables, `BeforeEach` blocks are typically defined at the top of the most relevant `Describe`,
+`Context` or `When` block.
+
+**:information_source: In the context of our framework, a new instance of `framework.Framework`, and therefore a new
+Kubernetes namespace, is created for each `It` block.** Consider this when writing tests that create API objects which
+take a long time to set up. Here is an [example test][optimized-test] optimized to run each of its specs in the same
+namespace.
+
+#### Fail within helpers
+
+Keeping the number of lines of code to a minimum within the main test body helps focusing on the actual logic. Resorting
+to helper functions is a great way to achieve this, and handling errors directly within those helpers is equally
+important.
+
+Generally speaking, if a function returns an error along with other values and we don't expect an error to occur within
+tests, that function can be wrapped inside a helper which only returns the values that are meant to be used in tests.
+Instead of leaving the error handling to `It` or `BeforeEach` blocks, the helper can call `framework.Failf` whenever an
+error occurs and immediately fail the current test.
+
+```go
+// okay-ish
+
+var _ = Describe("Error handling", func() {
+    It("does something and checks the output", func() {
+        something, err := mypkg.GetSomething()
+        Expect(err).ToNot(HaveOccured())
+
+        output, err := mypkg.HandleSomething(something)
+        Expect(err).ToNot(HaveOccured())
+        Expect(output).ToNot(BeNil())
+    })
+})
+```
+
+```go
+// better
+
+var _ = Describe("Error handling", func() {
+    It("does something and checks the output", func() {
+        Expect(doSomething()).ToNot(BeNil())
+    })
+})
+
+func doSomething() *mypkg.Output {
+    something, err := mypkg.GetSomething()
+    if err != nil {
+        framework.Failf("Failed to get something: %s", err)
+    }
+
+    output, err := mypkg.HandleSomething(something)
+    if err != nil {
+        framework.Failf("Failed to handle something: %s", err)
+    }
+
+    return output
+}
+```
+
+The benefits of this approach become more obvious when the complexity of test scenarios grows beyond the example above.
+
+
+[ginkgo-docs]: https://onsi.github.io/ginkgo/
+[ginkgo-issue222]: https://github.com/onsi/ginkgo/issues/222
+[ginkgo-struct]: https://onsi.github.io/ginkgo/#structuring-your-specs
+[optimized-test]: https://github.com/triggermesh/test-infra/blob/956c8ce257/test/e2e/sources/awscodecommit/main.go#L172-L188
+
+[k8s-e2e]: https://godoc.org/k8s.io/kubernetes/test/e2e
+[sigtesting-howto]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md
+
+[aws-go-session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+[gh-client]: https://github.com/triggermesh/test-infra/blob/9f19ed28a9/test/e2e/framework/github/github.go#L39-L53

--- a/test/e2e/aws_iam_policy.jsonc
+++ b/test/e2e/aws_iam_policy.jsonc
@@ -1,0 +1,39 @@
+/* AWS IAM policy for e2e tests.
+
+   Policy ARN:  arn:aws:iam::043455440429:policy/EndToEndTestSuite
+   Description: Set of permissions required by the TriggerMesh end-to-end test suite to run tests that manipulate AWS resources.
+*/
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "E2EFrameworkSQS",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:SendMessage",
+                "sqs:ReceiveMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:CreateQueue",
+                "sqs:DeleteQueue",
+                "sqs:SetQueueAttributes",
+                "sqs:TagQueue"
+            ],
+            "Resource": [
+                "arn:aws:sqs:*:043455440429:e2e-*"
+            ]
+        },
+        {
+            "Sid": "AWSSQSSourceReceiveAdapter",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+                "sqs:DeleteMessageBatch"
+            ],
+            "Resource": [
+                "arn:aws:sqs:*:043455440429:e2e-*"
+            ]
+        }
+    ]
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+package e2e
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
+	"testing"
+
+	. "github.com/onsi/ginkgo" //nolint:stylecheck
+	. "github.com/onsi/gomega" //nolint:stylecheck
+
+	// support client-go's auth providers
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	_ "github.com/triggermesh/triggermesh/test/e2e/framework"
+
+	// test suites
+	_ "github.com/triggermesh/triggermesh/test/e2e/sources"
 )
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}

--- a/test/e2e/framework/apps/deployments.go
+++ b/test/e2e/framework/apps/deployments.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"knative.dev/eventing/pkg/apis/duck"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+)
+
+// CreateSimpleApplication is a helper which creates a simple Deployment
+// exposed by a matching Service. `internalPort` is the TCP port number of the
+// container managed by the Deployment. `exposedPort` is the TCP port number
+// exposed by the Service.
+func CreateSimpleApplication(c clientset.Interface, namespace string,
+	name, image string, internalPort, exposedPort uint16,
+	deplOpts ...DeploymentOption) (*appsv1.Deployment, *corev1.Service) {
+
+	svc := newSimpleService(namespace, name, exposedPort, internalPort)
+
+	svc, err := c.CoreV1().Services(namespace).Create(context.Background(), svc, metav1.CreateOptions{})
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to create Service: %s", err)
+	}
+
+	depl := newSimpleDeployment(namespace, name, image, internalPort)
+
+	for _, o := range deplOpts {
+		o(depl)
+	}
+
+	depl, err = c.AppsV1().Deployments(namespace).Create(context.Background(), depl, metav1.CreateOptions{})
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to create Deployment: %s", err)
+	}
+
+	WaitUntilAvailable(c, depl)
+
+	return depl, svc
+}
+
+// DeploymentOption is a functional option for building a Deployment object.
+type DeploymentOption func(*appsv1.Deployment)
+
+// WithStartupProbe sets the HTTP startup probe of a Deployment's first
+// container, targetting this container's first TCP port.
+func WithStartupProbe(path string) DeploymentOption {
+	return func(d *appsv1.Deployment) {
+		sp := &d.Spec.Template.Spec.Containers[0].StartupProbe
+
+		port := int(d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+
+		*sp = &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: path,
+					Port: intstr.FromInt(port),
+				},
+			},
+			PeriodSeconds: 1,
+		}
+	}
+}
+
+// WaitUntilAvailable waits until the given Deployment becomes available.
+func WaitUntilAvailable(c clientset.Interface, d *appsv1.Deployment) {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", d.Name).String()
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return c.AppsV1().Deployments(d.Namespace).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return c.AppsV1().Deployments(d.Namespace).Watch(context.Background(), options)
+		},
+	}
+
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+
+	// checks whether the Deployment referenced in the given watch.Event is available.
+	var isDeploymentAvailable watchtools.ConditionFunc = func(e watch.Event) (bool, error) {
+		if e.Type == watch.Deleted {
+			return false, apierrors.NewNotFound(gr, d.Name)
+		}
+
+		if d, ok := e.Object.(*appsv1.Deployment); ok {
+			return duck.DeploymentIsAvailable(&d.Status, false), nil
+		}
+
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	_, err := watchtools.UntilWithSync(ctx, lw, &appsv1.Deployment{}, nil, isDeploymentAvailable)
+	if err != nil {
+		framework.FailfWithOffset(2, "Error waiting for %s %q to become available: %s", gr, d.Name, err)
+	}
+}
+
+// newSimpleDeployment returns a Deployment object with a single container and
+// default settings.
+func newSimpleDeployment(namespace, name, image string, containerPort uint16) *appsv1.Deployment {
+	const containerName = "app"
+
+	lbls := labels.Set{
+		labelAppName:   name,
+		labelManagedBy: labelManagedByVal,
+	}
+
+	metadata := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		Labels:    lbls,
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metadata,
+		Spec: appsv1.DeploymentSpec{
+			Selector: metav1.SetAsLabelSelector(lbls),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: lbls,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  containerName,
+						Image: image,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: int32(containerPort),
+						}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// newSimpleService returns a Service object with default settings.
+func newSimpleService(namespace, name string, port, targetPort uint16) *corev1.Service {
+	lbls := labels.Set{
+		labelAppName:   name,
+		labelManagedBy: labelManagedByVal,
+	}
+
+	metadata := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		Labels:    lbls,
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metadata,
+		Spec: corev1.ServiceSpec{
+			Selector: lbls,
+			Ports: []corev1.ServicePort{{
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(int(targetPort)),
+			}},
+		},
+	}
+}

--- a/test/e2e/framework/apps/doc.go
+++ b/test/e2e/framework/apps/doc.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+// Package apps contains helpers to interact with various Kubernetes workloads.
+package apps
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
+const (
+	labelAppName   = "app.kubernetes.io/name"
+	labelManagedBy = "app.kubernetes.io/managed-by"
+
+	labelManagedByVal = "e2e-test-suite"
 )

--- a/test/e2e/framework/apps/logs.go
+++ b/test/e2e/framework/apps/logs.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+)
+
+// GetLogs returns a stream of the logs of the first container in one of the
+// randomly-chosen Pods managed by the Deployment with the given name. Meant to
+// be used with Deployments that have a single replica and a single container.
+func GetLogs(c clientset.Interface, namespace, deploymentName string) io.ReadCloser {
+	depl, err := c.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to get Deployment: %s", err)
+	}
+
+	deplPods := podsForSelector(c, namespace, depl.Spec.Selector)
+	if len(deplPods) == 0 {
+		return nil
+	}
+
+	pod := deplPods[0]
+
+	logStream, err := c.CoreV1().Pods(namespace).
+		GetLogs(pod.Name, &corev1.PodLogOptions{Container: pod.Spec.Containers[0].Name}).Stream(context.Background())
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to stream logs of Pod %s: %s", pod.Name, err)
+	}
+
+	return logStream
+}
+
+// podsForSelector returns the list of all Pods that match the given LabelSelector.
+func podsForSelector(c clientset.Interface, namespace string, s *metav1.LabelSelector) []corev1.Pod {
+	selectorStr := metav1.FormatLabelSelector(s)
+
+	pods, err := c.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: selectorStr})
+	if err != nil {
+		framework.FailfWithOffset(3, "Failed to list Pods for selector %q: %s", selectorStr, err)
+	}
+
+	return pods.Items
+}

--- a/test/e2e/framework/aws/aws.go
+++ b/test/e2e/framework/aws/aws.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aws contains helpers to interact with AWS services.
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+)
+
+const e2eInstanceTagKey = "e2e_instance"
+
+// ParseARN parses an ARN string into an arn.ARN.
+func ParseARN(arnStr string) arn.ARN {
+	arn, err := arn.Parse(arnStr)
+	if err != nil {
+		framework.FailfWithOffset(2, "Error parsing ARN string %q: %s", arnStr, err)
+	}
+
+	return arn
+}
+
+// TagsFor returns a set of resource tags matching the given framework.Framework.
+func TagsFor(f *framework.Framework) map[string]*string {
+	return aws.StringMap(map[string]string{
+		e2eInstanceTagKey: f.UniqueName,
+	})
+}

--- a/test/e2e/framework/aws/iam/iam.go
+++ b/test/e2e/framework/aws/iam/iam.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package iam contains helpers to interact with IAM objects.
+package iam
+
+import "github.com/google/uuid"
+
+const latestPolicyLanguageVersion = "2012-10-17"
+
+// Policy mirrors the structure of an IAM Policy for easy marshaling and
+// unmarshaling to/from JSON.
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policies-json
+type Policy struct {
+	Version   string            `json:"Version"`
+	Id        string            `json:"Id,omitempty"` //nolint:stylecheck
+	Statement []PolicyStatement `json:"Statement,omitempty"`
+}
+
+// PolicyStatement is a Statement element in a Policy.
+type PolicyStatement struct {
+	Sid       string                   `json:"Sid,omitempty"`
+	Effect    PolicyStatementEffect    `json:"Effect"`
+	Principal PolicyStatementPrincipal `json:"Principal,omitempty"`
+	Action    []string                 `json:"Action"`
+	Resource  []string                 `json:"Resource"`
+	Condition PolicyStatementCondition `json:"Condition,omitempty"`
+}
+
+// PolicyStatementEffect represents the Effect element of a Statement.
+type PolicyStatementEffect string
+
+const (
+	EffectAllow PolicyStatementEffect = "Allow"
+)
+
+// PolicyStatementPrincipal is the Principal element of a Statement.
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+type PolicyStatementPrincipal struct {
+	Service *[]string `json:"Service"`
+}
+
+// PolicyStatementCondition is the Condition element of a Statement.
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html
+type PolicyStatementCondition struct {
+	ArnEquals *map[string]string `json:"ArnEquals,omitempty"`
+}
+
+// NewPolicy returns a new Policy with the given Statements applied to it.
+func NewPolicy(stmts ...PolicyStatement) Policy {
+	return Policy{
+		Version:   latestPolicyLanguageVersion,
+		Id:        uuid.New().String(),
+		Statement: stmts,
+	}
+}
+
+// NewPolicyStatement returns a new PolicyStatement with the given options
+// applied to it.
+func NewPolicyStatement(effect PolicyStatementEffect, opts ...PolicyStatementOpt) PolicyStatement {
+	p := PolicyStatement{
+		Sid:    uuid.New().String(),
+		Effect: effect,
+	}
+
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	return p
+}
+
+// PolicyStatementOpt is a functional option for a PolicyStatement.
+type PolicyStatementOpt func(*PolicyStatement)
+
+// PrincipalService adds a "Service" to the Principal.
+func PrincipalService(service string) PolicyStatementOpt {
+	return func(s *PolicyStatement) {
+		ps := &s.Principal.Service
+		if *ps == nil {
+			valPs := make([]string, 0, 1)
+			*ps = &valPs
+		}
+		**ps = append(**ps, service)
+	}
+}
+
+// Action adds an Action.
+func Action(action string) PolicyStatementOpt {
+	return func(s *PolicyStatement) {
+		a := &s.Action
+		if *a == nil {
+			*a = make([]string, 0, 1)
+		}
+		*a = append(*a, action)
+	}
+}
+
+// Resource adds a Resource.
+func Resource(resource string) PolicyStatementOpt {
+	return func(s *PolicyStatement) {
+		r := &s.Resource
+		if *r == nil {
+			*r = make([]string, 0, 1)
+		}
+		*r = append(*r, resource)
+	}
+}
+
+// ConditionArnEquals sets a Condition of type "ArnEquals".
+func ConditionArnEquals(key, val string) PolicyStatementOpt {
+	return func(s *PolicyStatement) {
+		aec := &s.Condition.ArnEquals
+		if *aec == nil {
+			valAec := make(map[string]string, 1)
+			*aec = &valAec
+		}
+		(**aec)[key] = val
+	}
+}

--- a/test/e2e/framework/aws/sqs/sqs.go
+++ b/test/e2e/framework/aws/sqs/sqs.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sqs contains helpers for AWS SQS.
+package sqs
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+	e2eaws "github.com/triggermesh/triggermesh/test/e2e/framework/aws"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/aws/iam"
+)
+
+// CreateQueue creates a queue named after the given framework.Framework.
+func CreateQueue(sqsClient sqsiface.SQSAPI, f *framework.Framework) string /*url*/ {
+	queue := &sqs.CreateQueueInput{
+		QueueName: &f.UniqueName,
+		Tags:      e2eaws.TagsFor(f),
+	}
+
+	resp, err := sqsClient.CreateQueue(queue)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to create queue %q: %s", *queue.QueueName, err)
+	}
+
+	return *resp.QueueUrl
+}
+
+// SetQueuePolicy sets the Policy attribute of the queue with the given URL.
+func SetQueuePolicy(sqsClient sqsiface.SQSAPI, url string, pol iam.Policy) {
+	polJSON, err := json.Marshal(pol)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to serialize queue policy: %s", err)
+	}
+
+	attrs := &sqs.SetQueueAttributesInput{
+		QueueUrl: &url,
+		Attributes: aws.StringMap(map[string]string{
+			sqs.QueueAttributeNamePolicy: string(polJSON),
+		}),
+	}
+
+	if _, err := sqsClient.SetQueueAttributes(attrs); err != nil {
+		framework.FailfWithOffset(2, "Failed to set attributes of queue %q: %s", *attrs.QueueUrl, err)
+	}
+}
+
+// DeleteQueue deletes the queue with the given URL.
+func DeleteQueue(sqsClient sqsiface.SQSAPI, url string) {
+	queue := &sqs.DeleteQueueInput{
+		QueueUrl: &url,
+	}
+
+	if _, err := sqsClient.DeleteQueue(queue); err != nil {
+		framework.FailfWithOffset(2, "Failed to delete queue %q: %s", *queue.QueueUrl, err)
+	}
+}
+
+// QueueARN returns the ARN of the queue with the given URL.
+func QueueARN(sqsClient sqsiface.SQSAPI, url string) string /*arn*/ {
+	attribs := &sqs.GetQueueAttributesInput{
+		QueueUrl: &url,
+		AttributeNames: aws.StringSlice([]string{
+			sqs.QueueAttributeNameQueueArn,
+		}),
+	}
+
+	resp, err := sqsClient.GetQueueAttributes(attribs)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to get attributes of queue %q: %s", *attribs.QueueUrl, err)
+	}
+
+	return *resp.Attributes[sqs.QueueAttributeNameQueueArn]
+}
+
+// SendMessage sends a message to the queue with the given URL.
+func SendMessage(sqsClient sqsiface.SQSAPI, url string) string /*msgId*/ {
+	msg := "hello, world!"
+
+	params := &sqs.SendMessageInput{
+		QueueUrl:    &url,
+		MessageBody: &msg,
+	}
+
+	msgOutput, err := sqsClient.SendMessage(params)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to send message to queue %q: %s", *params.QueueUrl, err)
+	}
+	return *msgOutput.MessageId
+}
+
+// ReceiveMessages retrieves messages from the queue with the given URL.
+func ReceiveMessages(sqsClient sqsiface.SQSAPI, url string) []*sqs.Message {
+	const maxRcvMsg int64 = 10
+	const maxLongPollingWaitTimeSeconds int64 = 20
+
+	params := &sqs.ReceiveMessageInput{
+		QueueUrl:            &url,
+		MaxNumberOfMessages: aws.Int64(maxRcvMsg),
+		WaitTimeSeconds:     aws.Int64(maxLongPollingWaitTimeSeconds),
+		MessageAttributeNames: aws.StringSlice([]string{
+			sqs.QueueAttributeNameAll,
+		}),
+	}
+
+	msgs, err := sqsClient.ReceiveMessage(params)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to receive message from queue %q: %s", *params.QueueUrl, err)
+	}
+
+	return msgs.Messages
+}

--- a/test/e2e/framework/bridges/doc.go
+++ b/test/e2e/framework/bridges/doc.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
-
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
-)
+// Package bridges contains helpers to interact with Bridge objects.
+package bridges

--- a/test/e2e/framework/bridges/sink.go
+++ b/test/e2e/framework/bridges/sink.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bridges
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/event/datacodec"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving"
+	revisionnames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/apps"
+)
+
+const (
+	eventDisplayName = "event-display"
+	// using a nightly image because versions prior to v0.25 (unreleased) don't expose "/healthz"
+	eventDisplayContainerImage = "gcr.io/knative-nightly/knative.dev/eventing/cmd/event_display@sha256:e1a70eabf59345a4b160f007cbfd121ef2aca6e0921fa81c79495c236a9f2d7b"
+)
+
+// CreateEventDisplaySink creates an event-display event sink and returns it as
+// a duckv1.Destination.
+func CreateEventDisplaySink(c clientset.Interface, namespace string) *duckv1.Destination {
+	const internalPort uint16 = 8080
+	const exposedPort uint16 = 80
+
+	_, svc := apps.CreateSimpleApplication(c, namespace,
+		eventDisplayName, eventDisplayContainerImage, internalPort, exposedPort,
+		apps.WithStartupProbe("/healthz"),
+	)
+
+	svcGVK := corev1.SchemeGroupVersion.WithKind("Service")
+
+	return &duckv1.Destination{
+		Ref: &duckv1.KReference{
+			APIVersion: svcGVK.GroupVersion().String(),
+			Kind:       svcGVK.Kind,
+			Name:       svc.Name,
+		},
+	}
+}
+
+// EventDisplayDeploymentName returns the name of the Deployment object
+// managing the event-display application, assuming that Deployment is managed
+// by a Knative Service with the expected default name.
+func EventDisplayDeploymentName(c dynamic.Interface, namespace string) string {
+	ksvcGVR := serving.ServicesResource.WithVersion("v1")
+
+	ksvc, err := c.Resource(ksvcGVR).Namespace(namespace).Get(context.Background(), eventDisplayName, metav1.GetOptions{})
+	if err != nil {
+		framework.FailfWithOffset(2, "Error getting event-display Knative Service: %s", err)
+	}
+
+	return ksvcDeploymentName(c, ksvc)
+}
+
+// ksvcDeployment returns the name of the Deployment matching the latest
+// revision of the given Knative Service.
+func ksvcDeploymentName(c dynamic.Interface, ksvc *unstructured.Unstructured) string {
+	latestRev, found, err := unstructured.NestedString(ksvc.Object, "status", "latestCreatedRevisionName")
+	if err != nil {
+		framework.FailfWithOffset(3, "Error reading status.latestCreatedRevisionName field: %s", err)
+	}
+	if !found {
+		framework.FailfWithOffset(3, "The Knative Service did not report its latestCreatedRevisionName")
+	}
+
+	var rev kmeta.Accessor = &unstructured.Unstructured{}
+	rev.SetName(latestRev)
+
+	return revisionnames.Deployment(rev)
+}
+
+// ReceivedEventDisplayEvents returns all events found in the given
+// event-display log stream.
+func ReceivedEventDisplayEvents(logStream io.ReadCloser) []cloudevents.Event {
+	defer func() {
+		if err := logStream.Close(); err != nil {
+			framework.FailfWithOffset(3, "Failed to close event-display's log stream: %s", err)
+		}
+	}()
+
+	eventStrings := splitEvents(logStream)
+
+	if len(eventStrings) == 0 {
+		return nil
+	}
+
+	events := make([]cloudevents.Event, len(eventStrings))
+
+	for i, eStr := range eventStrings {
+		events[i] = parseCloudEvent(eStr)
+	}
+
+	return events
+}
+
+// splitEvents parses the given stream into a list of event strings.
+func splitEvents(logStream io.Reader) []string {
+	const delimiter = '☁'
+
+	var buf bytes.Buffer
+
+	// read everything at once instead of per chunk, because a buffered
+	// read could end in the middle of a delimiter rune, causing an entire
+	// event to be overlooked while parsing
+	if _, err := buf.ReadFrom(logStream); err != nil {
+		framework.FailfWithOffset(2, "Error reading event-display's log stream: %s", err)
+	}
+
+	eventBuilders := make([]strings.Builder, 0)
+	currentEventIdx := -1
+
+	for {
+		r, _, err := buf.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			framework.FailfWithOffset(2, "Error reading buffer: %s", err)
+		}
+
+		if r == delimiter {
+			eventBuilders = append(eventBuilders, make([]strings.Builder, 1)...)
+			currentEventIdx++
+		}
+		// everything until the first found delimiter will be ignored
+		if currentEventIdx >= 0 {
+			eventBuilders[currentEventIdx].WriteRune(r)
+		}
+	}
+
+	events := make([]string, len(eventBuilders))
+
+	for i, eb := range eventBuilders {
+		events[i] = eb.String()
+	}
+
+	return events
+}
+
+// parseCloudEvent parses the content of a stringified CloudEvent into a
+// structured CloudEvent.
+//
+// Example of output from Event.String():
+//
+// ☁  cloudevents.Event
+// Validation: valid
+// Context Attributes,
+//   specversion: 1.0
+//   type: io.triggermesh.some.event
+//   source: some/source
+//   subject: some-subject
+//   id: edecf007-f651-4e10-959e-e2f0a5b8ccd0
+//   time: 2020-09-14T13:59:40.693213706Z
+//   datacontenttype: application/json
+// Extensions,
+//   someextension: some-value
+// Data,
+//   {
+//     ...
+//   }
+func parseCloudEvent(ce string) cloudevents.Event {
+	e := cloudevents.NewEvent()
+
+	contentType := cloudevents.ApplicationJSON
+
+	r := bufio.NewReader(strings.NewReader(ce))
+
+	for {
+		line, err := r.ReadString('\n')
+		line = strings.TrimSpace(line)
+
+		// try finding context attributes and data
+		subs := strings.SplitN(line, ":", 2)
+
+		switch len(subs) {
+		case 1:
+			if subs[0] != "Data," {
+				break
+			}
+
+			// read everything that's left to read and set
+			// it as the event's data
+			b, err := ioutil.ReadAll(r)
+			if err != nil {
+				framework.Logf("Error reading event's data: %s", err)
+				break
+			}
+
+			decodedData := make(map[string]interface{})
+
+			if err := datacodec.Decode(context.Background(), e.DataMediaType(), b, &decodedData); err != nil {
+				framework.Logf("Error decoding event's data, using raw bytes instead: %s", err)
+				if err := e.SetData(contentType, b); err != nil {
+					framework.Logf("Error setting event's data: %s", err)
+				}
+			} else {
+				if err := e.SetData(contentType, decodedData); err != nil {
+					framework.Logf("Error setting event's data: %s", err)
+				}
+			}
+
+		case 2:
+			switch k, v := subs[0], strings.TrimSpace(subs[1]); k {
+
+			// Required attributes
+			case "id":
+				e.SetID(v)
+			case "source":
+				e.SetSource(v)
+			case "specversion":
+				e.SetSpecVersion(v)
+			case "type":
+				e.SetType(v)
+
+			// Optional attributes
+			case "datacontenttype":
+				contentType = v
+				e.SetDataContentType(v)
+			case "dataschema":
+				e.SetDataSchema(v)
+			case "subject":
+				e.SetSubject(v)
+			case "time":
+				t, err := time.Parse(time.RFC3339Nano, v)
+				if err != nil {
+					framework.Logf("Error parsing event's time: %s", err)
+					break
+				}
+				e.SetTime(t)
+
+			// Extensions
+			default:
+				e.SetExtension(k, v)
+			}
+		}
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			framework.FailfWithOffset(3, "Error reading line from Reader: %s", err)
+		}
+	}
+
+	return e
+}

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+package framework
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
-)
+// Config holds the global configuration of the current test context.
+var Config TestConfig
+
+// TestConfig contains the configuration of a test context.
+type TestConfig struct {
+	// Path to a Kubeconfig file containing credentials to interact with Kubernetes.
+	Kubeconfig string
+}

--- a/test/e2e/framework/ducktypes/addressable.go
+++ b/test/e2e/framework/ducktypes/addressable.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ducktypes
+
+import (
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+)
+
+// Address returns the address of an Addressable object as a URL.
+// Fails the test if not found.
+func Address(obj *unstructured.Unstructured) *url.URL {
+	return (*url.URL)(unstructuredToAddressableType(obj).Status.Address.URL)
+}
+
+func unstructuredToAddressableType(obj *unstructured.Unstructured) *duckv1.AddressableType {
+	a := &duckv1.AddressableType{}
+	if err := duck.FromUnstructured(obj, a); err != nil {
+		framework.FailfWithOffset(2, "Failed to convert unstructured object to Addressable: %s", err)
+	}
+	return a
+}

--- a/test/e2e/framework/ducktypes/doc.go
+++ b/test/e2e/framework/ducktypes/doc.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
-
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
-)
+// Package ducktypes contains helpers to interact with Knative duck-typed objects.
+package ducktypes

--- a/test/e2e/framework/ducktypes/util.go
+++ b/test/e2e/framework/ducktypes/util.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ducktypes
+
+import duckv1 "knative.dev/pkg/apis/duck/v1"
+
+// DestinationToMap performs a conversion of duckv1.Destination to
+// map[string]interface{}.
+// Useful to avoid errors such as "cannot deep copy *v1.KReference" while
+// setting a fields on an unstructured.Unstrucured object.
+func DestinationToMap(dst *duckv1.Destination) map[string]interface{} {
+	dstMap := make(map[string]interface{})
+
+	if dst.Ref != nil {
+		dstMap["ref"] = map[string]interface{}{
+			"apiVersion": dst.Ref.APIVersion,
+			"kind":       dst.Ref.Kind,
+			"namespace":  dst.Ref.Namespace,
+			"name":       dst.Ref.Name,
+		}
+	}
+	if dst.URI != nil {
+		dstMap["uri"] = dst.URI.String()
+	}
+
+	return dstMap
+}

--- a/test/e2e/framework/ducktypes/wait.go
+++ b/test/e2e/framework/ducktypes/wait.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ducktypes
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+)
+
+// WaitUntilReady waits until the given resource's status becomes ready.
+func WaitUntilReady(c dynamic.Interface, obj *unstructured.Unstructured) *unstructured.Unstructured {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", obj.GetName()).String()
+	gvr, _ := meta.UnsafeGuessKindToResource(obj.GroupVersionKind())
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return c.Resource(gvr).Namespace(obj.GetNamespace()).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return c.Resource(gvr).Namespace(obj.GetNamespace()).Watch(context.Background(), options)
+		},
+	}
+
+	// checks whether the object referenced in the given watch.Event has
+	// its Ready condition set to True.
+	var isResourceReady watchtools.ConditionFunc = func(e watch.Event) (bool, error) {
+		if e.Type == watch.Deleted {
+			return false, apierrors.NewNotFound(gvr.GroupResource(), obj.GetName())
+		}
+
+		if u, ok := e.Object.(*unstructured.Unstructured); ok {
+			res := &duckv1.KResource{}
+			if err := duck.FromUnstructured(u, res); err != nil {
+				framework.FailfWithOffset(2, "Failed to convert unstructured object to KResource: %s", err)
+			}
+
+			if cond := res.Status.GetCondition(apis.ConditionReady); cond != nil && cond.IsTrue() {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	const watchTimeout = 1 * time.Minute
+
+	ctx, cancel := context.WithTimeout(context.Background(), watchTimeout)
+	defer cancel()
+
+	lastEvent, err := watchtools.UntilWithSync(ctx, lw, obj, nil, isResourceReady)
+	if err != nil {
+		framework.FailfWithOffset(2, "Error waiting for resource %s %q to become ready: %s",
+			gvr.GroupResource(), obj.GetName(), err)
+	}
+
+	return lastEvent.Object.(*unstructured.Unstructured)
+}

--- a/test/e2e/framework/flags.go
+++ b/test/e2e/framework/flags.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"os"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// registerFlags registers command-line flags
+// NOTE: `go test` calls flag.Parse() during normal operation.
+func registerFlags() {
+	stringFlag(&Config.Kubeconfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar),
+		"Path to a kubeconfig file containing credentials to interact with a Kubernetes cluster.")
+}
+
+// Prefix prepended to all command-line flags declared by this test suite.
+const flagPrefix = "e2e"
+
+// stringFlag is a wrapper around flag.StringVar.
+func stringFlag(varPtr *string, name, value, usage string) {
+	flag.StringVar(varPtr, flagName(name), value, usage)
+}
+
+// flagName prepends the given flag name with flagPrefix.
+func flagName(name string) string {
+	return flagPrefix + "." + name
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Framework wraps the context and common operations for tests.
+type Framework struct {
+	// Test identifiers
+	baseName   string // e.g. "mytest"
+	UniqueName string // e.g. "mytest-1234"
+
+	// Test context
+	namespacesToDelete []*corev1.Namespace
+
+	// API clients
+	clientCfg     *rest.Config
+	KubeClient    clientset.Interface
+	DynamicClient dynamic.Interface
+}
+
+// New creates a test Framework.
+func New(baseName string) *Framework {
+	f := &Framework{
+		baseName: baseName,
+	}
+
+	ginkgo.BeforeEach(f.BeforeEach)
+	ginkgo.AfterEach(f.AfterEach)
+
+	return f
+}
+
+// BeforeEach performs common initialization tasks.
+func (f *Framework) BeforeEach() {
+	// ensure the list of namespaces to delete is re-initialized in every
+	// BeforeEach, otherwise test namespaces are appended to the list from
+	// the previous test, etc.
+	f.namespacesToDelete = nil
+
+	ginkgo.By("creating test REST clients", func() {
+		restCfg := getRESTConfig()
+		f.clientCfg = restCfg
+		f.KubeClient = getKubeClient(restCfg)
+		f.DynamicClient = getDynamicClient(restCfg)
+	})
+
+	ginkgo.By("creating test namespace with base name "+f.baseName, func() {
+		f.UniqueName = createTestNamespace(f).Name
+	})
+}
+
+// AfterEach performs common cleanup tasks.
+func (f *Framework) AfterEach() {
+	// defer deletion of namespaces to avoid any intermediate failure from
+	// short-circuiting this action.
+	defer func() {
+		deleteNsFuncs := make([]func() error, len(f.namespacesToDelete))
+
+		for i, ns := range f.namespacesToDelete {
+			ginkgo.By("marking test namespace "+ns.Name+" for deletion", func() {
+				deleteNsFuncs[i] = func() error {
+					if err := deleteNamespace(f.KubeClient, ns.Name); err != nil {
+						return fmt.Errorf("failed to delete namespace %q: %v", ns.Name, err)
+					}
+					return nil
+				}
+			})
+		}
+
+		// offset level above caller
+		// e.g. "AfterEach -> f -> ExpectWithOffset(2, ...)" will be logged for "AfterEach"
+		const offset = 2
+		if err := errorsutil.AggregateGoroutines(deleteNsFuncs...); err != nil {
+			ginkgo.Fail(err.Error(), offset)
+		}
+	}()
+}
+
+// ClientConfig returns a copy of the Framework's rest.Config. Can be used to
+// generate new API clients.
+func (f *Framework) ClientConfig() *rest.Config {
+	return rest.CopyConfig(f.clientCfg)
+}
+
+// AddNamespacesToDelete marks one or more namespaces for deletion when the
+// test completes.
+func (f *Framework) AddNamespacesToDelete(namespaces ...*corev1.Namespace) {
+	for _, ns := range namespaces {
+		if ns == nil {
+			continue
+		}
+		f.namespacesToDelete = append(f.namespacesToDelete, ns)
+	}
+}
+
+func getRESTConfig() *rest.Config {
+	if kubeconfig := Config.Kubeconfig; kubeconfig != "" {
+		cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		expectNoError(err, "Unable to build client config from kubeconfig %s", kubeconfig)
+
+		return cfg
+	}
+
+	// fall back to in-cluster config if neither the KUBECONFIG env var not
+	// the kubeconfig flag was set
+	cfg, err := rest.InClusterConfig()
+	expectNoError(err, "Unable to build client config from in-cluster config")
+
+	return cfg
+}
+
+func getKubeClient(cfg *rest.Config) clientset.Interface {
+	cli, err := clientset.NewForConfig(cfg)
+	expectNoError(err, "Unable to obtain Kubernetes ClientSet using the provided REST config")
+
+	return cli
+}
+
+func getDynamicClient(cfg *rest.Config) dynamic.Interface {
+	cli, err := dynamic.NewForConfig(cfg)
+	expectNoError(err, "Unable to obtain dynamic ClientSet using the provided REST config")
+
+	return cli
+}
+
+func createTestNamespace(f *Framework) *corev1.Namespace {
+	ns, err := f.CreateNamespace(f.baseName, labels.Set{
+		"e2e-framework": f.baseName,
+	})
+	expectNoError(err, "Failed to create test namespace: %v", err)
+
+	return ns
+}
+
+// expectNoError is a convenience wrapper for failing functions called from
+// whithin this package at the expected offset level.
+func expectNoError(err error, context ...interface{}) {
+	// offset level above caller
+	// e.g. "BeforeEach -> f -> ExpectWithOffset(2, ...)" will be logged for "BeforeEach"
+	const offset = 2
+	gomega.ExpectWithOffset(offset, err).NotTo(gomega.HaveOccurred(), context...)
+}

--- a/test/e2e/framework/init.go
+++ b/test/e2e/framework/init.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+package framework
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
-)
+func init() {
+	registerFlags()
+}

--- a/test/e2e/framework/log.go
+++ b/test/e2e/framework/log.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+)
+
+// Logf logs the given message.
+func Logf(format string, args ...interface{}) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, format+"\n", args...)
+}
+
+// Failf fails the test with the given message.
+func Failf(format string, args ...interface{}) {
+	FailfWithOffset(1, format, args...)
+}
+
+// FailfWithOffset fails the test with the given message.
+//
+// The offset argument is used to modify the call-stack offset when computing
+// line numbers. This is useful in helper functions that make assertions so
+// that error messages refer to the calling line in the test, as opposed to the
+// line in the helper function.
+//
+// e.g. "It(...) -> f -> FailfWithOffset(1, ...)" will be logged for "It"
+func FailfWithOffset(offset int, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	ginkgo.Fail(msg, offset+1)
+}

--- a/test/e2e/framework/namespaces.go
+++ b/test/e2e/framework/namespaces.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+const namespacePrefix = "e2e-"
+
+// CreateNamespace creates a namespace and marks it for automatic cleanup at
+// the end of the test.
+func (f *Framework) CreateNamespace(baseName string, l ...labels.Set) (*corev1.Namespace, error) {
+	var lbls labels.Set
+	if len(l) > 0 {
+		lbls = l[0]
+	}
+
+	ns, err := createNamespace(f.KubeClient, baseName, lbls)
+	f.AddNamespacesToDelete(ns)
+	return ns, err
+}
+
+func createNamespace(c clientset.Interface, baseName string, labels labels.Set) (*corev1.Namespace, error) {
+	// Generate a random name instead of setting ObjectMeta.GenerateName so
+	// we can ensure the namespace is always deleted, even if the API call
+	// to create it failed.
+	var genName = func() string {
+		return namespacePrefix + baseName + "-" + RandomSuffix()
+	}
+	name := genName()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+
+	var createdNs *corev1.Namespace
+
+	var createNsFunc wait.ConditionFunc = func() (bool, error) {
+		var err error
+		if createdNs, err = c.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				Logf("Namespace %q already exists, will retry with a new name", ns.Name)
+				ns.Name = genName()
+			} else {
+				Logf("Error while creating namespace %q, will retry: %v", ns.Name, err)
+			}
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if err := wait.PollImmediate(200*time.Millisecond, 10*time.Second, createNsFunc); err != nil {
+		// return ns despite the failure, to allow the caller to ensure
+		// that the namespace is really absent.
+		return ns, err
+	}
+
+	if err := WaitForDefaultServiceAccountInNamespace(c, createdNs.Name); err != nil {
+		// Even if the serviceAccount creation failed, we still return
+		// the successfully created namespace.
+		Logf("Error waiting for the creation of the default ServiceAccount, ignoring: %v", err)
+	}
+
+	return createdNs, nil
+}
+
+func deleteNamespace(c clientset.Interface, name string) error {
+	var deleteNsFunc wait.ConditionFunc = func() (bool, error) {
+		err := c.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			Logf("Namespace %q does not exist or was already deleted", name)
+			return true, nil
+		case err != nil:
+			Logf("Error while deleting namespace %q, will retry: %v", name, err)
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	return wait.PollImmediate(200*time.Millisecond, 10*time.Second, deleteNsFunc)
+}
+
+// WaitForDefaultServiceAccountInNamespace waits for the default ServiceAccount
+// to be provisioned in the given namespace.
+func WaitForDefaultServiceAccountInNamespace(c clientset.Interface, namespace string) error {
+	return waitForServiceAccountInNamespace(c, namespace, "default")
+}
+
+// waitForServiceAccountInNamespace waits until the given ServiceAccount is
+// provisioned in the given namespace.
+func waitForServiceAccountInNamespace(c clientset.Interface, namespace, saName string) error {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", saName).String()
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return c.CoreV1().ServiceAccounts(namespace).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return c.CoreV1().ServiceAccounts(namespace).Watch(context.Background(), options)
+		},
+	}
+
+	// checks whether the ServiceAccount referenced in the given
+	// watch.Event has at least one secret.
+	var serviceAccountHasSecrets watchtools.ConditionFunc = func(e watch.Event) (bool, error) {
+		if e.Type == watch.Deleted {
+			return false, apierrors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, saName)
+		}
+
+		if sa, ok := e.Object.(*corev1.ServiceAccount); ok {
+			return len(sa.Secrets) > 0, nil
+		}
+
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := watchtools.UntilWithSync(ctx, lw, &corev1.ServiceAccount{}, nil, serviceAccountHasSecrets)
+	return err
+}

--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -1,8 +1,5 @@
-//go:build tools
-// +build tools
-
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2020 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+package framework
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
+	"math/rand"
+	"strconv"
+	"time"
 )
+
+// RandomSuffix provides a random sequence that can be appended to API objects' names.
+func RandomSuffix() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return strconv.Itoa(r.Intn(10000))
+}

--- a/test/e2e/sources/awssqs/main.go
+++ b/test/e2e/sources/awssqs/main.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssqs
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo" //nolint:stylecheck
+	. "github.com/onsi/gomega" //nolint:stylecheck
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/triggermesh/triggermesh/test/e2e/framework"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/apps"
+	e2esqs "github.com/triggermesh/triggermesh/test/e2e/framework/aws/sqs"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/bridges"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/ducktypes"
+)
+
+/* This test suite requires:
+
+   - AWS credentials in whichever form (https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Sessions_options_from_Shared_Config)
+   - The name of an AWS region exported in the environment as AWS_REGION
+*/
+
+var sourceAPIVersion = schema.GroupVersion{
+	Group:   "sources.triggermesh.io",
+	Version: "v1alpha1",
+}
+
+const (
+	sourceKind     = "AWSSQSSource"
+	sourceResource = "awssqssources"
+)
+
+var _ = Describe("AWS SQS source", func() {
+	f := framework.New("awssqssource")
+
+	var ns string
+
+	var srcClient dynamic.ResourceInterface
+
+	var queueURL string
+	var queueARN string
+	var awsCreds credentials.Value
+	var sink *duckv1.Destination
+
+	BeforeEach(func() {
+		ns = f.UniqueName
+
+		gvr := sourceAPIVersion.WithResource(sourceResource)
+		srcClient = f.DynamicClient.Resource(gvr).Namespace(ns)
+	})
+
+	Context("a source watches an existing queue", func() {
+		var sqsClient sqsiface.SQSAPI
+
+		BeforeEach(func() {
+			sess := session.Must(session.NewSession())
+			sqsClient = sqs.New(sess)
+			awsCreds = readAWSCredentials(sess)
+
+			By("creating an event sink", func() {
+				sink = bridges.CreateEventDisplaySink(f.KubeClient, ns)
+			})
+
+			By("creating a SQS queue", func() {
+				queueURL = e2esqs.CreateQueue(sqsClient, f)
+			})
+
+			By("creating an AWSSQSSource object", func() {
+				queueARN = e2esqs.QueueARN(sqsClient, queueURL)
+				src, err := createSource(srcClient, ns, "test-", sink,
+					withARN(queueARN),
+					withCredentials(awsCreds),
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				ducktypes.WaitUntilReady(f.DynamicClient, src)
+
+				// FIXME(antoineco): without this short pause, the receive adapter throws the following
+				// error when sending the event:
+				//
+				//   Sending SQS event
+				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
+				//
+				time.Sleep(5 * time.Second)
+			})
+		})
+
+		AfterEach(func() {
+			By("deleting SQS queue "+queueURL, func() {
+				e2esqs.DeleteQueue(sqsClient, queueURL)
+			})
+		})
+
+		When("a message is sent to the queue", func() {
+			var msgID string
+
+			BeforeEach(func() {
+				msgID = e2esqs.SendMessage(sqsClient, queueURL)
+			})
+
+			Specify("the source generates an event", func() {
+				const receiveTimeout = 15 * time.Second
+				const pollInterval = 500 * time.Millisecond
+
+				var receivedEvents []cloudevents.Event
+
+				readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
+
+				Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
+				Expect(receivedEvents).To(HaveLen(1))
+
+				e := receivedEvents[0]
+
+				Expect(e.Type()).To(Equal("com.amazon.sqs.message"))
+				Expect(e.ID()).To(Equal(msgID))
+				Expect(e.Source()).To(Equal(queueARN))
+			})
+		})
+	})
+
+	When("a client creates a source object with invalid specs", func() {
+
+		// Those tests do not require a real repository or sink
+		BeforeEach(func() {
+			queueARN = "arn:aws:sqs:us-west-2:123456789012:fake-queue"
+
+			awsCreds = credentials.Value{
+				AccessKeyID:     "fake",
+				SecretAccessKey: "fake",
+			}
+
+			sink = &duckv1.Destination{
+				Ref: &duckv1.KReference{
+					APIVersion: "fake/v1",
+					Kind:       "Fake",
+					Name:       "fake",
+				},
+			}
+		})
+
+		// Here we use
+		//   "Specify: the API server rejects ..., By: setting an invalid ..."
+		// instead of
+		//   "When: it sets an invalid ..., Specify: the API server rejects ..."
+		// to avoid creating a namespace for each spec, due to their simplicity.
+		Specify("the API server rejects the creation of that object", func() {
+
+			By("setting an invalid ARN", func() {
+				invalidARN := "arn:aws:sqs:invalid::"
+
+				_, err := createSource(srcClient, ns, "test-invalid-arn-", sink,
+					withARN(invalidARN),
+					withCredentials(awsCreds),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("spec.arn: Invalid value: "))
+			})
+
+			By("setting empty credentials", func() {
+				_, err := createSource(srcClient, ns, "test-nocreds-", sink,
+					withARN(queueARN),
+					withCredentials(credentials.Value{}),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(
+					`"spec.auth.credentials.accessKeyID" must validate one and only one schema (oneOf).`))
+			})
+		})
+	})
+})
+
+// createSource creates an AWSSQSSource object initialized with the given options.
+func createSource(srcClient dynamic.ResourceInterface, namespace, namePrefix string,
+	sink *duckv1.Destination, opts ...sourceOption) (*unstructured.Unstructured, error) {
+
+	src := &unstructured.Unstructured{}
+	src.SetAPIVersion(sourceAPIVersion.String())
+	src.SetKind(sourceKind)
+	src.SetNamespace(namespace)
+	src.SetGenerateName(namePrefix)
+
+	if err := unstructured.SetNestedMap(src.Object, ducktypes.DestinationToMap(sink), "spec", "sink"); err != nil {
+		framework.FailfWithOffset(2, "Failed to set spec.sink field: %s", err)
+	}
+
+	for _, opt := range opts {
+		opt(src)
+	}
+
+	return srcClient.Create(context.Background(), src, metav1.CreateOptions{})
+}
+
+type sourceOption func(*unstructured.Unstructured)
+
+func withARN(arn string) sourceOption {
+	return func(src *unstructured.Unstructured) {
+		if err := unstructured.SetNestedField(src.Object, arn, "spec", "arn"); err != nil {
+			framework.FailfWithOffset(3, "Failed to set spec.arn field: %s", err)
+		}
+	}
+}
+
+func withCredentials(creds credentials.Value) sourceOption {
+	credsMap := map[string]interface{}{
+		"accessKeyID":     map[string]interface{}{},
+		"secretAccessKey": map[string]interface{}{},
+	}
+	if creds.AccessKeyID != "" {
+		credsMap["accessKeyID"] = map[string]interface{}{"value": creds.AccessKeyID}
+	}
+	if creds.SecretAccessKey != "" {
+		credsMap["secretAccessKey"] = map[string]interface{}{"value": creds.SecretAccessKey}
+	}
+
+	return func(src *unstructured.Unstructured) {
+		if err := unstructured.SetNestedMap(src.Object, credsMap, "spec", "auth", "credentials"); err != nil {
+			framework.FailfWithOffset(3, "Failed to set spec.auth.credentials field: %s", err)
+		}
+	}
+}
+
+func readAWSCredentials(sess *session.Session) credentials.Value {
+	creds, err := sess.Config.Credentials.Get()
+	if err != nil {
+		framework.FailfWithOffset(2, "Error reading AWS credentials: %s", err)
+	}
+
+	return creds
+}
+
+// readReceivedEvents returns a function that reads CloudEvents received by the
+// event-display application and stores the result as the value of the given
+// `receivedEvents` variable.
+// The returned function signature satisfies the contract expected by
+// gomega.Eventually: no argument and one or more return values.
+func readReceivedEvents(c clientset.Interface, namespace, eventDisplayDeplName string,
+	receivedEvents *[]cloudevents.Event) func() []cloudevents.Event {
+
+	return func() []cloudevents.Event {
+		ev := bridges.ReceivedEventDisplayEvents(
+			apps.GetLogs(c, namespace, eventDisplayDeplName),
+		)
+		*receivedEvents = ev
+		return ev
+	}
+}

--- a/test/e2e/sources/main.go
+++ b/test/e2e/sources/main.go
@@ -1,6 +1,3 @@
-//go:build tools
-// +build tools
-
 /*
 Copyright 2021 TriggerMesh Inc.
 
@@ -17,11 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
+package sources
 
-// These imports ensure build tools are included in Go modules.
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-	_ "k8s.io/code-generator"
+	_ "github.com/triggermesh/triggermesh/test/e2e/sources/awssqs"
 )


### PR DESCRIPTION
Part of #339
Requires #354
Second take on #355 (not from my fork this time)

Migrates the core of the e2e test framework and the test suite for the AWS SQS source, in isolation from the rest, to ensure that the e2e workflow is working reliably inside the CI environment. (There is no reason for starting with the SQS test suite in particular, except for the fact that it has proven to remain stable over time.)

I'll follow up with the bulk of the other tests in a separate PR, once everybody is OK with this flow and strucuture.

---

Here is a successful test run: https://github.com/triggermesh/triggermesh/actions/runs/1624016057