### PR TITLE
Introduce startup probe in AWS sources' adapters

### DIFF
--- a/pkg/routing/reconciler/common/resource/container.go
+++ b/pkg/routing/reconciler/common/resource/container.go
@@ -163,10 +163,6 @@ func Probe(path, port string) ObjectOption {
 					Port: intstrPort,
 				},
 			},
-			// TODO(antoineco): remove delay after switching to StartupProbe, which is enabled by default
-			// starting with Kubernetes 1.18.
-			// Ref. https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-			InitialDelaySeconds: 2,
 		}
 	}
 }

--- a/pkg/routing/reconciler/common/resource/container_test.go
+++ b/pkg/routing/reconciler/common/resource/container_test.go
@@ -82,7 +82,6 @@ func TestNewContainer(t *testing.T) {
 					Port: intstr.FromString("health"),
 				},
 			},
-			InitialDelaySeconds: 2,
 		},
 		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/pkg/routing/reconciler/common/resource/knservice_test.go
+++ b/pkg/routing/reconciler/common/resource/knservice_test.go
@@ -93,7 +93,6 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 											Path: "/health",
 										},
 									},
-									InitialDelaySeconds: 2,
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
 
 const (
@@ -116,6 +117,14 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
+	go health.Start(ctx)
+
+	if _, err := a.getLatestStreamARN(ctx); err != nil {
+		return fmt.Errorf("verifying stream for table %q: %w", a.arn, err)
+	}
+
+	health.MarkReady()
+
 	a.logger.Info("Starting collection of DynamoDB records for table ", a.arn)
 
 	t := time.NewTimer(0)

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -18,6 +18,7 @@ package awsperformanceinsightssource
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/pi"
+	"github.com/aws/aws-sdk-go/service/pi/piiface"
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
@@ -35,9 +37,8 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/health"
 )
-
-const serviceType = "RDS"
 
 // envConfig is a set parameters sourced from the environment for the source's
 // adapter.
@@ -135,6 +136,14 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 // Start implements adapter.Adapter.
 func (a *adapter) Start(ctx context.Context) error {
+	go health.Start(ctx)
+
+	if err := peekResourceMetrics(ctx, a.pIClient, a.resourceID); err != nil {
+		return fmt.Errorf("unable to read resource metrics: %w", err)
+	}
+
+	health.MarkReady()
+
 	a.logger.Info("Enabling AWS Performance Insights Source")
 
 	// Setup polling to retrieve metrics
@@ -162,7 +171,7 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 		StartTime:     aws.Time(priorTime),
 		Identifier:    aws.String(a.resourceID),
 		MetricQueries: a.metricQueries,
-		ServiceType:   aws.String(serviceType),
+		ServiceType:   aws.String(pi.ServiceTypeRds),
 	}
 
 	rm, err := a.pIClient.GetResourceMetrics(rmi)
@@ -199,4 +208,16 @@ func (a *adapter) PollMetrics(priorTime time.Time, currentTime time.Time) {
 			}
 		}
 	}
+}
+
+// peekResourceMetrics verifies that there are metrics available for the given
+// DB instance.
+func peekResourceMetrics(ctx context.Context, cli piiface.PIAPI, dbInstanceID string) error {
+	_, err := cli.ListAvailableResourceMetricsWithContext(ctx, &pi.ListAvailableResourceMetricsInput{
+		Identifier:  &dbInstanceID,
+		MetricTypes: aws.StringSlice([]string{"os", "db"}),
+		ServiceType: aws.String(pi.ServiceTypeRds),
+		MaxResults:  aws.Int64(1),
+	})
+	return err
 }

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -36,6 +36,8 @@ const envPollingInterval = "POLLING_INTERVAL"
 
 const defaultPollingInterval = 5 * time.Minute
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -64,6 +66,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(envPollingInterval, pollingInterval.String()),
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -41,6 +41,8 @@ const (
 
 const defaultPollingInterval = 5 * time.Minute
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -78,6 +80,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
 		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/sources/reconciler/awscodecommitsource/adapter.go
@@ -37,6 +37,8 @@ const (
 	envEventTypes = "EVENT_TYPES"
 )
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -61,6 +63,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(envEventTypes, strings.Join(typedSrc.Spec.EventTypes, ",")),
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -53,6 +55,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -57,7 +57,7 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
-		resource.Probe("/health", healthPortName),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -53,6 +55,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -53,6 +55,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -37,6 +37,8 @@ const (
 	envMetrics         = "PI_METRICS"
 )
 
+const healthPortName = "health"
+
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
 type adapterConfig struct {
@@ -59,9 +61,11 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
 		resource.EnvVar(envPollingInterval, typedSrc.Spec.PollingInterval.String()),
 		resource.EnvVar(envMetrics, strings.Join(typedSrc.Spec.Metrics, ",")),
-
 		resource.EnvVars(common.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -70,7 +70,7 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.Port(healthPortName, 8080),
 		resource.Port("metrics", 9090),
 
-		resource.Probe("/health", healthPortName),
+		resource.StartupProbe("/health", healthPortName),
 
 		// See awssqssource/adapter.go for an justification for these values.
 		resource.Requests(

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -63,7 +63,7 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.Port(healthPortName, 8080),
 		resource.Port("metrics", 9090),
 
-		resource.Probe("/health", healthPortName),
+		resource.StartupProbe("/health", healthPortName),
 
 		// CPU throttling can be observed below a limit of 1,
 		// although the CPU usage under load remains below 400m.

--- a/pkg/sources/reconciler/common/resource/container.go
+++ b/pkg/sources/reconciler/common/resource/container.go
@@ -163,10 +163,6 @@ func Probe(path, port string) ObjectOption {
 					Port: intstrPort,
 				},
 			},
-			// TODO(antoineco): remove delay after switching to StartupProbe, which is enabled by default
-			// starting with Kubernetes 1.18.
-			// Ref. https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-			InitialDelaySeconds: 2,
 		}
 	}
 }

--- a/pkg/sources/reconciler/common/resource/container_test.go
+++ b/pkg/sources/reconciler/common/resource/container_test.go
@@ -82,7 +82,6 @@ func TestNewContainer(t *testing.T) {
 					Port: intstr.FromString("health"),
 				},
 			},
-			InitialDelaySeconds: 2,
 		},
 		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/pkg/sources/reconciler/common/resource/deployment_test.go
+++ b/pkg/sources/reconciler/common/resource/deployment_test.go
@@ -107,7 +107,6 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 									Port: intstr.FromString("health"),
 								},
 							},
-							InitialDelaySeconds: 2,
 						},
 						StartupProbe: &corev1.Probe{
 							Handler: corev1.Handler{

--- a/pkg/sources/reconciler/common/resource/knservice_test.go
+++ b/pkg/sources/reconciler/common/resource/knservice_test.go
@@ -93,7 +93,6 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 											Path: "/health",
 										},
 									},
-									InitialDelaySeconds: 2,
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/test/e2e/sources/awscodecommit/main.go
+++ b/test/e2e/sources/awscodecommit/main.go
@@ -112,14 +112,6 @@ var _ = Describe("AWS CodeCommit source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Sending CodeCommit event
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(2 * time.Second)
 			})
 		})
 

--- a/test/e2e/sources/awscognitouserpool/main.go
+++ b/test/e2e/sources/awscognitouserpool/main.go
@@ -117,14 +117,6 @@ var _ = Describe("AWS Cognito UserPool source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Sending Cognito event
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(2 * time.Second)
 			})
 		})
 

--- a/test/e2e/sources/awsdynamodb/main.go
+++ b/test/e2e/sources/awsdynamodb/main.go
@@ -115,14 +115,6 @@ var _ = Describe("AWS DynamoDB source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Sending DynamoDB event
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(2 * time.Second)
 			})
 		})
 

--- a/test/e2e/sources/awskinesis/main.go
+++ b/test/e2e/sources/awskinesis/main.go
@@ -113,14 +113,6 @@ var _ = Describe("AWS Kinesis source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Sending Kinesis event
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(2 * time.Second)
 			})
 		})
 

--- a/test/e2e/sources/awssns/main.go
+++ b/test/e2e/sources/awssns/main.go
@@ -111,14 +111,6 @@ var _ = Describe("AWS SNS source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Failed to send CloudEvent:
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(5 * time.Second)
 			})
 		})
 

--- a/test/e2e/sources/awssqs/main.go
+++ b/test/e2e/sources/awssqs/main.go
@@ -111,14 +111,6 @@ var _ = Describe("AWS SQS source", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ducktypes.WaitUntilReady(f.DynamicClient, src)
-
-				// FIXME(antoineco): without this short pause, the receive adapter throws the following
-				// error when sending the event:
-				//
-				//   Sending SQS event
-				//   Post "http://event-display.{...}": dial tcp 10.x.x.x:80: connect: connection refused
-				//
-				time.Sleep(5 * time.Second)
 			})
 		})
 


### PR DESCRIPTION
Closes #418

Prevents sources from becoming ready if the provided credentials aren't valid, or if the provided resource doesn't exist.

As a side effect, allows running all these adapters as long-running Knative Services in Google Cloud Run (because poking port 8080 will now return a response).