### PR TITLE
Improve E2E test suite for Google Cloud Pub/Sub source

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -367,7 +367,7 @@ The benefits of this approach become more obvious when the complexity of test sc
 [ginkgo-docs]: https://onsi.github.io/ginkgo/
 [ginkgo-issue222]: https://github.com/onsi/ginkgo/issues/222
 [ginkgo-struct]: https://onsi.github.io/ginkgo/#structuring-your-specs
-[optimized-test]: https://github.com/triggermesh/triggermesh/blob/main/test/e2e/sources/awscodecommit/main.go#L171-L187
+[optimized-test]: https://github.com/triggermesh/triggermesh/blob/1d8390e2/test/e2e/sources/awscodecommit/main.go#L171-L187
 
 [k8s-e2e]: https://godoc.org/k8s.io/kubernetes/test/e2e
 [sigtesting-howto]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md

--- a/test/e2e/framework/gcloud/gcloud.go
+++ b/test/e2e/framework/gcloud/gcloud.go
@@ -23,6 +23,11 @@ import (
 	"github.com/triggermesh/triggermesh/test/e2e/framework"
 )
 
+const (
+	envServiceAccountKey = "GCLOUD_SERVICEACCOUNT_KEY"
+	envProjectName       = "GCLOUD_PROJECT"
+)
+
 const pubsubLabelOwnerResource = "io-triggermesh_owner-resource"
 
 // PubSubResourceID returns a deterministic Pub/Sub resource ID matching the given framework.Framework.
@@ -37,12 +42,14 @@ func TagsFor(f *framework.Framework) map[string]string {
 	}
 }
 
-// GetCreds returns the Google Cloud creds read from the environment.
-func GetCreds(credsEnvVar string) string {
-	return os.Getenv(credsEnvVar)
+// ServiceAccountKeyFromEnv returns the Service Account key read from the
+// environment.
+func ServiceAccountKeyFromEnv() string {
+	return os.Getenv(envServiceAccountKey)
 }
 
-// GetProject returns the Google Cloud project read from the environment.
-func GetProject(projectEnvVar string) string {
-	return os.Getenv(projectEnvVar)
+// ProjectNameFromEnv returns the name of the Google Cloud project read from
+// the environment.
+func ProjectNameFromEnv() string {
+	return os.Getenv(envProjectName)
 }

--- a/test/e2e/framework/gcloud/gcloud.go
+++ b/test/e2e/framework/gcloud/gcloud.go
@@ -28,17 +28,12 @@ const (
 	envProjectName       = "GCLOUD_PROJECT"
 )
 
-const pubsubLabelOwnerResource = "io-triggermesh_owner-resource"
-
-// PubSubResourceID returns a deterministic Pub/Sub resource ID matching the given framework.Framework.
-func PubSubResourceID(f *framework.Framework) string {
-	return f.UniqueName
-}
+const e2eInstanceTagKey = "e2e_instance"
 
 // TagsFor returns a set of resource tags matching the given framework.Framework.
 func TagsFor(f *framework.Framework) map[string]string {
 	return map[string]string{
-		pubsubLabelOwnerResource: f.UniqueName,
+		e2eInstanceTagKey: f.UniqueName,
 	}
 }
 

--- a/test/e2e/framework/gcloud/pubsub/pubsub.go
+++ b/test/e2e/framework/gcloud/pubsub/pubsub.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package pubsub contains helpers for Google Cloud PubSub.
+// Package pubsub contains helpers for Google Cloud Pub/Sub.
 package pubsub
 
 import (
@@ -26,55 +26,68 @@ import (
 	"github.com/triggermesh/triggermesh/test/e2e/framework/gcloud"
 )
 
-// CreateTopic creates a topic named after the given framework.Framework.
+// CreateTopic creates a Pub/Sub topic named after the given framework.Framework.
 func CreateTopic(pubsubCli *pubsub.Client, f *framework.Framework) *pubsub.Topic {
+	topicID := f.UniqueName
+
 	cfg := &pubsub.TopicConfig{
 		Labels: gcloud.TagsFor(f),
 	}
 
-	topicID := gcloud.PubSubResourceID(f)
-
-	resp, err := pubsubCli.CreateTopicWithConfig(context.Background(), topicID, cfg)
+	topic, err := pubsubCli.CreateTopicWithConfig(context.Background(), topicID, cfg)
 	if err != nil {
 		framework.FailfWithOffset(2, "Failed to create topic %q: %s", topicID, err)
 	}
 
-	return resp
+	return topic
 }
 
-// CreateSubscription creates a subscription for a topic.
-func CreateSubscription(pubsubCli *pubsub.Client, topic *pubsub.Topic, f *framework.Framework) string {
+// CreateSubscription creates a subscription for the given Pub/Sub topic.
+func CreateSubscription(pubsubCli *pubsub.Client, topic *pubsub.Topic, f *framework.Framework) *pubsub.Subscription {
 	cfg := pubsub.SubscriptionConfig{
 		Topic:  topic,
 		Labels: gcloud.TagsFor(f),
 	}
 
-	subscriptionID := gcloud.PubSubResourceID(f)
+	subscriptionID := topic.ID()
 
-	resp, err := pubsubCli.CreateSubscription(context.Background(), subscriptionID, cfg)
+	subscription, err := pubsubCli.CreateSubscription(context.Background(), subscriptionID, cfg)
 	if err != nil {
-		framework.FailfWithOffset(2, "Failed to create subscription for topic %q: %s", topic.String(), err)
+		framework.FailfWithOffset(2, "Failed to create subscription for topic %q: %s", topic.ID(), err)
 	}
 
-	return resp.String()
+	return subscription
 }
 
-func SendMessage(pubsubCli *pubsub.Client, topic *pubsub.Topic, f *framework.Framework) string {
-	sendMessage := pubsubCli.Topic(topic.ID()).Publish(context.Background(), &pubsub.Message{
-		Data: []byte("Hello world"),
-	})
-
-	id, err := sendMessage.Get(context.Background())
-	if err != nil {
-		framework.FailfWithOffset(2, "Failed to send message: %s", err)
+// SendMessage sends a message to the given Pub/Sub topic and returns the
+// corresponding message ID.
+func SendMessage(pubsubCli *pubsub.Client, topicID string) string /*msg id*/ {
+	msg := &pubsub.Message{
+		Data: []byte("Hello, World!"),
 	}
 
-	return id
+	ctx := context.Background()
+
+	publishResult := pubsubCli.Topic(topicID).Publish(ctx, msg)
+
+	msgID, err := publishResult.Get(ctx)
+	if err != nil {
+		framework.FailfWithOffset(2, "Failed to send message to topic %q: %s", topicID, err)
+	}
+
+	return msgID
 }
 
-func DeleteTopic(pubsubCli *pubsub.Client, topic *pubsub.Topic) {
-	err := pubsubCli.Topic(topic.ID()).Delete(context.Background())
-	if err != nil {
-		framework.FailfWithOffset(2, "Failed to delete topic %q: %s", topic, err)
+// DeleteTopic deletes the Pub/Sub topic with the given name.
+func DeleteTopic(pubsubCli *pubsub.Client, topicID string) {
+	if err := pubsubCli.Topic(topicID).Delete(context.Background()); err != nil {
+		framework.FailfWithOffset(2, "Failed to delete topic %q: %s", topicID, err)
+	}
+}
+
+// DeleteSubscription deletes the Pub/Sub subscription with the given name.
+func DeleteSubscription(pubsubCli *pubsub.Client, subsID string) {
+	if err := pubsubCli.Subscription(subsID).Delete(context.Background()); err != nil {
+		framework.FailfWithOffset(2, "Failed to delete subscription %q: %s", subsID, err)
 	}
 }

--- a/test/e2e/gcloud_iam_roles.yaml
+++ b/test/e2e/gcloud_iam_roles.yaml
@@ -24,8 +24,12 @@ name: projects/cebuk-01/roles/TriggerMeshE2E
 title: TriggerMesh E2E test suite
 description: Grants permissions required by the TriggerMesh E2E test suite.
 includedPermissions:
+- pubsub.subscriptions.create
+- pubsub.subscriptions.delete
+- pubsub.topics.attachSubscription
 - pubsub.topics.create
 - pubsub.topics.delete
+- pubsub.topics.detachSubscription
 - pubsub.topics.publish
 - source.repos.create
 - source.repos.delete

--- a/test/e2e/sources/googlecloudauditlogs/main.go
+++ b/test/e2e/sources/googlecloudauditlogs/main.go
@@ -58,9 +58,6 @@ var sourceAPIVersion = schema.GroupVersion{
 const (
 	sourceKind     = "GoogleCloudAuditLogsSource"
 	sourceResource = "googlecloudauditlogssources"
-
-	credsEnvVar   = "GCLOUD_SERVICEACCOUNT_KEY"
-	projectEnvVar = "GCLOUD_PROJECT"
 )
 
 var _ = Describe("Google Cloud AuditLogs source", func() {
@@ -91,8 +88,8 @@ var _ = Describe("Google Cloud AuditLogs source", func() {
 		BeforeEach(func() {
 			serviceName = "pubsub.googleapis.com"
 			methodName = "google.pubsub.v1.Publisher.CreateTopic"
-			saKey = e2egcloud.GetCreds(credsEnvVar)
-			project = e2egcloud.GetProject(projectEnvVar)
+			saKey = e2egcloud.ServiceAccountKeyFromEnv()
+			project = e2egcloud.ProjectNameFromEnv()
 			pubsubClient, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/sources/googlecloudauditlogs/main.go
+++ b/test/e2e/sources/googlecloudauditlogs/main.go
@@ -123,7 +123,7 @@ var _ = Describe("Google Cloud AuditLogs source", func() {
 			})
 			AfterEach(func() {
 				By("deleting Pub/Sub topic "+topic.String(), func() {
-					e2epubsub.DeleteTopic(pubsubClient, topic)
+					e2epubsub.DeleteTopic(pubsubClient, topic.ID())
 				})
 			})
 			Specify("the source generates an event", func() {

--- a/test/e2e/sources/googlecloudpubsub/main.go
+++ b/test/e2e/sources/googlecloudpubsub/main.go
@@ -58,9 +58,6 @@ var sourceAPIVersion = schema.GroupVersion{
 const (
 	sourceKind     = "GoogleCloudPubSubSource"
 	sourceResource = "googlecloudpubsubsources"
-
-	credsEnvVar   = "GCLOUD_SERVICEACCOUNT_KEY"
-	projectEnvVar = "GCLOUD_PROJECT"
 )
 
 var _ = Describe("Google Cloud Pub/Sub source", func() {
@@ -89,8 +86,8 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 		var err error
 
 		BeforeEach(func() {
-			saKey = e2egcloud.GetCreds(credsEnvVar)
-			project = e2egcloud.GetProject(projectEnvVar)
+			saKey = e2egcloud.ServiceAccountKeyFromEnv()
+			project = e2egcloud.ProjectNameFromEnv()
 			pubsubClient, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 
@@ -150,8 +147,8 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 		var err error
 
 		BeforeEach(func() {
-			saKey = e2egcloud.GetCreds(credsEnvVar)
-			project = e2egcloud.GetProject(projectEnvVar)
+			saKey = e2egcloud.ServiceAccountKeyFromEnv()
+			project = e2egcloud.ProjectNameFromEnv()
 			pubsubClient, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/sources/googlecloudpubsub/main.go
+++ b/test/e2e/sources/googlecloudpubsub/main.go
@@ -67,9 +67,6 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 
 	var srcClient dynamic.ResourceInterface
 
-	var topic *pubsub.Topic
-	var subscription string
-	var project string
 	var saKey string
 
 	var sink *duckv1.Destination
@@ -81,130 +78,107 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 		srcClient = f.DynamicClient.Resource(gvr).Namespace(ns)
 	})
 
-	Context("a source watches an non-existing subscription", func() {
+	Context("a source subscribes to a topic", func() {
 		var pubsubClient *pubsub.Client
+		var gcloudProject string
+
+		var topic *pubsub.Topic
+
 		var err error
+
+		SendMessageAndAssertReceivedEvent := func() func() {
+			return func() {
+				var msgID string
+
+				BeforeEach(func() {
+					msgID = e2epubsub.SendMessage(pubsubClient, topic.ID())
+				})
+
+				Specify("the source generates an event", func() {
+					const receiveTimeout = 15 * time.Second
+					const pollInterval = 500 * time.Millisecond
+
+					var receivedEvents []cloudevents.Event
+
+					readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
+
+					Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
+					Expect(receivedEvents).To(HaveLen(1))
+
+					e := receivedEvents[0]
+
+					Expect(e.Type()).To(Equal("com.google.cloud.pubsub.message"))
+					Expect(e.ID()).To(Equal(msgID))
+					Expect(e.Source()).To(Equal(topic.String()))
+				})
+			}
+		}
 
 		BeforeEach(func() {
 			saKey = e2egcloud.ServiceAccountKeyFromEnv()
-			project = e2egcloud.ProjectNameFromEnv()
-			pubsubClient, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON([]byte(saKey)))
+			gcloudProject = e2egcloud.ProjectNameFromEnv()
+			pubsubClient, err = pubsub.NewClient(context.Background(), gcloudProject, option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 
 			By("creating an event sink", func() {
 				sink = bridges.CreateEventDisplaySink(f.KubeClient, ns)
 			})
 
-			By("creating a pubsub topic", func() {
+			By("creating a Pub/Sub topic", func() {
 				topic = e2epubsub.CreateTopic(pubsubClient, f)
-			})
-
-			By("creating a GoogleCloudPubSub object", func() {
-				src, err := createSource(srcClient, ns, "test-", sink,
-					withTopic(topic.String()),
-					withCredentials(saKey),
-				)
-				Expect(err).ToNot(HaveOccurred())
-				ducktypes.WaitUntilReady(f.DynamicClient, src)
 			})
 		})
 
 		AfterEach(func() {
-			By("deleting pubsub topic "+topic.String(), func() {
-				e2epubsub.DeleteTopic(pubsubClient, topic)
+			By("deleting the Pub/Sub topic "+topic.ID(), func() {
+				e2epubsub.DeleteTopic(pubsubClient, topic.ID())
 			})
 		})
 
-		When("a message is sent to the topic", func() {
-			var msgID string
+		Context("the subscription is managed by the source", func() {
 
 			BeforeEach(func() {
-				msgID = e2epubsub.SendMessage(pubsubClient, topic, f)
+				By("creating a GoogleCloudPubSubSource object", func() {
+					src, err := createSource(srcClient, ns, "test-", sink,
+						withTopic(topic.String()),
+						withServiceAccountKey(saKey),
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					ducktypes.WaitUntilReady(f.DynamicClient, src)
+				})
 			})
 
-			Specify("the source generates an event", func() {
-				const receiveTimeout = 15 * time.Second
-				const pollInterval = 500 * time.Millisecond
-
-				var receivedEvents []cloudevents.Event
-
-				readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
-
-				Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
-				Expect(receivedEvents).To(HaveLen(1))
-
-				e := receivedEvents[0]
-
-				Expect(e.Type()).To(Equal("com.google.cloud.pubsub.message"))
-				Expect(e.ID()).To(Equal(msgID))
-				Expect(e.Source()).To(Equal(topic.String()))
-			})
-		})
-	})
-
-	Context("a source watches an existing subscription", func() {
-		var pubsubClient *pubsub.Client
-		var err error
-
-		BeforeEach(func() {
-			saKey = e2egcloud.ServiceAccountKeyFromEnv()
-			project = e2egcloud.ProjectNameFromEnv()
-			pubsubClient, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON([]byte(saKey)))
-			Expect(err).ToNot(HaveOccurred())
-
-			By("creating an event sink", func() {
-				sink = bridges.CreateEventDisplaySink(f.KubeClient, ns)
-			})
-
-			By("creating a pubsub topic", func() {
-				topic = e2epubsub.CreateTopic(pubsubClient, f)
-			})
-
-			By("creating a pubsub subscription", func() {
-				subscription = e2epubsub.CreateSubscription(pubsubClient, topic, f)
-			})
-
-			By("creating a GoogleCloudPubSub object", func() {
-				src, err := createSource(srcClient, ns, "test-", sink,
-					withTopic(topic.String()),
-					withSubscription(subscription),
-					withCredentials(saKey),
-				)
-				Expect(err).ToNot(HaveOccurred())
-				ducktypes.WaitUntilReady(f.DynamicClient, src)
-			})
+			When("a message is sent to the topic", SendMessageAndAssertReceivedEvent())
 		})
 
-		AfterEach(func() {
-			By("deleting pubsub topic "+topic.String(), func() {
-				e2epubsub.DeleteTopic(pubsubClient, topic)
-			})
-		})
-
-		When("a message is sent to the topic", func() {
-			var msgID string
+		Context("the subscription is managed by the user", func() {
+			var subscriptionID string
 
 			BeforeEach(func() {
-				msgID = e2epubsub.SendMessage(pubsubClient, topic, f)
+				By("creating a Pub/Sub subscription", func() {
+					subscriptionID = e2epubsub.CreateSubscription(pubsubClient, topic, f).ID()
+				})
+
+				By("creating a GoogleCloudPubSubSource object", func() {
+					src, err := createSource(srcClient, ns, "test-", sink,
+						withTopic(topic.String()),
+						withSubscriptionID(subscriptionID),
+						withServiceAccountKey(saKey),
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					ducktypes.WaitUntilReady(f.DynamicClient, src)
+				})
 			})
 
-			Specify("the source generates an event", func() {
-				const receiveTimeout = 15 * time.Second
-				const pollInterval = 500 * time.Millisecond
-
-				var receivedEvents []cloudevents.Event
-
-				readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
-
-				Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
-				Expect(receivedEvents).To(HaveLen(1))
-
-				e := receivedEvents[0]
-
-				Expect(e.Type()).To(Equal("com.google.cloud.pubsub.message"))
-				Expect(e.ID()).To(Equal(msgID))
-				Expect(e.Source()).To(Equal(topic.String()))
+			AfterEach(func() {
+				By("deleting the Pub/Sub subscription "+subscriptionID, func() {
+					e2epubsub.DeleteSubscription(pubsubClient, subscriptionID)
+				})
 			})
+
+			When("a message is sent to the topic", SendMessageAndAssertReceivedEvent())
 		})
 	})
 
@@ -235,7 +209,7 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 
 				_, err := createSource(srcClient, ns, "test-invalid-topic-", sink,
 					withTopic(invalidTopic),
-					withCredentials(saKey),
+					withServiceAccountKey(saKey),
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("spec.topic: Invalid value: "))
@@ -245,7 +219,7 @@ var _ = Describe("Google Cloud Pub/Sub source", func() {
 	})
 })
 
-// createSource creates an GoogleCloudPubSub object initialized with the given options.
+// createSource creates a GoogleCloudPubSubSource object initialized with the given options.
 func createSource(srcClient dynamic.ResourceInterface, namespace, namePrefix string,
 	sink *duckv1.Destination, opts ...sourceOption) (*unstructured.Unstructured, error) {
 
@@ -276,20 +250,18 @@ func withTopic(topic string) sourceOption {
 	}
 }
 
-func withSubscription(subscription string) sourceOption {
+func withSubscriptionID(subscriptionID string) sourceOption {
 	return func(src *unstructured.Unstructured) {
-		if err := unstructured.SetNestedField(src.Object, subscription, "spec", "subscription"); err != nil {
-			framework.FailfWithOffset(3, "Failed to set spec.subscription field: %s", err)
+		if err := unstructured.SetNestedField(src.Object, subscriptionID, "spec", "subscriptionID"); err != nil {
+			framework.FailfWithOffset(3, "Failed to set spec.subscriptionID field: %s", err)
 		}
 	}
 }
 
-func withCredentials(creds string) sourceOption {
-	c := map[string]interface{}{"value": creds}
-
+func withServiceAccountKey(key string) sourceOption {
 	return func(src *unstructured.Unstructured) {
-		if err := unstructured.SetNestedField(src.Object, c, "spec", "serviceAccountKey"); err != nil {
-			framework.FailfWithOffset(3, "Failed to set spec.serviceAccountKey field: %s", err)
+		if err := unstructured.SetNestedField(src.Object, key, "spec", "serviceAccountKey", "value"); err != nil {
+			framework.FailfWithOffset(3, "Failed to set spec.serviceAccountKey.value field: %s", err)
 		}
 	}
 }

--- a/test/e2e/sources/googlecloudrepositories/main.go
+++ b/test/e2e/sources/googlecloudrepositories/main.go
@@ -58,9 +58,6 @@ var sourceAPIVersion = schema.GroupVersion{
 const (
 	sourceKind     = "GoogleCloudRepositoriesSource"
 	sourceResource = "googlecloudrepositoriessources"
-
-	credsEnvVar   = "GCLOUD_SERVICEACCOUNT_KEY"
-	projectEnvVar = "GCLOUD_PROJECT"
 )
 
 var _ = Describe("Google Cloud Repositories source", func() {
@@ -89,8 +86,8 @@ var _ = Describe("Google Cloud Repositories source", func() {
 		var err error
 
 		BeforeEach(func() {
-			saKey = e2egcloud.GetCreds(credsEnvVar)
-			project = "projects/" + e2egcloud.GetProject(projectEnvVar)
+			saKey = e2egcloud.ServiceAccountKeyFromEnv()
+			project = "projects/" + e2egcloud.ProjectNameFromEnv()
 			repoClient, err = sourcerepo.NewService(context.Background(), option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/sources/googlecloudstorage/main.go
+++ b/test/e2e/sources/googlecloudstorage/main.go
@@ -58,9 +58,6 @@ var sourceAPIVersion = schema.GroupVersion{
 const (
 	sourceKind     = "GoogleCloudStorageSource"
 	sourceResource = "googlecloudstoragesources"
-
-	credsEnvVar   = "GCLOUD_SERVICEACCOUNT_KEY"
-	projectEnvVar = "GCLOUD_PROJECT"
 )
 
 var _ = Describe("Google Cloud Storage source", func() {
@@ -91,8 +88,8 @@ var _ = Describe("Google Cloud Storage source", func() {
 		var err error
 
 		BeforeEach(func() {
-			saKey = e2egcloud.GetCreds(credsEnvVar)
-			project = e2egcloud.GetProject(projectEnvVar)
+			saKey = e2egcloud.ServiceAccountKeyFromEnv()
+			project = e2egcloud.ProjectNameFromEnv()
 			storageClient, err = storage.NewClient(context.Background(), option.WithCredentialsJSON([]byte(saKey)))
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
While migrating E2E tests in #357, I noticed a few issues / possible improvements with the test suite for the Google Cloud Pub/Sub source:

- The test case where the Pub/Sub subscription is provided by the user...
  - ... does not clean up the subscription at the end of the test ([code](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/test/e2e/sources/googlecloudpubsub/main.go#L181-L185))
  - ... sets `spec.subscription` while the attribute is called `spec.subscriptionID` ([code](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/test/e2e/sources/googlecloudpubsub/main.go#L284-L285), [spec](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/config/300-googlecloudpubsubsource.yaml#L60-L65))

- The same setup steps and test logic were duplicated ([code](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/test/e2e/sources/googlecloudpubsub/main.go#L91-L113), [code](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/test/e2e/sources/googlecloudpubsub/main.go#L187-L211)).
  - _solution:_
    - I nested the two tests under a common test context, so they can use shared setup steps (`BeforeEach`).
    - I moved the test logic to a closure (`SendMessageAndAssertReceivedEvent`), as demonstrated in the [Ginkgo docs](https://onsi.github.io/ginkgo/#locally-scoped-shared-behaviors).

- Some variable names weren't explicit about what they represent.
  - _solution:_ append `Name` when something represents a _Resource Name_, `ID` when something represents an ID

- Every Google Cloud test was re-declaring common own environment variables ([code](https://github.com/triggermesh/triggermesh/blob/1d8390e2bbe5fb30ec9dbe62fc2b8f67747a477c/test/e2e/sources/googlecloudpubsub/main.go#L62-L63)).
  - _solution:_ I moved the variables to the framework's `gcloud` package, and simplified the contract with `ServiceAccountKeyFromEnv()` and `ProjectnameFromEnv()` helpers that do not require any parameter.

- Misc:
  - Some helpers were accepting a `Topic` struct (client) while only the topic ID was required.
  - Added more test cases for invalid specs (empty creds, invalid subscription ID, empty topic name)