### PR TITLE
Update Google Cloud Storage Target

### DIFF
--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -81,6 +81,11 @@ spec:
                   payloadPolicy:
                     type: string
                     enum: [always, error, never]
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in objects created in GCP Storage.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
+                type: boolean
             required:
             - credentialsJson
             - bucketName

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
@@ -56,6 +56,11 @@ type GoogleCloudStorageTargetSpec struct {
 	// BucketName specifies the Google Storage Bucket
 	BucketName string `json:"bucketName"`
 
+	// Whether to omit CloudEvent context attributes in objects created in Google Cloud Storage.
+	// When this property is false (default), the entire CloudEvent payload is included.
+	// When this property is true, only the CloudEvent data is included.
+	DiscardCEContext bool `json:"discardCloudEventContext"`
+
 	// EventOptions for targets
 	EventOptions *EventOptions `json:"eventOptions,omitempty"`
 }

--- a/pkg/targets/adapter/googlecloudstoragetarget/config.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/config.go
@@ -35,4 +35,6 @@ type envAccessor struct {
 
 	// BridgeIdentifier is the name of the bridge workflow this target is part of
 	BridgeIdentifier string `envconfig:"EVENTS_BRIDGE_IDENTIFIER"`
+
+	DiscardCEContext bool `envconfig:"GOOGLE_STORAGE_DISCARD_CE_CONTEXT"`
 }

--- a/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
@@ -17,6 +17,8 @@ limitations under the License.
 package googlecloudstoragetarget
 
 import (
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -73,6 +75,9 @@ func makeAppEnv(spec *v1alpha1.GoogleCloudStorageTargetSpec) []corev1.EnvVar {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: spec.Credentials.SecretKeyRef,
 			},
+		}, {
+			Name:  "GOOGLE_STORAGE_DISCARD_CE_CONTEXT",
+			Value: strconv.FormatBool(spec.DiscardCEContext),
 		},
 	}
 


### PR DESCRIPTION
Update Google Cloud Storage Target:

- Remove the possibility to select the file
- By default store the event and not only the event data
- Have a special type to save only the event data
- Add support for DiscardCeContext