### PR TITLE
Add missing permission for E2E framework's Cloud Storage helper

### DIFF
--- a/test/e2e/iam/gcloud_iam_roles.yaml
+++ b/test/e2e/iam/gcloud_iam_roles.yaml
@@ -37,6 +37,7 @@ includedPermissions:
 - storage.buckets.delete
 - storage.objects.create
 - storage.objects.delete
+- storage.objects.list
 
 ---
 


### PR DESCRIPTION
This permission got omitted in #502