### PR TITLE
Do not erase status fields on MarkNotSubscribed

### DIFF
--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -122,7 +122,6 @@ func (s *AWSSNSSourceStatus) MarkSubscribed(subARN string) {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and associated message.
 func (s *AWSSNSSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.SubscriptionARN = nil
 	awsSNSSourceConditionSet.Manage(s).MarkFalse(AWSSNSConditionSubscribed,
 		reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
@@ -118,6 +118,5 @@ func (s *AzureBlobStorageSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *AzureBlobStorageSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.EventHubID = nil
 	azureBlobStorageSourceConditionSet.Manage(s).MarkFalse(AzureBlobStorageConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
@@ -102,7 +102,5 @@ func (s *AzureEventGridSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *AzureEventGridSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.EventSubscriptionID = nil
-	s.EventHubID = nil
 	azureEventGridSourceConditionSet.Manage(s).MarkFalse(AzureEventGridConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
@@ -85,6 +85,5 @@ func (s *AzureServiceBusTopicSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *AzureServiceBusTopicSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.SubscriptionID = nil
 	azureServiceBusTopicSourceConditionSet.Manage(s).MarkFalse(AzureServiceBusTopicConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
@@ -88,8 +88,5 @@ func (s *GoogleCloudAuditLogsSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *GoogleCloudAuditLogsSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.AuditLogsSink = nil
-	s.Topic = nil
-	s.Subscription = nil
 	GoogleCloudAuditLogsSourceConditionSet.Manage(s).MarkFalse(GoogleCloudAuditLogsConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
@@ -88,7 +88,5 @@ func (s *GoogleCloudBillingSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *GoogleCloudBillingSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.Topic = nil
-	s.Subscription = nil
 	GoogleCloudBillingSourceConditionSet.Manage(s).MarkFalse(GoogleCloudBillingConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
@@ -88,7 +88,5 @@ func (s *GoogleCloudIoTSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *GoogleCloudIoTSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.Topic = nil
-	s.Subscription = nil
 	googleCloudIoTSourceConditionSet.Manage(s).MarkFalse(GoogleCloudIoTConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
@@ -88,7 +88,5 @@ func (s *GoogleCloudSourceRepositoriesSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *GoogleCloudSourceRepositoriesSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.Topic = nil
-	s.Subscription = nil
 	googleCloudSourceRepoSourceConditionSet.Manage(s).MarkFalse(GoogleCloudSourceRepoConditionSubscribed, reason, msg)
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
@@ -88,8 +88,5 @@ func (s *GoogleCloudStorageSourceStatus) MarkSubscribed() {
 // MarkNotSubscribed sets the Subscribed condition to False with the given
 // reason and message.
 func (s *GoogleCloudStorageSourceStatus) MarkNotSubscribed(reason, msg string) {
-	s.NotificationID = nil
-	s.Topic = nil
-	s.Subscription = nil
 	googleCloudStorageSourceConditionSet.Manage(s).MarkFalse(GoogleCloudStorageConditionSubscribed, reason, msg)
 }


### PR DESCRIPTION
Fixes #403
Related to #392 (but this one requires an additional change in the finalizer logic)

If the observed resource is deleted before the source object is deleted, these fields are `nil` while entering the finalizer. As a result, all previously reconciled Pub/Sub resources get ignored instead of being properly cleaned up.

Generally speaking, it is not useful to erase these fields (I'm the one to blame for thinking this would be a good idea). Status conditions already convey that an error occurred, and leaving status fields untouched is a good indicator that something was reconciled, at some point (as opposed to a reconciliation that never succeeded).