### PR TITLE
Restructure Google Cloud Storage test suite

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -35,7 +35,7 @@ import (
 type Framework struct {
 	// Test identifiers
 	baseName   string // e.g. "mytest"
-	UniqueName string // e.g. "mytest-1234"
+	UniqueName string // e.g. "e2e-mytest-1234"
 
 	// Test context
 	namespacesToDelete []*corev1.Namespace


### PR DESCRIPTION
While migrating E2E tests in #357, I noticed a few issues / possible improvements with the test suite for the Google Cloud Storage source:

- An actual file is created inside `/tmp` on the local filesystem of the host running the test, but that file isn't relevant for creating/updating the object inside the storage bucket.
- The test bucket has multi-region enabled. Single-region is enough in tests, and cheaper.
- The source object is being manually deleted at the end of the test. This is not necessary because the entire namespace gets automatically deleted by the test framework.

On top of addressing the above:

- I made a few variable names clearer by adding `Name` or `ID` suffixes where relevant.
- I added a few test cases to assert that invalid/missing spec attributes are properly rejected.