### PR TITLE
IBM MQ source DLQ support

### DIFF
--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -86,6 +86,8 @@ spec:
                   retry:
                     description: The number of delivery retries before moving the message to DLQ.
                     type: integer
+                required:
+                - deadLetterQueue
               sink:
                 description: The destination of events sourced from IBM MQ.
                 type: object

--- a/config/samples/sources/ibmmqsource.yaml
+++ b/config/samples/sources/ibmmqsource.yaml
@@ -29,7 +29,7 @@ spec:
   queueName: DEV.QUEUE.2
   channelName: DEV.APP.SVRCONN
   delivery:
-    deadLetterQueue: DEAD.LETTER.QUEUE
+    deadLetterQueue: DEV.DEAD.LETTER.QUEUE
     backoffDelay: 10
     retry: 3
   credentials:

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -65,7 +65,7 @@ func (a *ibmmqsourceAdapter) Start(ctx context.Context) error {
 	}
 	defer conn.Disc()
 
-	queue, err := mq.OpenQueue(a.mqEnvs.EnvConnectionConfig.QueueName, conn)
+	queue, err := mq.OpenQueue(a.mqEnvs.EnvConnectionConfig.QueueName, a.mqEnvs.DeadLetterQueue, conn)
 	if err != nil {
 		return fmt.Errorf("failed to open IBM MQ queue: %w", err)
 	}

--- a/pkg/sources/adapter/ibmmqsource/config.go
+++ b/pkg/sources/adapter/ibmmqsource/config.go
@@ -50,9 +50,13 @@ func EnvAccessorCtor() pkgadapter.EnvConfigAccessor {
 
 // Delivery returns the MQ delivery parameters.
 func (e *SourceEnvAccessor) Delivery() *mq.Delivery {
+	if e.DeadLetterQManager == "" {
+		e.DeadLetterQManager = e.QueueManager
+	}
 	return &mq.Delivery{
-		DeadLetterQueue: e.DeadLetterQueue,
-		BackoffDelay:    e.BackoffDelay,
-		Retry:           e.Retry,
+		DeadLetterQManager: e.DeadLetterQManager,
+		DeadLetterQueue:    e.DeadLetterQueue,
+		BackoffDelay:       e.BackoffDelay,
+		Retry:              e.Retry,
 	}
 }

--- a/pkg/sources/adapter/ibmmqsource/mq/config.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/config.go
@@ -36,6 +36,5 @@ func (e *EnvConnectionConfig) ConnectionConfig() *ConnConfig {
 		User:           e.User,
 		Password:       e.Password,
 		QueueManager:   e.QueueManager,
-		QueueName:      e.QueueName,
 	}
 }


### PR DESCRIPTION
This PR fixes Dead Letter Queue support in IBM MQ Source:
If the adapter receives an "undelivered" response \<retry\> number of times, the message will be forwarded to the \<deadLetterQueue\>.

The delivery mechanism still missing:
- Separate Queue manager for Dead Letter Queue - this will require storing additional queue configuration, creating and keeping open new connections. Can be added when we face the need for this kind of setup. 
- Backoff Delay - not clear if the delay can be implemented on the server-side, still investigating.