### PR TITLE
Refactor e2e test suite for sources based on Azure Event Grid

### DIFF
--- a/test/e2e/framework/azure/azure.go
+++ b/test/e2e/framework/azure/azure.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -116,4 +117,19 @@ func CreateStorageAccountCommon(ctx context.Context, cli *armstorage.StorageAcco
 	}
 
 	return newSaClient.StorageAccount
+}
+
+// randAlphanumString returns a random string of the given length containing
+// only lowercase alphanumeric characters.
+// It is useful to help in generating names for Azure resources.
+func randAlphanumString(n int) string {
+	const alphanumCharset = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphanumCharset[r.Intn(len(alphanumCharset))]
+	}
+	return string(b)
 }

--- a/test/e2e/framework/azure/blobstorage.go
+++ b/test/e2e/framework/azure/blobstorage.go
@@ -45,7 +45,7 @@ func CreateBlobStorageAccount(ctx context.Context, cli *armstorage.StorageAccoun
 }
 
 // CreateBlobContainer will create a new blob storage container
-func CreateBlobContainer(ctx context.Context, rg string, sa armstorage.StorageAccount, subscriptionID, name string) armstorage.BlobContainer {
+func CreateBlobContainer(ctx context.Context, rg, saName, subscriptionID, name string) armstorage.BlobContainer {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to authenticate: %s", err)
@@ -53,7 +53,7 @@ func CreateBlobContainer(ctx context.Context, rg string, sa armstorage.StorageAc
 
 	client := armstorage.NewBlobContainersClient(subscriptionID, cred, nil)
 
-	resp, err := client.Create(ctx, rg, *sa.Name, name, armstorage.BlobContainer{}, nil)
+	resp, err := client.Create(ctx, rg, saName, name, armstorage.BlobContainer{}, nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to create blob container: %s", err)
 	}
@@ -62,13 +62,13 @@ func CreateBlobContainer(ctx context.Context, rg string, sa armstorage.StorageAc
 }
 
 // UploadBlob will upload a new chunk of data to the blob storage
-func UploadBlob(ctx context.Context, container armstorage.BlobContainer, sa armstorage.StorageAccount, name string, data string) {
+func UploadBlob(ctx context.Context, containerName, saName, name, data string) {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to authenticate: %s", err)
 	}
 
-	url := "https://" + *sa.Name + AzureBlobStorageURL + *container.Name
+	url := "https://" + saName + AzureBlobStorageURL + containerName
 	containerClient, err := azblob.NewContainerClient(url, cred, nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to obtain blob client: %s", err)
@@ -84,13 +84,13 @@ func UploadBlob(ctx context.Context, container armstorage.BlobContainer, sa arms
 }
 
 // DeleteBlob will delete the blob located at the name location
-func DeleteBlob(ctx context.Context, container armstorage.BlobContainer, sa armstorage.StorageAccount, name string) {
+func DeleteBlob(ctx context.Context, containerName, saName, name string) {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to authenticate: %s", err)
 	}
 
-	url := "https://" + *sa.Name + AzureBlobStorageURL + *container.Name
+	url := "https://" + saName + AzureBlobStorageURL + containerName
 	containerClient, err := azblob.NewContainerClient(url, cred, nil)
 	if err != nil {
 		framework.FailfWithOffset(2, "Unable to obtain blob client: %s", err)

--- a/test/e2e/framework/azure/blobstorage.go
+++ b/test/e2e/framework/azure/blobstorage.go
@@ -31,8 +31,16 @@ const (
 	AzureBlobStorageURL = ".blob.core.windows.net/"
 )
 
-// CreateBlobStorageAccount provides a wrapper to support blob storage test
-func CreateBlobStorageAccount(ctx context.Context, cli *armstorage.StorageAccountsClient, name, rgName, region string) armstorage.StorageAccount {
+// CreateBlobStorageAccount creates an Azure storage account in the given
+// resource group and region.
+// Because storage account names are globally unique, this helper generates a
+// random name to reduce the risk of running into naming conflicts.
+func CreateBlobStorageAccount(ctx context.Context, cli *armstorage.StorageAccountsClient, rgName, region string) armstorage.StorageAccount {
+	const maxStorAccNameLen = 24
+	const stoAccNamePrefix = "tme2e"
+
+	name := stoAccNamePrefix + randAlphanumString(maxStorAccNameLen-len(stoAccNamePrefix))
+
 	return CreateStorageAccountCommon(ctx, cli, name, rgName, region, true)
 }
 

--- a/test/e2e/sources/azureactivitylogs/main.go
+++ b/test/e2e/sources/azureactivitylogs/main.go
@@ -76,7 +76,7 @@ var activityCategories = []string{"Administrative", "Policy", "Security"}
  * Create a resource group and watch the event flow in
 */
 
-var _ = Describe("Azure Activity Logs", func() {
+var _ = Describe("Azure Activity Logs source", func() {
 	f := framework.New("azureactivitylogssource")
 
 	var ns string
@@ -98,8 +98,6 @@ var _ = Describe("Azure Activity Logs", func() {
 		var rgName string
 		var eventHubsInstanceName string
 
-		subscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
-
 		region := os.Getenv("AZURE_REGION")
 		if region == "" {
 			region = "westus2"
@@ -108,6 +106,7 @@ var _ = Describe("Azure Activity Logs", func() {
 		ctx := context.Background()
 
 		BeforeEach(func() {
+			subscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
 
 			By("creating a resource group", func() {
 				rg := azure.CreateResourceGroup(ctx, subscriptionID, ns, region)
@@ -228,7 +227,6 @@ var _ = Describe("Azure Activity Logs", func() {
 					withSubscriptionID(subscriptionID),
 					withActivityCategories(activityCategories),
 					withEventHubsNamespaceID(eventHubsNamespaceID),
-					withEventHubsInstanceName(ns),
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(
@@ -245,7 +243,7 @@ var _ = Describe("Azure Activity Logs", func() {
 				Expect(err.Error()).To(ContainSubstring(`spec.destination: Required value`))
 			})
 
-			By("setting invalid eventhub namespace", func() {
+			By("setting invalid Event Hubs namespace", func() {
 				invalidEventHubsNamespace := "I'm an invalid Event Hubs namespace"
 
 				_, err := createSource(srcClient, ns, "test-invalid-eventhubs-ns-", sink,
@@ -253,7 +251,6 @@ var _ = Describe("Azure Activity Logs", func() {
 					withSubscriptionID(subscriptionID),
 					withActivityCategories(activityCategories),
 					withEventHubsNamespaceID(invalidEventHubsNamespace),
-					withEventHubsInstanceName(ns),
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(`spec.destination.eventHubs.namespaceID: Invalid value: "`))
@@ -277,9 +274,10 @@ var _ = Describe("Azure Activity Logs", func() {
 
 type sourceOption func(*unstructured.Unstructured)
 
-// createSource creates an AzureEventHubSource object initialized with the test parameters
+// createSource creates an AzureActivityLogsSource object initialized with the given options.
 func createSource(srcClient dynamic.ResourceInterface, namespace, namePrefix string,
 	sink *duckv1.Destination, opts ...sourceOption) (*unstructured.Unstructured, error) {
+
 	src := &unstructured.Unstructured{}
 	src.SetAPIVersion(sourceAPIVersion.String())
 	src.SetKind(sourceKind)

--- a/test/e2e/sources/azureblobstorage/main.go
+++ b/test/e2e/sources/azureblobstorage/main.go
@@ -129,10 +129,8 @@ var _ = Describe("Azure Blob Storage", func() {
 
 				saClient := azure.CreateStorageAccountsClient(subscriptionID)
 
-				// storageaccount name must be alphanumeric characters only and 3-24 characters long
-				saName = strings.Replace(ns, "-", "", -1)
-				saName = strings.Replace(saName, "e2eazureblobstoragesource", "tme2etest", -1)
-				sa = azure.CreateBlobStorageAccount(ctx, saClient, saName, *rg.Name, region)
+				sa = azure.CreateBlobStorageAccount(ctx, saClient, *rg.Name, region)
+				saName = *sa.Name
 
 				container = azure.CreateBlobContainer(ctx, *rg.Name, sa, subscriptionID, ns)
 

--- a/test/e2e/sources/azureblobstorage/main.go
+++ b/test/e2e/sources/azureblobstorage/main.go
@@ -18,19 +18,13 @@ package azureblobstorage
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
-
-	"github.com/triggermesh/triggermesh/test/e2e/framework/azure"
+	"github.com/onsi/gomega/types"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +36,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/test/e2e/framework"
 	"github.com/triggermesh/triggermesh/test/e2e/framework/apps"
+	"github.com/triggermesh/triggermesh/test/e2e/framework/azure"
 	"github.com/triggermesh/triggermesh/test/e2e/framework/bridges"
 	"github.com/triggermesh/triggermesh/test/e2e/framework/ducktypes"
 )
@@ -58,11 +53,12 @@ import (
   - AZURE_TENANT_ID - Azure tenant to create the resources against
   - AZURE_CLIENT_ID - The Azure ServicePrincipal Client ID
   - AZURE_CLIENT_SECRET - The Azure ServicePrincipal Client Secret
-  - AZURE_REGION - Define the Azure region to run the test (default uswest2)
+  - AZURE_REGION - Define the Azure region to run the test (default "westus2")
 
   These will be done by the e2e test:
-  - Create an Azure Resource Group, EventHubs Namespace, and EventHub
-  - Setup Azure Blob Storage and configure the events to stream to the Azure EventHub
+  - Create an Azure Resource Group, Event Hubs Namespace, and Event Hubs instance
+  - Create an Azure Storage Account
+  - Create an AzureBlobStorageSource instance that subscribes to events from the storage account
 
 */
 
@@ -73,7 +69,7 @@ var sourceAPIVersion = schema.GroupVersion{
 
 const (
 	sourceKind     = "AzureBlobStorageSource"
-	sourceResource = "azureblobstoragesource"
+	sourceResource = "azureblobstoragesources"
 )
 
 /*
@@ -86,134 +82,154 @@ const (
  * Delete the blob and verify the event
 */
 
-var _ = Describe("Azure Blob Storage", func() {
-	ctx := context.Background()
-	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
-	region := os.Getenv("AZURE_REGION")
-
-	if region == "" {
-		region = "westus2"
-	}
-
-	f := framework.New(sourceResource)
+var _ = Describe("Azure Blob Storage source", func() {
+	f := framework.New("azureblobstoragesource")
 
 	var ns string
-	var saName string
+
 	var srcClient dynamic.ResourceInterface
+
 	var sink *duckv1.Destination
-
-	var rg armresources.ResourceGroup
-
-	var sa armstorage.StorageAccount
-	var container armstorage.BlobContainer
+	var storageAccountID string
+	var eventHubsNamespaceID string
 
 	BeforeEach(func() {
 		ns = f.UniqueName
-		gvr := sourceAPIVersion.WithResource(sourceResource + "s")
+
+		gvr := sourceAPIVersion.WithResource(sourceResource)
 		srcClient = f.DynamicClient.Resource(gvr).Namespace(ns)
 	})
 
-	Context("an Azure Blob is created and deleted ", func() {
-		var err error // stubbed
+	Context("a source subscribes to events from a blob container", func() {
+		var rgName string
+		var storageAccountName string
+		var blobContainerName string
 
-		When("a blob is created and deleted", func() {
-			BeforeEach(func() {
-				rg = azure.CreateResourceGroup(ctx, subscriptionID, ns, region)
-				_ = azure.CreateEventHubNamespaceOnly(ctx, subscriptionID, ns, region, *rg.Name)
+		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+
+		region := os.Getenv("AZURE_REGION")
+		if region == "" {
+			region = "westus2"
+		}
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+
+			By("creating a resource group", func() {
+				rg := azure.CreateResourceGroup(ctx, subscriptionID, ns, region)
+				rgName = *rg.Name
 			})
 
-			var src *unstructured.Unstructured
+			By("creating a storage account and Blob container", func() {
+				storCli := azure.CreateStorageAccountsClient(subscriptionID)
+				storageAccount := azure.CreateBlobStorageAccount(ctx, storCli, rgName, region)
+				storageAccountID = *storageAccount.ID
+				storageAccountName = *storageAccount.Name
 
-			BeforeEach(func() {
+				container := azure.CreateBlobContainer(ctx, rgName, *storageAccount.Name, subscriptionID, "e2e")
+				blobContainerName = *container.Name
+			})
+
+			By("creating an Event Hubs namespace", func() {
+				nsName := f.UniqueName
+				_ = azure.CreateEventHubNamespaceOnly(ctx, subscriptionID, nsName, region, rgName)
+
+				eventHubsNamespaceID = eventHubsNamespaceResourceID(subscriptionID, rgName, nsName)
+			})
+
+			By("creating an event sink", func() {
 				sink = bridges.CreateEventDisplaySink(f.KubeClient, ns)
+			})
 
-				saClient := azure.CreateStorageAccountsClient(subscriptionID)
-
-				sa = azure.CreateBlobStorageAccount(ctx, saClient, *rg.Name, region)
-				saName = *sa.Name
-
-				container = azure.CreateBlobContainer(ctx, *rg.Name, sa, subscriptionID, ns)
-
-				src, err = createSource(srcClient, ns, "test-", sink,
+			By("creating an AzureBlobStorageSource object", func() {
+				src, err := createSource(srcClient, ns, "test-", sink,
 					withServicePrincipal(),
+					withStorageAccount(storageAccountID),
 					withEventTypes([]string{"Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"}),
-					withEventHubNamespace(createEventhubID(subscriptionID, ns)),
-					withStorageAccountID(createStorageAccountID(subscriptionID, ns, saName)),
+					withEventHubsNamespaceID(eventHubsNamespaceID),
 				)
-
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-				time.Sleep(30 * time.Second) // Will take some extra time to bring up the Azure Eventgrid
+
+				// FIXME(antoineco): Azure needs some extra time for setting up Event Grid's system
+				// topic upon creation of the Event Grid subscription by our reconciler (Blob Storage
+				// events are routed over Event Grid). The source shouldn't report Ready before this
+				// system topic is available, because events occuring prior to that are dropped.
+				time.Sleep(1 * time.Minute)
 			})
+		})
 
-			It("should verify an Azure storage event is sent", func() {
-				By("uploading a blob", func() {
-					azure.UploadBlob(ctx, container, sa, ns, generatePayload(4096))
-					time.Sleep(30 * time.Second) // wait for the blob to be created
+		AfterEach(func() {
+			By("deleting the resource group "+rgName, func() {
+				_ = azure.DeleteResourceGroup(ctx, subscriptionID, rgName)
+			})
+		})
 
-					const receiveTimeout = 60 * time.Second // it takes events a little longer to flow in from azure
+		When("blobs are created and deleted", func() {
+
+			// This test is structured as
+			//   "Specify: the source generates ..., By: creating/deleting a blob ..."
+			// instead of
+			//   "When: a blob is created/deleted ..., Specify: the source generates ..."
+			// to avoid creating a separate set of Azure resources for each spec, which would significantly
+			// increases the duration of the test with no real benefit.
+			Specify("the source generates events", func() {
+
+				By("creating a blob", func() {
+					azure.UploadBlob(ctx, blobContainerName, storageAccountName, "hello.txt", "Hello, World!")
+				})
+
+				By("asserting that a BlobCreated event is received", func() {
+					const receiveTimeout = 15 * time.Second
 					const pollInterval = 500 * time.Millisecond
 
 					var receivedEvents []cloudevents.Event
 
 					readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
 
-					Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
-					Expect(receivedEvents).To(HaveLen(1))
+					Eventually(readReceivedEvents, receiveTimeout, pollInterval).Should(HaveLen(1))
 
 					e := receivedEvents[0]
 
 					Expect(e.Type()).To(Equal("Microsoft.Storage.BlobCreated"))
-					Expect(e.Source()).To(Equal(createStorageAccountID(subscriptionID, ns, saName)))
-
-					// Verify the put request
-					var data map[string]interface{}
-					err = json.Unmarshal(e.Data(), &data)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(data["api"]).To(Equal("PutBlob"))
-					Expect(data["url"]).To(Equal("https://" + *sa.Name + azure.AzureBlobStorageURL + *container.Name + "/" + ns))
+					Expect(e.Source()).To(equalResourceID(storageAccountID))
+					Expect(e.Subject()).To(Equal("/blobServices/default/containers/" + blobContainerName + "/blobs/hello.txt"))
 				})
 
-				By("deleting a blob", func() {
-					azure.DeleteBlob(ctx, container, sa, ns)
-					time.Sleep(60 * time.Second) // wait for the blob to be deleted
+				By("deleting the blob", func() {
+					azure.DeleteBlob(ctx, blobContainerName, storageAccountName, "hello.txt")
+				})
 
-					const receiveTimeout = 60 * time.Second // it takes events a little longer to flow in from azure
+				By("asserting that a BlobDeleted event is received", func() {
+					const receiveTimeout = 15 * time.Second
 					const pollInterval = 500 * time.Millisecond
 
 					var receivedEvents []cloudevents.Event
 
 					readReceivedEvents := readReceivedEvents(f.KubeClient, ns, sink.Ref.Name, &receivedEvents)
 
-					Eventually(readReceivedEvents, receiveTimeout, pollInterval).ShouldNot(BeEmpty())
-					Expect(receivedEvents).To(HaveLen(2))
+					Eventually(readReceivedEvents, receiveTimeout, pollInterval).Should(HaveLen(2))
 
 					e := receivedEvents[1]
 
 					Expect(e.Type()).To(Equal("Microsoft.Storage.BlobDeleted"))
-					Expect(e.Source()).To(Equal(createStorageAccountID(subscriptionID, ns, saName)))
-
-					// Verify the put request
-					var data map[string]interface{}
-					err = json.Unmarshal(e.Data(), &data)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(data["api"]).To(Equal("DeleteBlob"))
-					Expect(data["url"]).To(Equal("https://" + *sa.Name + azure.AzureBlobStorageURL + *container.Name + "/" + ns))
+					Expect(e.Source()).To(equalResourceID(storageAccountID))
+					Expect(e.Subject()).To(Equal("/blobServices/default/containers/" + blobContainerName + "/blobs/hello.txt"))
 				})
-			})
-
-			AfterEach(func() {
-				_ = azure.DeleteResourceGroup(ctx, subscriptionID, *rg.Name)
 			})
 		})
 	})
 
 	When("a client creates a source object with invalid specs", func() {
-		// Those tests do not require a real sink
+
+		// Those tests do not require a real sink, storage account, or Event Hubs namespace
 		BeforeEach(func() {
+			const subscriptionID = "00000000-0000-0000-0000-000000000000"
+			storageAccountID = storageAccountResourceID(subscriptionID, "testRg", "teststoracc")
+			eventHubsNamespaceID = eventHubsNamespaceResourceID(subscriptionID, "testRg", "testNs")
+
 			sink = &duckv1.Destination{
 				Ref: &duckv1.KReference{
 					APIVersion: "fake/v1",
@@ -221,80 +237,75 @@ var _ = Describe("Azure Blob Storage", func() {
 					Name:       "fake",
 				},
 			}
-
-			saName = strings.Replace(ns, "-", "", -1)
-			saName = strings.Replace(saName, "e2eazureblobstoragesource", "fakesaname", -1)
 		})
 
 		Specify("the API server rejects the creation of that object", func() {
 
+			By("setting an invalid storage account", func() {
+				invalidStorAccResourceID := "I'm an invalid resource ID"
+
+				_, err := createSource(srcClient, ns, "test-invalid-storacc", sink,
+					withServicePrincipal(),
+					withStorageAccount(invalidStorAccResourceID),
+					withEventHubsNamespaceID(eventHubsNamespaceID),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("spec.storageAccountID: Invalid value: "))
+			})
+
+			By("setting unsupported event types", func() {
+				_, err := createSource(srcClient, ns, "test-invalid-eventtypes", sink,
+					withServicePrincipal(),
+					withStorageAccount(storageAccountID),
+					withEventTypes([]string{"Microsoft.NotStorage.FakeEvent"}),
+					withEventHubsNamespaceID(eventHubsNamespaceID),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("spec.eventTypes: Unsupported value: "))
+			})
+
 			By("omitting credentials", func() {
-				_, err := createSource(srcClient, ns, "test-empty-credentials", sink,
-					withEventHubNamespace(createEventhubID(subscriptionID, ns)),
-					withStorageAccountID(createStorageAccountID(subscriptionID, ns, saName)),
+				_, err := createSource(srcClient, ns, "test-nocreds-", sink,
+					withStorageAccount(storageAccountID),
+					withEventHubsNamespaceID(eventHubsNamespaceID),
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(
 					`spec.auth: Required value`))
 			})
 
-			By("omitting storageAccountID", func() {
-				_, err := createSource(srcClient, ns, "test-empty-storage-id", sink,
+			By("omitting the Event Hubs endpoint", func() {
+				_, err := createSource(srcClient, ns, "test-no-eventhubs-", sink,
 					withServicePrincipal(),
-					withEventTypes([]string{"Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"}),
-					withEventHubNamespace(createEventhubID(subscriptionID, ns)),
+					withStorageAccount(storageAccountID),
 				)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(
-					`spec.storageAccountID: Required value`))
-			})
-
-			By("setting invalid storageAccountID", func() {
-				fakeStorageAccountID := "I'm a fake storage account"
-				_, err := createSource(srcClient, ns, "test-invalid-storageAccountID", sink,
-					withServicePrincipal(),
-					withEventTypes([]string{"Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"}),
-					withEventHubNamespace(createEventhubID(subscriptionID, ns)),
-					withStorageAccountID(fakeStorageAccountID),
-				)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(
-					`spec.storageAccountID: Invalid value: "`))
-			})
-
-			By("omitting the eventhub endpoint", func() {
-				_, err := createSource(srcClient, ns, "test-missing-endpoint", sink,
-					withServicePrincipal(),
-					withEventTypes([]string{"Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"}),
-					withStorageAccountID(createStorageAccountID(subscriptionID, ns, saName)),
-				)
-
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(`spec.endpoint: Required value`))
 			})
 
-			By("setting invalid eventhub endpoint", func() {
-				fakeEventHubNamespace := "I'm a fake eventhub namespace"
-				_, err := createSource(srcClient, ns, "test-invalid-eventhub-ns", sink,
+			By("setting an invalid Event Hubs namespace", func() {
+				invalidEventHubsNamespace := "I'm an invalid Event Hubs namespace"
+
+				_, err := createSource(srcClient, ns, "test-invalid-eventhubs-ns-", sink,
 					withServicePrincipal(),
-					withEventTypes([]string{"Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"}),
-					withEventHubNamespace(fakeEventHubNamespace),
-					withStorageAccountID(createStorageAccountID(subscriptionID, ns, saName)),
+					withStorageAccount(storageAccountID),
+					withEventHubsNamespaceID(invalidEventHubsNamespace),
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(`spec.endpoint.eventHubs.namespaceID: Invalid value: "`))
 			})
 
-			By("setting invalid eventTypes", func() {
-				fakeEventTypes := []string{"Microsoft.EventGrid.All"}
-				_, err := createSource(srcClient, ns, "test-invalid-eventtype", sink,
+			By("setting an invalid Event Hubs instance name", func() {
+				invalidName := "I'm an invalid Event Hubs instance name"
+
+				_, err := createSource(srcClient, ns, "test-invalid-eventhubs-name-", sink,
 					withServicePrincipal(),
-					withEventTypes(fakeEventTypes),
-					withEventHubNamespace(createEventhubID(subscriptionID, ns)),
-					withStorageAccountID(createStorageAccountID(subscriptionID, ns, saName)),
+					withStorageAccount(storageAccountID),
+					withEventHubsNamespaceID(eventHubsNamespaceID),
+					withEventHubsInstanceName(invalidName),
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(`spec.eventTypes: Unsupported value: "`))
+				Expect(err.Error()).To(ContainSubstring(`spec.endpoint.eventHubs.hubName: Invalid value: "`))
 			})
 		})
 	})
@@ -302,9 +313,10 @@ var _ = Describe("Azure Blob Storage", func() {
 
 type sourceOption func(*unstructured.Unstructured)
 
-// createSource creates an AzureBlobStorageSource object initialized with the test parameters
+// createSource creates an AzureBlobStorageSource object initialized with the given options.
 func createSource(srcClient dynamic.ResourceInterface, namespace, namePrefix string,
 	sink *duckv1.Destination, opts ...sourceOption) (*unstructured.Unstructured, error) {
+
 	src := &unstructured.Unstructured{}
 	src.SetAPIVersion(sourceAPIVersion.String())
 	src.SetKind(sourceKind)
@@ -326,18 +338,18 @@ func createSource(srcClient dynamic.ResourceInterface, namespace, namePrefix str
 
 // Define the creation parameters to pass along
 
-func withStorageAccountID(id string) sourceOption {
+func withEventHubsNamespaceID(ns string) sourceOption {
 	return func(src *unstructured.Unstructured) {
-		if err := unstructured.SetNestedField(src.Object, id, "spec", "storageAccountID"); err != nil {
-			framework.FailfWithOffset(2, "Failed to set spec.storageAccountID: %s", err)
+		if err := unstructured.SetNestedField(src.Object, ns, "spec", "endpoint", "eventHubs", "namespaceID"); err != nil {
+			framework.FailfWithOffset(2, "Failed to set spec.endpoint.eventHubs.namespaceID: %s", err)
 		}
 	}
 }
 
-func withEventHubNamespace(namespaceID string) sourceOption {
+func withEventHubsInstanceName(name string) sourceOption {
 	return func(src *unstructured.Unstructured) {
-		if err := unstructured.SetNestedField(src.Object, namespaceID, "spec", "endpoint", "eventHubs", "namespaceID"); err != nil {
-			framework.FailfWithOffset(2, "Failed to set spec.endpoint.eventHubs.namespaceID: %s", err)
+		if err := unstructured.SetNestedField(src.Object, name, "spec", "endpoint", "eventHubs", "hubName"); err != nil {
+			framework.FailfWithOffset(2, "Failed to set spec.endpoint.eventHubs.hubName: %s", err)
 		}
 	}
 }
@@ -350,7 +362,15 @@ func withEventTypes(eventTypes []string) sourceOption {
 	}
 }
 
-// withServicePrincipal will create the service principal component based on the azure environment variables
+func withStorageAccount(storAccID string) sourceOption {
+	return func(src *unstructured.Unstructured) {
+		if err := unstructured.SetNestedField(src.Object, storAccID, "spec", "storageAccountID"); err != nil {
+			framework.FailfWithOffset(2, "Failed to set spec.storageAccountID: %s", err)
+		}
+	}
+}
+
+// withServicePrincipal will create the secret and service principal based on the azure environment variables
 func withServicePrincipal() sourceOption {
 	credsMap := map[string]interface{}{
 		"tenantID":     map[string]interface{}{"value": os.Getenv("AZURE_TENANT_ID")},
@@ -382,23 +402,28 @@ func readReceivedEvents(c clientset.Interface, namespace, eventDisplayName strin
 	}
 }
 
-// createEventhubID will create the EventHub path used by the k8s given the subscriptionID and the test unique name
-func createEventhubID(subscriptionID, testName string) string {
-	return "/subscriptions/" + subscriptionID + "/resourceGroups/" + testName + "/providers/Microsoft.EventHub/namespaces/" + testName
+// eventHubsNamespaceResourceID returns a fully qualified Azure resource ID for
+// an Event Hubs namespace.
+func eventHubsNamespaceResourceID(subscriptionID, rgName, nsName string) string {
+	return "/subscriptions/" + subscriptionID + "/resourceGroups/" + rgName +
+		"/providers/Microsoft.EventHub/namespaces/" + nsName
 }
 
-// createStorageAccountID will create the StorageAccountID path used by the k8s
-func createStorageAccountID(subscriptionID, rgName, saName string) string {
-	return "/subscriptions/" + subscriptionID + "/resourceGroups/" + rgName + "/providers/Microsoft.Storage/storageAccounts/" + saName
+// storageAccountResourceID returns a fully qualified Azure resource ID for a
+// Storage Account.
+func storageAccountResourceID(subscriptionID, rgName, saName string) string {
+	return "/subscriptions/" + subscriptionID + "/resourceGroups/" + rgName +
+		"/providers/Microsoft.Storage/storageAccounts/" + saName
 }
 
-func generatePayload(size int) string {
-	var sb strings.Builder
-
-	for i := 0; i < size; i++ {
-		s := fmt.Sprintf("%d", rand.Int31())
-		sb.WriteString(s)
-	}
-
-	return sb.String()
+// equalResourceID returns a Gomega matcher which asserts the equality of two
+// Azure resource IDs.
+// Unlike gomega.Equal, this function accounts for Event Grid generating
+// CloudEvent attributes with an inconsistent casing of the "resourceGroups"
+// segment of resource IDs.
+func equalResourceID(expectID string) types.GomegaMatcher {
+	return SatisfyAny(
+		Equal(expectID),
+		Equal(strings.Replace(expectID, "/resourceGroups/", "/resourcegroups/", 1)),
+	)
 }

--- a/test/e2e/sources/azureeventgrid/main.go
+++ b/test/e2e/sources/azureeventgrid/main.go
@@ -156,7 +156,7 @@ var _ = Describe("Azure Event Grid source", func() {
 			BeforeEach(func() {
 				By("creating a storage account to generate an event", func() {
 					storCli := azure.CreateStorageAccountsClient(subscriptionID)
-					storageAccount := azure.CreateBlobStorageAccount(ctx, storCli, "e2eo3by9w5zh4f92p5fxlmg", rgName, region)
+					storageAccount := azure.CreateBlobStorageAccount(ctx, storCli, rgName, region)
 
 					sampleStorageAccountID = *storageAccount.ID
 				})


### PR DESCRIPTION
In this PR, I propose the same refactoring as I did in #440 (stricter structure and variable scope, rename a few variables, ...), with the following addition:

1. Actually create the Storage Account as part of the "Azure Event Grid source" test.

    - This was announced in the test's description, but then omitted in the code of the original submission. As a result, the test was "accidentally" receiving events unrelated to the one we were supposed to assert.

    - This also fixes #441

1. Generate randomized names for Azure Storage Accounts.

    - Naming a storage account is delicate, because names are _globally unique_ within Azure. By using random names, we

        - Are less likely to run into a name that's already taken (and the test's author doesn't have to care)
        - Are able to run the same test multiple times in parallel (related to #443)