### PR TITLE
Azure EventHub fixes

### DIFF
--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -259,7 +259,15 @@ spec:
                   required:
                   - type
                   - status
+              address:
+                type: object
+                properties:
+                  url:
+                    type: string
     additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
     - name: Ready
       type: string
       jsonPath: .status.conditions[?(@.type=='Ready')].status

--- a/pkg/apis/targets/v1alpha1/register.go
+++ b/pkg/apis/targets/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,6 +52,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&AWSSQSTargetList{},
 		&AWSKinesisTarget{},
 		&AWSKinesisTargetList{},
+		&AzureEventHubsTarget{},
+		&AzureEventHubsTargetList{},
 		&ConfluentTarget{},
 		&ConfluentTargetList{},
 		&DatadogTarget{},

--- a/pkg/targets/adapter/azureeventhubstarget/adapter.go
+++ b/pkg/targets/adapter/azureeventhubstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/azureeventhubstarget/config.go
+++ b/pkg/targets/adapter/azureeventhubstarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,4 +36,16 @@ type envAccessor struct {
 
 	// DiscardCEContext chooses to keep or discard the incoming cloudevent context
 	DiscardCEContext bool `envconfig:"DISCARD_CE_CONTEXT"`
+
+	// The environment variables below aren't read from the envConfig struct
+	// by the Event Hubs SDK, but rather directly using os.Getenv().
+	// They are nevertheless listed here for documentation purposes.
+	_ string `envconfig:"EVENTHUB_NAMESPACE"`
+	_ string `envconfig:"EVENTHUB_NAME"`
+	_ string `envconfig:"AZURE_TENANT_ID"`
+	_ string `envconfig:"AZURE_CLIENT_ID"`
+	_ string `envconfig:"AZURE_CLIENT_SECRET"`
+	_ string `envconfig:"EVENTHUB_KEY_NAME"`
+	_ string `envconfig:"EVENTHUB_KEY_VALUE"`
+	_ string `envconfig:"EVENTHUB_CONNECTION_STRING"`
 }


### PR DESCRIPTION
While working on creating an end to end test for the EventHubs target, I noticed that there were some critical pieces that didn't make the transition from their original locations which resulted in this target not being fully functional. In particular, missing registration for the target, missing URLs for streaming events into, or documentation updates to correspond with the sources.