### PR TITLE
Log the generated unique name of a E2E test after creating its namespace

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -75,6 +75,8 @@ func (f *Framework) BeforeEach() {
 	ginkgo.By("creating test namespace with base name "+f.baseName, func() {
 		f.UniqueName = createTestNamespace(f).Name
 	})
+
+	ginkgo.GinkgoWriter.Println("Unique name:", f.UniqueName)
 }
 
 // AfterEach performs common cleanup tasks.


### PR DESCRIPTION
Log the generated unique name at the beginning of every test, right after creating the corresponding namespace.
Makes it easier to identify the base namespace a test's resources are created in while troubleshooting.

Sample output in verbose mode:

```console
$ ginkgo -v ./test/e2e
------------------------------
Azure Activity Logs source / a source subscribes to activities from an Azure subscription / an activity is logged
  inside the subscription / the source generates an event
...
STEP: creating test REST clients 01/19/22 09:37:15.402
STEP: creating test namespace with base name azureactivitylogssource 01/19/22 09:37:15.405
Unique name: e2e-azureactivitylogssource-3591
...
STEP: marking test namespace e2e-azureactivitylogssource-3591 for deletion 01/19/22 09:37:15.983
------------------------------
```