### PR TITLE
Revert to release version of event-display image

### DIFF
--- a/test/e2e/framework/bridges/sink.go
+++ b/test/e2e/framework/bridges/sink.go
@@ -44,9 +44,8 @@ import (
 )
 
 const (
-	eventDisplayName = "event-display"
-	// using a nightly image because versions prior to v0.25 (unreleased) don't expose "/healthz"
-	eventDisplayContainerImage = "gcr.io/knative-nightly/knative.dev/eventing/cmd/event_display@sha256:e1a70eabf59345a4b160f007cbfd121ef2aca6e0921fa81c79495c236a9f2d7b"
+	eventDisplayName           = "event-display"
+	eventDisplayContainerImage = "gcr.io/knative-releases/knative.dev/eventing/cmd/event_display"
 )
 
 // CreateEventDisplaySink creates an event-display event sink and returns it as


### PR DESCRIPTION
We had to fast forward the image version of Knative's `event-display` at some point (ref. https://github.com/triggermesh/test-infra/pull/100) because we needed to ensure that it was actually listening before sending events to it. This required the addition of a health probe upstream.

The health probe was officially added in Knative v0.25, therefore we can revert the aforementioned change, and use release images instead of nightlies again.