### PR TITLE
Document GetBucketLocation perm for S3 target adapter

### DIFF
--- a/test/e2e/iam/aws_iam_policy.jsonc
+++ b/test/e2e/iam/aws_iam_policy.jsonc
@@ -195,6 +195,7 @@
             "Sid": "AWSS3TargetReceiveAdapter",
             "Effect": "Allow",
             "Action": [
+                "s3:GetBucketLocation",
                 "s3:PutObject"
             ],
             "Resource": "arn:aws:s3:::e2e-*"


### PR DESCRIPTION
This permission got omitted in #489 and the test failed as a result (I already fixed it).