### PR TITLE
Raise Ginkgo's slow spec threshold

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -78,4 +78,4 @@ jobs:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      run: ginkgo -p -slow-spec-threshold=1m -randomize-all ./test/e2e/
+      run: ginkgo -p -slow-spec-threshold=10m -randomize-all ./test/e2e/


### PR DESCRIPTION
These tests, especially the ones that involve the creation of cloud resources on Microsoft Azure, are slow by nature. We don't want Ginkgo to warn us about each one of them because the long duration is expected.