### PR TITLE
Add startup probe and improve logging in Azure Event Hubs source adapter

### DIFF
--- a/pkg/sources/reconciler/azureactivitylogssource/adapter.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 const defaultActivityLogsEventHubName = "insights-activity-logs"
 
@@ -83,6 +85,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvCEType, ceType),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/azureblobstoragesource/adapter.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 const envMessageProcessor = "EVENTHUB_MESSAGE_PROCESSOR"
 
@@ -77,6 +79,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVars(hubEnvs...),
 		resource.EnvVar(envMessageProcessor, "eventgrid"),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/azureeventgridsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventgridsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 const envMessageProcessor = "EVENTHUB_MESSAGE_PROCESSOR"
 
@@ -77,6 +79,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVars(hubEnvs...),
 		resource.EnvVar(envMessageProcessor, "eventgrid"),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/azureeventhubsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventhubsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
+
+const healthPortName = "health"
 
 // adapterConfig contains properties used to configure the source's adapter.
 // These are automatically populated by envconfig.
@@ -68,6 +70,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVar(common.EnvHubName, typedSrc.Spec.EventHubID.ResourceName),
 		resource.EnvVars(hubEnvs...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
 	)
 }
 

--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,9 +32,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
-const (
-	envAzureIOTHubConnString = "IOTHUB_CONNECTION_STRING"
-)
+const envAzureIOTHubConnString = "IOTHUB_CONNECTION_STRING"
 
 // adapterConfig contains properties used to configure the adapter.
 // These are automatically populated by envconfig.

--- a/pkg/sources/reconciler/common/resource/container.go
+++ b/pkg/sources/reconciler/common/resource/container.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -186,7 +186,8 @@ func StartupProbe(path, port string) ObjectOption {
 					Port: intstr.FromString(port),
 				},
 			},
-			PeriodSeconds: 1,
+			PeriodSeconds:    1,
+			FailureThreshold: 60,
 		}
 	}
 }

--- a/pkg/sources/reconciler/common/resource/container_test.go
+++ b/pkg/sources/reconciler/common/resource/container_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -90,7 +90,8 @@ func TestNewContainer(t *testing.T) {
 					Port: intstr.FromString("health"),
 				},
 			},
-			PeriodSeconds: 1,
+			PeriodSeconds:    1,
+			FailureThreshold: 60,
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/pkg/sources/reconciler/common/resource/deployment_test.go
+++ b/pkg/sources/reconciler/common/resource/deployment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -115,7 +115,8 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 									Port: intstr.FromString("health"),
 								},
 							},
-							PeriodSeconds: 1,
+							PeriodSeconds:    1,
+							FailureThreshold: 60,
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{


### PR DESCRIPTION
Fixes #512

1. Adds a startup probe that only gets active if all message receivers have been successfully started
2. Improves the logging around startup, shut down, and failures.