### PR TITLE
Do not set core CE attributes via `ceOverrides`

### DIFF
--- a/pkg/sources/adapter/azureeventhubsource/adapter_test.go
+++ b/pkg/sources/adapter/azureeventhubsource/adapter_test.go
@@ -32,6 +32,9 @@ import (
 )
 
 func TestHandleMessage(t *testing.T) {
+	const ceSource = "fake.source"
+	const ceType = "fake.type"
+
 	testCases := []struct {
 		name            string
 		eventData       []byte
@@ -68,7 +71,10 @@ func TestHandleMessage(t *testing.T) {
 				},
 				logger:   loggingtesting.TestLogger(t),
 				ceClient: ceClient,
-				msgPrcsr: &defaultMessageProcessor{},
+				msgPrcsr: &defaultMessageProcessor{
+					ceSource: ceSource,
+					ceType:   ceType,
+				},
 			}
 
 			err := a.handleMessage(context.Background(), &event)
@@ -80,6 +86,9 @@ func TestHandleMessage(t *testing.T) {
 			// ensure the sent event has the expected encoding (base64 / raw JSON)
 			eventDataStr := extractDataFromEvent(t, events[0].Data())
 			assert.Equal(t, tc.expectEventData, eventDataStr)
+
+			assert.Equal(t, ceSource, events[0].Source())
+			assert.Equal(t, ceType, events[0].Type())
 		})
 	}
 }

--- a/pkg/sources/adapter/googlecloudpubsubsource/process.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/process.go
@@ -23,8 +23,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"cloud.google.com/go/pubsub"
-
-	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 )
 
 // MessageProcessor converts a Pub/Sub message to a CloudEvent.
@@ -39,11 +37,12 @@ var (
 // defaultMessageProcessor is the default processor for Pub/Sub messages.
 type defaultMessageProcessor struct {
 	ceSource string
+	ceType   string
 }
 
 // Process implements MessageProcessor.
 func (p *defaultMessageProcessor) Process(msg *pubsub.Message) ([]*cloudevents.Event, error) {
-	event, err := makePubSubEvent(msg, p.ceSource)
+	event, err := makePubSubEvent(msg, p.ceSource, p.ceType)
 	if err != nil {
 		return nil, fmt.Errorf("creating CloudEvent from Pub/Sub message: %w", err)
 	}
@@ -52,12 +51,12 @@ func (p *defaultMessageProcessor) Process(msg *pubsub.Message) ([]*cloudevents.E
 }
 
 // makePubSubEvent returns a CloudEvent for a generic Pub/Sub message.
-func makePubSubEvent(msg *pubsub.Message, srcAttr string) (*cloudevents.Event, error) {
+func makePubSubEvent(msg *pubsub.Message, srcAttr, typeAttr string) (*cloudevents.Event, error) {
 	event := cloudevents.NewEvent()
 	event.SetID(msg.ID)
 	event.SetTime(msg.PublishTime)
-	event.SetType(v1alpha1.GoogleCloudPubSubGenericEventType)
 	event.SetSource(srcAttr)
+	event.SetType(typeAttr)
 
 	for name, val := range ceExtensionAttrsForMessage(msg) {
 		event.SetExtension(name, val)

--- a/pkg/sources/adapter/googlecloudpubsubsource/process_test.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/process_test.go
@@ -27,9 +27,16 @@ import (
 )
 
 func TestProcessMessageDefault(t *testing.T) {
+	const ceSource = "fake.source"
+	const ceType = "fake.type"
+
 	testData := fakePubSubMessage()
 
-	msgPrcsr := &defaultMessageProcessor{ceSource: "fake.source"}
+	msgPrcsr := &defaultMessageProcessor{
+		ceSource: ceSource,
+		ceType:   ceType,
+	}
+
 	events, err := msgPrcsr.Process(testData)
 
 	require.NoError(t, err)
@@ -39,8 +46,8 @@ func TestProcessMessageDefault(t *testing.T) {
 
 	assert.Equal(t, "000", event.ID())
 	assert.Equal(t, time.Unix(0, 0), event.Time())
-	assert.Equal(t, "com.google.cloud.pubsub.message", event.Type())
-	assert.Equal(t, "fake.source", event.Source())
+	assert.Equal(t, ceSource, event.Source())
+	assert.Equal(t, ceType, event.Type())
 
 	eventExts := event.Extensions()
 

--- a/pkg/sources/cloudevents/overrides.go
+++ b/pkg/sources/cloudevents/overrides.go
@@ -22,11 +22,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-const (
-	AttributeSource = "source"
-	AttributeType   = "type"
-)
-
 // OverridesJSON returns the JSON representation of a duckv1.CloudEventOverrides,
 // after applying some optional transformations to it.
 func OverridesJSON(ceo *duckv1.CloudEventOverrides, overrides ...ceOverrideOption) string {

--- a/pkg/sources/reconciler/common/env.go
+++ b/pkg/sources/reconciler/common/env.go
@@ -25,6 +25,10 @@ const (
 	envComponent             = "K_COMPONENT"
 	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
 
+	// Overrides for CloudEvents context attributes (only supported by a subset of components)
+	EnvCESource = "CE_SOURCE"
+	EnvCEType   = "CE_TYPE"
+
 	// Common AWS attributes
 	EnvARN             = "ARN"
 	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -60,16 +60,15 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
-		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
-		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudAuditLogsGenericEventType),
-	)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(common.EnvCESource, src.AsEventSource()),
+		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudAuditLogsGenericEventType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -60,16 +60,15 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
-		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
-		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudBillingGenericEventType),
-	)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(common.EnvCESource, src.AsEventSource()),
+		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudBillingGenericEventType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -60,16 +60,15 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
-		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
-		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudIoTGenericEventType),
-	)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(common.EnvCESource, src.AsEventSource()),
+		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudIoTGenericEventType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -60,16 +60,15 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
-		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
-		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudSourceRepoGenericEventType),
-	)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(common.EnvCESource, src.AsEventSource()),
+		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudSourceRepoGenericEventType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -60,16 +60,15 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 	var authEnvs []corev1.EnvVar
 	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides,
-		cloudevents.SetExtension(cloudevents.AttributeSource, src.AsEventSource()),
-		cloudevents.SetExtension(cloudevents.AttributeType, v1alpha1.GoogleCloudStorageGenericEventType),
-	)
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
 		resource.EnvVars(authEnvs...),
+		resource.EnvVar(common.EnvCESource, src.AsEventSource()),
+		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudStorageGenericEventType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)


### PR DESCRIPTION
Fixes #373

This no more permitted as of cloudevents/sdk-go@v2.7.0:
"CloudEvents spec attribute MUST NOT be overwritten by extension"

Instead, introduce the `CE_SOURCE` and `CE_TYPE` (optional) environment variables for overriding the default source/type context attributes.

Currently supported by the following receive adapters:
- Azure Event Hubs
- Google Cloud Pub/Sub

We have no use for such override in any other source.