### PR TITLE
Updates to Include Missing Event Type Registry Entries

### DIFF
--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -21,6 +21,10 @@ metadata:
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
   annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
     registry.knative.dev/eventTypes: |
       [
         { "type": "io.triggermesh.targets.aws.comprehend.result" }

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -22,6 +22,14 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
   annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "io.triggermesh.azure.eventhubs.put.response" }
+      ]
 
 spec:
   group: targets.triggermesh.io

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -20,6 +20,11 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: targets.triggermesh.io
   names:

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -20,6 +20,15 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: targets.triggermesh.io
   names:

--- a/config/301-infratarget.yaml
+++ b/config/301-infratarget.yaml
@@ -20,6 +20,15 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: targets.triggermesh.io
   names:

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -21,6 +21,10 @@ metadata:
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
   annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
     registry.knative.dev/eventTypes: |
       [
         { "type": "io.triggermesh.logz.ship.response" }

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -20,6 +20,15 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "functions.oracletargets.targets.triggermesh.io" }
+      ]
 spec:
   group: targets.triggermesh.io
   names:

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -20,6 +20,11 @@ metadata:
     knative.dev/crd-install: 'true'
     triggermesh.io/crd-install: 'true'
     duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: targets.triggermesh.io
   scope: Namespaced

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -18,6 +18,15 @@ metadata:
   name: filters.routing.triggermesh.io
   labels:
     triggermesh.io/crd-install: "true"
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: routing.triggermesh.io
   scope: Namespaced

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -18,6 +18,15 @@ metadata:
   name: splitters.routing.triggermesh.io
   labels:
     triggermesh.io/crd-install: "true"
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: routing.triggermesh.io
   scope: Namespaced

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -18,6 +18,15 @@ metadata:
   name: functions.extensions.triggermesh.io
   labels:
     triggermesh.io/crd-install: "true"
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: extensions.triggermesh.io
   scope: Namespaced

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -18,6 +18,15 @@ metadata:
   name: transformations.flow.triggermesh.io
   labels:
     triggermesh.io/crd-install: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: flow.triggermesh.io
   scope: Namespaced

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -18,6 +18,17 @@ metadata:
   name: xmltojsontransformations.flow.triggermesh.io
   labels:
     triggermesh.io/crd-install: 'true'
+    duck.knative.dev/addressable: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "io.triggermesh.xmltojsontransformation.error" },
+        { "type": "*" }
+      ]
 spec:
   group: flow.triggermesh.io
   scope: Namespaced

--- a/config/304-xslttransform.yaml
+++ b/config/304-xslttransform.yaml
@@ -18,6 +18,15 @@ metadata:
   name: xslttransforms.flow.triggermesh.io
   labels:
     triggermesh.io/crd-install: 'true'
+  annotations:
+    registry.triggermesh.io/acceptedEventTypes: |
+      [
+        { "type": "*" }
+      ]
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "*" }
+      ]
 spec:
   group: flow.triggermesh.io
   scope: Namespaced


### PR DESCRIPTION
This updates the Event Type registry entries in the CRD for the following:
* AWSComprehendTarget
* AzureEventHubsTarget
* ConfluentTarget
* HTTPTarget
* InfraJSTarget
* LogzTarget
* OracleTarget
* SplunkTarget
* All the Transformation/flow bits. 

Closes issue #77 