### PR TITLE
Document `GetRepository` IAM permission for AWS CodeCommit source adapter

### DIFF
--- a/test/e2e/iam/aws_iam_policy.jsonc
+++ b/test/e2e/iam/aws_iam_policy.jsonc
@@ -109,6 +109,7 @@
             "Sid": "AWSCodeCommitSourceReceiveAdapter",
             "Effect": "Allow",
             "Action": [
+                "codecommit:GetRepository",
                 "codecommit:GetBranch",
                 "codecommit:GetCommit",
                 "codecommit:ListPullRequests",


### PR DESCRIPTION
Since #478, the source adapter for AWS CodeCommit [requires this extra permission](https://github.com/triggermesh/triggermesh/blob/9015d96df2143eb0e0637a748d242313e6f78a53/pkg/sources/adapter/awscodecommitsource/adapter.go#L304-L310).
E2E tests have been failing ever since we merged this PR for that reason.