### PR TITLE
Fix a small error in XMLToJSONTransformation

### DIFF
--- a/pkg/flow/adapter/xmltojsontransformation/adapter.go
+++ b/pkg/flow/adapter/xmltojsontransformation/adapter.go
@@ -110,8 +110,9 @@ func (a *Adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 	}
 
 	if a.sink != "" {
-		if err := a.ceClient.Send(ctx, event); err != nil {
+		if result := a.ceClient.Send(ctx, event); !cloudevents.IsACK(result) {
 			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, nil)
+
 		}
 		return nil, cloudevents.ResultACK
 	}

--- a/pkg/flow/adapter/xmltojsontransformation/adapter.go
+++ b/pkg/flow/adapter/xmltojsontransformation/adapter.go
@@ -112,7 +112,6 @@ func (a *Adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 	if a.sink != "" {
 		if result := a.ceClient.Send(ctx, event); !cloudevents.IsACK(result) {
 			return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, nil)
-
 		}
 		return nil, cloudevents.ResultACK
 	}


### PR DESCRIPTION
I had improperly implemented the Cloudevents client `.Send` method error handling. This PR fixes that issue. 