### PR TITLE
IBM MQ build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,6 @@ jobs:
           environment:
             KO_DOCKER_REPO: gcr.io/triggermesh
             DIST_DIR: /tmp/dist/
-            DOCKER_BUILDKIT: 1
       - persist_to_workspace:
           root: /tmp/
           paths:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,6 +42,7 @@ jobs:
       with:
         languages: go
 
+    # Install IBM MQ redis client required by IBM MQ source and target adapters
     - name: Install IBM MQ client
       run: |
         curl https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.3.0-IBM-MQC-Redist-LinuxX64.tar.gz -o mq.tar.gz

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,6 +42,12 @@ jobs:
       with:
         languages: go
 
+    - name: Install IBM MQ client
+      run: |
+        curl https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.3.0-IBM-MQC-Redist-LinuxX64.tar.gz -o mq.tar.gz
+        mkdir -p /opt/mqm
+        tar -C /opt/mqm -xzf mq.tar.gz
+
     # The code compiled in this step is also the one being analyzed in the next
     # step, due to build tracing being enabled via the CODEQL_EXTRACTOR_GO_BUILD_TRACING
     # environment variable.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,8 @@ linters:
 
 run:
   timeout: 10m
+  build-tags:
+    - codeanalysis
 
 linters-settings:
   stylecheck:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,7 @@ linters:
 run:
   timeout: 10m
   build-tags:
-    - codeanalysis
+  - noclibs
 
 linters-settings:
   stylecheck:

--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.3
-
 FROM golang:bullseye as builder
 
 RUN apt-get update && \
@@ -21,8 +19,7 @@ RUN go mod download
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter 
+RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter 
 
 
 FROM debian:stable-slim

--- a/cmd/ibmmqsource-adapter/main.go
+++ b/cmd/ibmmqsource-adapter/main.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/cmd/ibmmqsource-adapter/main.go
+++ b/cmd/ibmmqsource-adapter/main.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.3
-
 FROM golang:bullseye as builder
 
 RUN apt-get update && \
@@ -21,8 +19,7 @@ RUN go mod download
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget-adapter 
+RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget-adapter 
 
 
 FROM debian:stable-slim

--- a/cmd/ibmmqtarget-adapter/main.go
+++ b/cmd/ibmmqtarget-adapter/main.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/cmd/ibmmqtarget-adapter/main.go
+++ b/cmd/ibmmqtarget-adapter/main.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/sources/adapter/ibmmqsource/config.go
+++ b/pkg/sources/adapter/ibmmqsource/config.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/sources/adapter/ibmmqsource/config.go
+++ b/pkg/sources/adapter/ibmmqsource/config.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/sources/adapter/ibmmqsource/mq/config.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/config.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/sources/adapter/ibmmqsource/mq/config.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/config.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/targets/adapter/ibmmqtarget/adapter.go
+++ b/pkg/targets/adapter/ibmmqtarget/adapter.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/targets/adapter/ibmmqtarget/adapter.go
+++ b/pkg/targets/adapter/ibmmqtarget/adapter.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/targets/adapter/ibmmqtarget/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/config.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/targets/adapter/ibmmqtarget/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/config.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/targets/adapter/ibmmqtarget/mq/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/config.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/targets/adapter/ibmmqtarget/mq/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/config.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 

--- a/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
@@ -1,4 +1,4 @@
-//go:build !codeanalysis
+//go:build !noclibs
 
 /*
 Copyright 2021 TriggerMesh Inc.

--- a/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 /*
 Copyright 2021 TriggerMesh Inc.
 


### PR DESCRIPTION
In this PR:

- Buildkit cache disabled to prevent building IBM images with the same binary for the source and the target adapters. The reason for that behavior is not completely clear since we're using cache for go modules only, but the result is reproducible. An example of the CI job with the "Cached" build:
  https://app.circleci.com/pipelines/github/triggermesh/triggermesh/994/workflows/b26c1c56-0d3e-465d-ab4a-7e54d54c6990/jobs/2633?invite=true#step-112-4838
  Ideally, we should bring this cache back as it drastically improves the build time, but for now, to get the working adapter images in the registry we can get rid of it

- Added IBM MQ redis client installation to CodeQL workflow to run analysis in the IBM adapters code

- Golangci's Linter job uses `codeanalysis` build tag to be able to skip analysis on the certain packages