### PR TITLE
Add missing `MarkSubscribed` to Pub/Sub reconciliation

### DIFF
--- a/pkg/sources/reconciler/googlecloudpubsubsource/subscription.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/subscription.go
@@ -99,6 +99,7 @@ func ensureSubscription(ctx context.Context, cli *pubsub.Client) error {
 		// here, otherwise BuildAdapter() won't be able to configure
 		// the Pub/Sub adapter properly
 		status.Subscription = makeSubscriptionResourceName(topicResName.Project, *userProvided)
+		status.MarkSubscribed()
 
 		return nil
 	}


### PR DESCRIPTION
Fixes #378

I forgot to mark the source as "Subscribed" in the special case where the user provides their own Pub/Sub subscription (as opposed to letting the source create/reconcile a subscription).