### PR TITLE
Document IAM permissions for Kinesis target test

### DIFF
--- a/test/e2e/iam/aws_iam_policy.jsonc
+++ b/test/e2e/iam/aws_iam_policy.jsonc
@@ -57,7 +57,10 @@
                 "kinesis:PutRecord",
                 "kinesis:DeleteStream",
                 "kinesis:CreateStream",
-                "kinesis:DescribeStream"
+                "kinesis:DescribeStream",
+                "kinesis:ListShards",
+                "kinesis:GetShardIterator",
+                "kinesis:GetRecords"
             ],
             "Resource": [
                 "arn:aws:kinesis:*:043455440429:stream/e2e-*"
@@ -129,8 +132,7 @@
             "Action": [
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage",
-                "sqs:DeleteMessage",
-                "sqs:DeleteMessageBatch"
+                "sqs:DeleteMessage"
             ],
             "Resource": [
                 "arn:aws:sqs:*:043455440429:e2e-*"


### PR DESCRIPTION
The target test introduced in #439 requires some [extra permissions](https://github.com/triggermesh/triggermesh/runs/4843697215?check_suite_focus=true), which are documented in this PR.