### PR TITLE
Remove unnecessary interface check on `runtime.Object`

### DIFF
--- a/pkg/apis/routing/v1alpha1/filter_types.go
+++ b/pkg/apis/routing/v1alpha1/filter_types.go
@@ -18,9 +18,9 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/kmeta"
 )
 
 // +genclient
@@ -45,14 +45,11 @@ type Filter struct {
 
 var (
 	// Check that Filter can be validated and defaulted.
-	_ apis.Validatable   = (*Filter)(nil)
-	_ apis.Defaultable   = (*Filter)(nil)
-	_ kmeta.OwnerRefable = (*Filter)(nil)
-	// Check that the type conforms to the duck Knative Resource shape.
-	_ duckv1.KRShaped = (*Filter)(nil)
-	_ multiTenant     = (*Filter)(nil)
+	_ apis.Validatable = (*Filter)(nil)
+	_ apis.Defaultable = (*Filter)(nil)
 
-	_ Router = (*Filter)(nil)
+	_ Router      = (*Filter)(nil)
+	_ multiTenant = (*Filter)(nil)
 )
 
 // FilterSpec contains CEL expression string and the destination sink

--- a/pkg/apis/routing/v1alpha1/splitter_types.go
+++ b/pkg/apis/routing/v1alpha1/splitter_types.go
@@ -18,9 +18,9 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/kmeta"
 )
 
 // +genclient
@@ -45,14 +45,11 @@ type Splitter struct {
 
 var (
 	// Check that Splitter can be validated and defaulted.
-	_ apis.Validatable   = (*Splitter)(nil)
-	_ apis.Defaultable   = (*Splitter)(nil)
-	_ kmeta.OwnerRefable = (*Splitter)(nil)
-	// Check that the type conforms to the duck Knative Resource shape.
-	_ duckv1.KRShaped = (*Splitter)(nil)
-	_ multiTenant     = (*Splitter)(nil)
+	_ apis.Validatable = (*Splitter)(nil)
+	_ apis.Defaultable = (*Splitter)(nil)
 
-	_ Router = (*Splitter)(nil)
+	_ Router      = (*Splitter)(nil)
+	_ multiTenant = (*Splitter)(nil)
 )
 
 // SplitterSpec holds the desired state of the Splitter.

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSCloudWatchSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSCloudWatchSource)(nil)
-	_ EventSource    = (*AWSCloudWatchSource)(nil)
+	_ EventSource = (*AWSCloudWatchSource)(nil)
 )
 
 // AWSCloudWatchSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSCloudWatchLogsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSCloudWatchLogsSource)(nil)
-	_ EventSource    = (*AWSCloudWatchLogsSource)(nil)
+	_ EventSource = (*AWSCloudWatchLogsSource)(nil)
 )
 
 // AWSCloudWatchLogsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awscodecommit_types.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSCodeCommitSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSCodeCommitSource)(nil)
-	_ EventSource    = (*AWSCodeCommitSource)(nil)
+	_ EventSource = (*AWSCodeCommitSource)(nil)
 )
 
 // AWSCodeCommitSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSCognitoIdentitySource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSCognitoIdentitySource)(nil)
-	_ EventSource    = (*AWSCognitoIdentitySource)(nil)
+	_ EventSource = (*AWSCognitoIdentitySource)(nil)
 )
 
 // AWSCognitoIdentitySourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSCognitoUserPoolSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSCognitoUserPoolSource)(nil)
-	_ EventSource    = (*AWSCognitoUserPoolSource)(nil)
+	_ EventSource = (*AWSCognitoUserPoolSource)(nil)
 )
 
 // AWSCognitoUserPoolSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSDynamoDBSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSDynamoDBSource)(nil)
-	_ EventSource    = (*AWSDynamoDBSource)(nil)
+	_ EventSource = (*AWSDynamoDBSource)(nil)
 )
 
 // AWSDynamoDBSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awskinesis_types.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSKinesisSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSKinesisSource)(nil)
-	_ EventSource    = (*AWSKinesisSource)(nil)
+	_ EventSource = (*AWSKinesisSource)(nil)
 )
 
 // AWSKinesisSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSPerformanceInsightsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSPerformanceInsightsSource)(nil)
-	_ EventSource    = (*AWSPerformanceInsightsSource)(nil)
+	_ EventSource = (*AWSPerformanceInsightsSource)(nil)
 )
 
 // AWSPerformanceInsightsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,8 +38,7 @@ type AWSS3Source struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AWSS3Source)(nil)
-	_ EventSource    = (*AWSS3Source)(nil)
+	_ EventSource = (*AWSS3Source)(nil)
 )
 
 // AWSS3SourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -28,11 +28,6 @@ func (s *AWSSNSSource) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("AWSSNSSource")
 }
 
-// GetUntypedSpec implements apis.HasSpec.
-func (s *AWSSNSSource) GetUntypedSpec() interface{} {
-	return s.Spec
-}
-
 // GetConditionSet implements duckv1.KRShaped.
 func (s *AWSSNSSource) GetConditionSet() apis.ConditionSet {
 	return awsSNSSourceConditionSet

--- a/pkg/apis/sources/v1alpha1/awssns_types.go
+++ b/pkg/apis/sources/v1alpha1/awssns_types.go
@@ -18,9 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	pkgapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -41,10 +38,8 @@ type AWSSNSSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object  = (*AWSSNSSource)(nil)
-	_ pkgapis.HasSpec = (*AWSSNSSource)(nil)
-	_ EventSource     = (*AWSSNSSource)(nil)
-	_ multiTenant     = (*AWSSNSSource)(nil)
+	_ EventSource = (*AWSSNSSource)(nil)
+	_ multiTenant = (*AWSSNSSource)(nil)
 )
 
 // AWSSNSSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
@@ -40,7 +38,6 @@ type AWSSQSSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object         = (*AWSSQSSource)(nil)
 	_ EventSource            = (*AWSSQSSource)(nil)
 	_ serviceAccountProvider = (*AWSSQSSource)(nil)
 )

--- a/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
+++ b/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureActivityLogsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureActivityLogsSource)(nil)
-	_ EventSource    = (*AzureActivityLogsSource)(nil)
+	_ EventSource = (*AzureActivityLogsSource)(nil)
 )
 
 // AzureActivityLogsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -44,8 +42,7 @@ type AzureBlobStorageSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureBlobStorageSource)(nil)
-	_ EventSource    = (*AzureBlobStorageSource)(nil)
+	_ EventSource = (*AzureBlobStorageSource)(nil)
 )
 
 // AzureBlobStorageSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureEventGridSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureEventGridSource)(nil)
-	_ EventSource    = (*AzureEventGridSource)(nil)
+	_ EventSource = (*AzureEventGridSource)(nil)
 )
 
 // AzureEventGridSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureeventhub_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventhub_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureEventHubSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureEventHubSource)(nil)
-	_ EventSource    = (*AzureEventHubSource)(nil)
+	_ EventSource = (*AzureEventHubSource)(nil)
 )
 
 // AzureEventHubSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureiothubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/azureiothubsource_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureIOTHubSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureIOTHubSource)(nil)
-	_ EventSource    = (*AzureIOTHubSource)(nil)
+	_ EventSource = (*AzureIOTHubSource)(nil)
 )
 
 // AzureIOTHubSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureQueueStorageSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureQueueStorageSource)(nil)
-	_ EventSource    = (*AzureQueueStorageSource)(nil)
+	_ EventSource = (*AzureQueueStorageSource)(nil)
 )
 
 // AzureQueueStorageSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureservicebusqueue_types.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebusqueue_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureServiceBusQueueSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureServiceBusQueueSource)(nil)
-	_ EventSource    = (*AzureServiceBusQueueSource)(nil)
+	_ EventSource = (*AzureServiceBusQueueSource)(nil)
 )
 
 // AzureServiceBusQueueSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_types.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type AzureServiceBusTopicSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*AzureServiceBusTopicSource)(nil)
-	_ EventSource    = (*AzureServiceBusTopicSource)(nil)
+	_ EventSource = (*AzureServiceBusTopicSource)(nil)
 )
 
 // AzureServiceBusTopicSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type GoogleCloudAuditLogsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudAuditLogsSource)(nil)
-	_ EventSource    = (*GoogleCloudAuditLogsSource)(nil)
+	_ EventSource = (*GoogleCloudAuditLogsSource)(nil)
 )
 
 // GoogleCloudAuditLogsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type GoogleCloudBillingSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudBillingSource)(nil)
-	_ EventSource    = (*GoogleCloudBillingSource)(nil)
+	_ EventSource = (*GoogleCloudBillingSource)(nil)
 )
 
 // GoogleCloudBillingSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -44,8 +42,7 @@ type GoogleCloudIoTSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudIoTSource)(nil)
-	_ EventSource    = (*GoogleCloudIoTSource)(nil)
+	_ EventSource = (*GoogleCloudIoTSource)(nil)
 )
 
 // GoogleCloudIoTSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type GoogleCloudPubSubSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudPubSubSource)(nil)
-	_ EventSource    = (*GoogleCloudPubSubSource)(nil)
+	_ EventSource = (*GoogleCloudPubSubSource)(nil)
 )
 
 // GoogleCloudPubSubSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type GoogleCloudSourceRepositoriesSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudSourceRepositoriesSource)(nil)
-	_ EventSource    = (*GoogleCloudSourceRepositoriesSource)(nil)
+	_ EventSource = (*GoogleCloudSourceRepositoriesSource)(nil)
 )
 
 // GoogleCloudSourceRepositoriesSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type GoogleCloudStorageSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*GoogleCloudStorageSource)(nil)
-	_ EventSource    = (*GoogleCloudStorageSource)(nil)
+	_ EventSource = (*GoogleCloudStorageSource)(nil)
 )
 
 // GoogleCloudStorageSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/httppollersource_types.go
+++ b/pkg/apis/sources/v1alpha1/httppollersource_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -41,8 +40,7 @@ type HTTPPollerSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*HTTPPollerSource)(nil)
-	_ EventSource    = (*HTTPPollerSource)(nil)
+	_ EventSource = (*HTTPPollerSource)(nil)
 )
 
 // HTTPPollerSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/ibmmq_types.go
+++ b/pkg/apis/sources/v1alpha1/ibmmq_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -37,8 +36,7 @@ type IBMMQSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*IBMMQSource)(nil)
-	_ EventSource    = (*IBMMQSource)(nil)
+	_ EventSource = (*IBMMQSource)(nil)
 )
 
 // IBMMQSourceSpec holds the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/ocimetricssource_types.go
+++ b/pkg/apis/sources/v1alpha1/ocimetricssource_types.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -41,8 +39,7 @@ type OCIMetricsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*OCIMetricsSource)(nil)
-	_ EventSource    = (*OCIMetricsSource)(nil)
+	_ EventSource = (*OCIMetricsSource)(nil)
 )
 
 // OCIMetricsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/salesforce_types.go
+++ b/pkg/apis/sources/v1alpha1/salesforce_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type SalesforceSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*SalesforceSource)(nil)
-	_ EventSource    = (*SalesforceSource)(nil)
+	_ EventSource = (*SalesforceSource)(nil)
 )
 
 // SalesforceSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/slacksource_types.go
+++ b/pkg/apis/sources/v1alpha1/slacksource_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type SlackSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*SlackSource)(nil)
-	_ EventSource    = (*SlackSource)(nil)
+	_ EventSource = (*SlackSource)(nil)
 )
 
 // SlackSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/twiliosource_types.go
+++ b/pkg/apis/sources/v1alpha1/twiliosource_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type TwilioSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*TwilioSource)(nil)
-	_ EventSource    = (*TwilioSource)(nil)
+	_ EventSource = (*TwilioSource)(nil)
 )
 
 // TwilioSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/webhooksource_types.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_types.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,8 +36,7 @@ type WebhookSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object = (*WebhookSource)(nil)
-	_ EventSource    = (*WebhookSource)(nil)
+	_ EventSource = (*WebhookSource)(nil)
 )
 
 // WebhookSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
@@ -28,11 +28,6 @@ func (*ZendeskSource) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("ZendeskSource")
 }
 
-// GetUntypedSpec implements apis.HasSpec.
-func (s *ZendeskSource) GetUntypedSpec() interface{} {
-	return s.Spec
-}
-
 // GetConditionSet implements duckv1.KRShaped.
 func (*ZendeskSource) GetConditionSet() apis.ConditionSet {
 	return zendeskSourceConditionSet

--- a/pkg/apis/sources/v1alpha1/zendesksource_types.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_types.go
@@ -18,9 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	pkgapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -39,10 +36,8 @@ type ZendeskSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ runtime.Object  = (*ZendeskSource)(nil)
-	_ pkgapis.HasSpec = (*ZendeskSource)(nil)
-	_ EventSource     = (*ZendeskSource)(nil)
-	_ multiTenant     = (*ZendeskSource)(nil)
+	_ EventSource = (*ZendeskSource)(nil)
+	_ multiTenant = (*ZendeskSource)(nil)
 )
 
 // ZendeskSourceSpec defines the desired state of the event source.

--- a/pkg/sources/reconciler/zendesksource/zendesk.go
+++ b/pkg/sources/reconciler/zendesksource/zendesk.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	pkgapis "knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 
@@ -60,7 +59,7 @@ func (r *Reconciler) ensureZendeskTargetAndTrigger(ctx context.Context) error {
 		return nil
 	}
 
-	spec := src.(pkgapis.HasSpec).GetUntypedSpec().(v1alpha1.ZendeskSourceSpec)
+	spec := src.(*v1alpha1.ZendeskSource).Spec
 
 	sg := secret.NewGetter(r.secretClient(src.GetNamespace()))
 
@@ -255,7 +254,7 @@ func (r *Reconciler) ensureNoZendeskTargetAndTrigger(ctx context.Context) error 
 
 	title := targetTitle(src)
 
-	spec := src.(pkgapis.HasSpec).GetUntypedSpec().(v1alpha1.ZendeskSourceSpec)
+	spec := src.(*v1alpha1.ZendeskSource).Spec
 
 	sg := secret.NewGetter(r.secretClient(src.GetNamespace()))
 


### PR DESCRIPTION
`runtime.Object` is already part of the `EventSource` interface, so we have a double assertion.