### PR TITLE
Fix description of `discardCloudEventContext` attribute in CRDs

### DIFF
--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -91,7 +91,9 @@ spec:
                 description: A Kinesis partition name is required for the target to know where to stream the events to.
                 type: string
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from the Kinesis invocation.
+                description: Whether to omit CloudEvent context attributes in records created in Kinesis.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - arn

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -89,7 +89,9 @@ spec:
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:lambda:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:(function|layer|event-source-mapping):.+$
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from the lambda function.
+                description: Whether to omit CloudEvent context attributes in Lambda function calls.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - arn

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -90,7 +90,9 @@ spec:
                   https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
                 pattern: ^arn:aws(-cn|-us-gov)?:s3:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from the Kinesis invocation.
+                description: Whether to omit CloudEvent context attributes in objects created in S3.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - arn

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -89,7 +89,9 @@ spec:
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from the SNS API call.
+                description: Whether to omit CloudEvent context attributes in notifications sent to SNS.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - arn

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -89,7 +89,9 @@ spec:
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from the lambda function.
+                description: Whether to omit CloudEvent context attributes in messages sent to SQS.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - arn

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -87,7 +87,9 @@ spec:
                   mechanism to use. This can be "Gssapi", "OAuthBearer", "Plain", "ScramSha256", and "ScramSha512".
                 type: string
               discardCloudEventContext:
-                description: Produce a new cloud event based on the response from calling Kafka.
+                description: Whether to omit CloudEvent context attributes in messages sent to Kafka.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - username

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -110,7 +110,9 @@ spec:
                     type: string
                     enum: [always, error, never]
               discardCloudEventContext:
-                description: Discard cloud event metadata from payload being sent to Elasticsearch.
+                description: Whether to omit CloudEvent context attributes in documents created in Elasticsearch.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                 type: boolean
             required:
             - connection

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -67,7 +67,9 @@ spec:
                 description: Google Cloud Project ID associated with the firestore database.
                 type: string
               discardCloudEventContext:
-                description: Indicate whether the full cloud event payload should be sent to the target, or the data
+                description: Whether to omit CloudEvent context attributes in documents created in Firestore.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
                   component only.
                 type: boolean
               credentialsJson:

--- a/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
@@ -63,7 +63,7 @@ type AWSKinesisTargetSpec struct {
 	// Kinesis Partition to publish the events to
 	Partition string `json:"partition"`
 
-	// Whether to omit CloudEvent context attributes in created Kinesis records.
+	// Whether to omit CloudEvent context attributes in records created in Kinesis.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/aws_s3_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_types.go
@@ -63,7 +63,7 @@ type AWSS3TargetSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html#amazons3-resources-for-iam-policies
 	ARN string `json:"arn"`
 
-	// Whether to omit CloudEvent context attributes in created S3 objects.
+	// Whether to omit CloudEvent context attributes in objects created in S3.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/aws_sns_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sns_types.go
@@ -60,7 +60,7 @@ type AWSSNSTargetSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies
 	ARN string `json:"arn"`
 
-	// Whether to omit CloudEvent context attributes in created SNS notifications.
+	// Whether to omit CloudEvent context attributes in notifications sent to SNS.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/aws_sqs_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_types.go
@@ -59,7 +59,7 @@ type AWSSQSTargetSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies
 	ARN string `json:"arn"`
 
-	// Whether to omit CloudEvent context attributes in created SQS messages.
+	// Whether to omit CloudEvent context attributes in messages sent to SQS.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/confluent_types.go
+++ b/pkg/apis/targets/v1alpha1/confluent_types.go
@@ -74,7 +74,7 @@ type ConfluentTargetSpec struct {
 	// SASLMechanisms all the assignment of specific SASL mechanisms.
 	SASLMechanisms string `json:"saslMechanism"`
 
-	// Whether to omit CloudEvent context attributes in created messages.
+	// Whether to omit CloudEvent context attributes in messages sent to Kafka.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_types.go
@@ -60,7 +60,7 @@ type ElasticsearchTargetSpec struct {
 	// IndexName to write to.
 	IndexName string `json:"indexName"`
 
-	// Whether to omit CloudEvent context attributes in created documents.
+	// Whether to omit CloudEvent context attributes in documents created in Elasticsearch.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
@@ -59,7 +59,7 @@ type GoogleCloudFirestoreTargetSpec struct {
 	// ProjectID specifies the Google project ID
 	ProjectID string `json:"projectID"`
 
-	// Whether to omit CloudEvent context attributes in created SNS notifications.
+	// Whether to omit CloudEvent context attributes in documents created in Firestore.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`

--- a/pkg/apis/targets/v1alpha1/ibmmq_types.go
+++ b/pkg/apis/targets/v1alpha1/ibmmq_types.go
@@ -60,6 +60,9 @@ type IBMMQTargetSpec struct {
 	// EventOptions for targets
 	EventOptions *EventOptions `json:"eventOptions,omitempty"`
 
+	// Whether to omit CloudEvent context attributes in messages sent to MQ.
+	// When this property is false (default), the entire CloudEvent payload is included.
+	// When this property is true, only the CloudEvent data is included.
 	DiscardCEContext bool `json:"discardCloudEventContext"`
 }
 


### PR DESCRIPTION
Something went wrong when the description of these fields was added:

- The description doesn't correspond to what the attribute does
- The description doesn't match the corresponding Godoc

This PR fixes both.