### PR TITLE
Updates Missing Event Type Registration

### DIFF
--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -18,6 +18,17 @@ metadata:
   name: xmltojsontransformations.flow.triggermesh.io
   labels:
     triggermesh.io/crd-install: 'true'
+    duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "io.triggermesh.xmltojsontransformation.error" },
+        { "type": "*" }
+      ]
 spec:
   group: flow.triggermesh.io
   scope: Namespaced


### PR DESCRIPTION
I forgot to add the incoming/outgoing event types. I also noticed I missed `duck.knative.dev/addressable: 'true'`