### PR TITLE
Treat empty AWS credentials as a denied access

### DIFF
--- a/pkg/sources/reconciler/awss3source/bucket.go
+++ b/pkg/sources/reconciler/awss3source/bucket.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -240,6 +241,10 @@ func isNotFound(err error) bool {
 // API could not be authorized.
 func isDenied(err error) bool {
 	if awsErr := awserr.Error(nil); errors.As(err, &awsErr) {
+		if awsErr == credentials.ErrStaticCredentialsEmpty {
+			return true
+		}
+
 		if awsReqFail := awserr.RequestFailure(nil); errors.As(err, &awsReqFail) {
 			code := awsReqFail.StatusCode()
 			return code == http.StatusUnauthorized || code == http.StatusForbidden

--- a/pkg/sources/reconciler/awssnssource/subscription.go
+++ b/pkg/sources/reconciler/awssnssource/subscription.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 
@@ -334,6 +335,10 @@ func isNotFound(err error) bool {
 // API could not be authorized.
 func isDenied(err error) bool {
 	if awsErr := awserr.Error(nil); errors.As(err, &awsErr) {
+		if awsErr == credentials.ErrStaticCredentialsEmpty {
+			return true
+		}
+
 		if awsReqFail := awserr.RequestFailure(nil); errors.As(err, &awsReqFail) {
 			code := awsReqFail.StatusCode()
 			return code == http.StatusUnauthorized || code == http.StatusForbidden

--- a/pkg/sources/reconciler/awssnssource/subscription_test.go
+++ b/pkg/sources/reconciler/awssnssource/subscription_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/sns"
 )
 
@@ -48,9 +49,13 @@ func TestErrors(t *testing.T) {
 			return awserr.NewRequestFailure(genericAWSErr, httpCode, "00000000-0000-...")
 		}
 
+		emptyStaticCredsErr := credentials.ErrStaticCredentialsEmpty
+
 		assert.True(t, isDenied(deniedErr))
 		assert.True(t, isDenied(fmt.Errorf("wrapped: %w", deniedErr)))
 		assert.True(t, isDenied(reqFailErr(http.StatusUnauthorized)))
+		assert.True(t, isDenied(emptyStaticCredsErr))
+		assert.True(t, isDenied(fmt.Errorf("wrapped: %w", emptyStaticCredsErr)))
 		assert.False(t, isDenied(genericAWSErr))
 		assert.False(t, isDenied(genericErr))
 		assert.False(t, isDenied(reqFailErr(http.StatusBadRequest)))


### PR DESCRIPTION
Fixes #411

A different error is returned when static credentials are being used, and these credentials are empty.
We need to treat this edge case as an access denied (exactly like malformed credentials, for example).