### PR TITLE
List env vars required by the AWS SDK for documentation purposes

### DIFF
--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -46,6 +46,12 @@ type envConfig struct {
 	ARN string `envconfig:"ARN"`
 
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"` // free tier is 5m
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -46,6 +46,12 @@ type envConfig struct {
 
 	Query           string `envconfig:"QUERIES" required:"true"`          // JSON based array of name/query pairs
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"` // free tier is 5m
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awscodecommitsource/adapter.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter.go
@@ -57,6 +57,12 @@ type envConfig struct {
 	ARN           string `envconfig:"ARN" required:"true"`
 	Branch        string `envconfig:"BRANCH" required:"true"`
 	GitEventTypes string `envconfig:"EVENT_TYPES" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter.go
@@ -45,6 +45,12 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
@@ -46,6 +46,12 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -60,6 +60,12 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awskinesissource/adapter.go
+++ b/pkg/sources/adapter/awskinesissource/adapter.go
@@ -46,6 +46,12 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -49,6 +49,12 @@ type envConfig struct {
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"`
 
 	Metrics []string `envconfig:"PI_METRICS" required:"true"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.

--- a/pkg/sources/adapter/awssqssource/adapter.go
+++ b/pkg/sources/adapter/awssqssource/adapter.go
@@ -64,6 +64,12 @@ type envConfig struct {
 	// Visibility timeout to set on all messages received by this event source.
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
 	VisibilityTimeout *time.Duration `envconfig:"SQS_VISIBILITY_TIMEOUT"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the AWS SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"AWS_ACCESS_KEY_ID"`
+	_ string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 // adapter implements the source's adapter.


### PR DESCRIPTION
Documents the environment variables described at https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Environment_Variables