### PR TITLE
Expose KinD gateway and set Knative domain in E2E test environment

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,6 +49,45 @@ jobs:
         # use for a container registry.
         registry: 'false'
 
+    - name: Read KinD network subnet
+      id: kind-subnet
+      run: |
+        kind_subnet_prefix="$(\
+          docker network inspect kind -f '{{ (index .IPAM.Config 0).Subnet }}' | cut -d'.' -f'1,2'\
+        )"
+
+        echo "Subnet prefix of 'kind' network: ${kind_subnet_prefix}"
+        echo "::set-output name=prefix::${kind_subnet_prefix}"
+
+    - name: MetalLB load-balancer
+      # Based on https://kind.sigs.k8s.io/docs/user/loadbalancer/
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/namespace.yaml
+        kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/metallb.yaml
+        kubectl -n metallb-system wait --timeout=1m --for=condition=Available deployments.apps/controller
+
+        cat <<'EOM' | kubectl create -f-
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          namespace: metallb-system
+          name: config
+        data:
+          config: |
+            address-pools:
+            - name: default
+              protocol: layer2
+              addresses:
+              - ${{ steps.kind-subnet.outputs.prefix }}.255.200-${{ steps.kind-subnet.outputs.prefix }}.255.250
+        EOM
+
+    - name: Knative default domain
+      # Sets a magic default Knative domain that resolves to <gateway-ip>.sslip.io
+      run: |
+        kubectl create -f https://github.com/knative/serving/releases/download/knative-v1.0.0/serving-default-domain.yaml
+        kubectl -n knative-serving wait --timeout=1m --for=condition=Complete jobs.batch/default-domain
+
     - name: Install ko
       run: go install github.com/google/ko@v0.9.3
 

--- a/test/e2e/sources/webhook/main.go
+++ b/test/e2e/sources/webhook/main.go
@@ -69,10 +69,7 @@ var _ = Describe("Webhook source", func() {
 		srcClient = f.DynamicClient.Resource(gvr).Namespace(ns)
 	})
 
-	// PENDING SPEC (not executed)
-	// Requires a HTTP endpoint which address (Knative Service) is reachable by the CI host.
-	// TODO: configure Knative in CI to use resolvable KinD domain.
-	XContext("a source receives an HTTP request", func() {
+	Context("a source receives an HTTP request", func() {
 		var srcURL *url.URL
 
 		// sample payload struct and instance to be


### PR DESCRIPTION
KinD doesn't ship with a LoadBalancer implementation for Kubernetes, therefore the ingress gateway's external IP address was always `<pending>` in the E2E local cluster until now:

```
NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
kourier            LoadBalancer   10.96.63.132   <pending>     80:30758/TCP,443:30526/TCP   32s
```

This PR installs [MetalLB](https://metallb.universe.tf/) into the Kind Cluster, as described in the [docs](https://kind.sigs.k8s.io/docs/user/loadbalancer/), so that Kubernetes services of type LoadBalancer can automatically obtain an IP in the Docker subnet (notice the `EXTERNAL-IP` column):

```
NAME               TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                      AGE
kourier            LoadBalancer   10.96.254.43    172.18.255.200   80:30337/TCP,443:30002/TCP   62s
```

This IP is then used to configure the domain suffix in Knative Serving, so that the addresses of Knative Services are routable from the host (e.g. from Ginkgo tests):

```
NAME           URL                                                   LATESTCREATED        LATESTREADY           READY
event-display  http://event-display.default.172.18.255.200.sslip.io  event-display-00001  event-display-00001   True
```

This will allow us to facilitate the execution of E2E tests because we are now able to communicate directly with Knative Services.