### PR TITLE
Add handler to the Amazon SNS source for HTTP startup probe

### DIFF
--- a/pkg/sources/adapter/awssnssource/probe/http.go
+++ b/pkg/sources/adapter/awssnssource/probe/http.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probe
+
+import "net/http"
+
+// EndpointPath is the recommended URL path of the health endpoint to serve a
+// ReadinessChecker over HTTP.
+const EndpointPath = "/health"
+
+// ignoreHealthEndpoint allows ignoring the health endpoint in results returned
+// by router.HandlersCount().
+func ignoreHealthEndpoint(urlPath string) bool {
+	return urlPath == EndpointPath
+}
+
+// ReadinessCheckerHTTPHandler returns a http.Handler which executes the given ReadinessChecker.
+func ReadinessCheckerHTTPHandler(c ReadinessChecker) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isReady, err := c.IsReady()
+		switch {
+		case err != nil:
+			w.WriteHeader(http.StatusInternalServerError)
+		case isReady:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+}

--- a/pkg/sources/adapter/awssnssource/probe/probe.go
+++ b/pkg/sources/adapter/awssnssource/probe/probe.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package probe contains facilities for asserting the readiness of a
+// multi-tenant receive adapter.
+package probe
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	listersv1alpha1 "github.com/triggermesh/triggermesh/pkg/client/generated/listers/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/router"
+)
+
+// ReadinessChecker can assert the readiness of a component.
+type ReadinessChecker interface {
+	IsReady() (bool, error)
+}
+
+// AdapterReadyChecker asserts the readiness of a receive adapter.
+type AdapterReadyChecker struct {
+	srcLister listersv1alpha1.AWSSNSSourceLister
+
+	srcRouter *router.Router
+
+	sync.RWMutex
+	isReady bool
+}
+
+var _ ReadinessChecker = (*AdapterReadyChecker)(nil)
+
+// NewAdapterReadyChecker returns an AdapterReadyChecker initialized with the
+// given Lister and Router.
+func NewAdapterReadyChecker(ls listersv1alpha1.AWSSNSSourceLister, r *router.Router) *AdapterReadyChecker {
+	return &AdapterReadyChecker{
+		srcLister: ls,
+		srcRouter: r,
+	}
+}
+
+// IsReady implements ReadinessChecker.
+// It checks whether the adapter has registered a handler for all observed sources.
+//
+// NOTE(antoineco): we might want to revisit this in the future, because the
+// following implementation details are currently leaking into this
+// ReadinessChecker implementation:
+//
+// - The fact that the adapter exposes a health endpoint via the HTTP router.
+// - The exact URL path of this health endpoint.
+// - The fact that a handler isn't registered for sources which don't have a valid sink.
+//
+// We consider this tight coupling acceptable for the time being, because this
+// is a sub-package of the main adapter package for the SNS source
+// specifically.
+func (c *AdapterReadyChecker) IsReady() (bool, error) {
+	// readiness already observed at an earlier point in time,
+	// short-circuit the check
+	if c.readLockedIsReady() {
+		return true, nil
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	// double-checked lock to ensure we don't write the value of "isReady"
+	// twice if multiple goroutines called IsReady() simultaneously.
+	if c.isReady {
+		return true, nil
+	}
+
+	sources, err := c.srcLister.List(labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("listing cached sources: %w", err)
+	}
+	// informer cache wasn't populated yet
+	if len(sources) == 0 {
+		return false, nil
+	}
+
+	numCachedSrcsWithSink := len(filterSourcesWithSink(sources))
+	numSrcHandlers := c.srcRouter.HandlersCount(ignoreHealthEndpoint)
+
+	c.isReady = numSrcHandlers >= numCachedSrcsWithSink
+
+	return c.isReady, nil
+}
+
+// readLockedIsReady returns the value of c.isReady while guaranteeing that
+// this value isn't currently being written by another goroutine.
+func (c *AdapterReadyChecker) readLockedIsReady() bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.isReady
+}
+
+// filterSourcesWithSink filters all source objects which don't report a valid
+// sink URL.
+func filterSourcesWithSink(srcs []*v1alpha1.AWSSNSSource) []*v1alpha1.AWSSNSSource {
+	srcsWithSink := make([]*v1alpha1.AWSSNSSource, 0, len(srcs))
+
+	for _, src := range srcs {
+		if src.Status.SinkURI != nil {
+			srcsWithSink = append(srcsWithSink, src)
+		}
+	}
+
+	return srcsWithSink
+}

--- a/pkg/sources/adapter/awssnssource/probe/probe_test.go
+++ b/pkg/sources/adapter/awssnssource/probe/probe_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probe_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/awssnssource/probe"
+	"github.com/triggermesh/triggermesh/pkg/sources/adapter/common/router"
+	adaptesting "github.com/triggermesh/triggermesh/pkg/sources/adapter/testing"
+)
+
+func TestAdapterReadyChecker(t *testing.T) {
+	testCases := map[string]struct {
+		cachedSrcs         []runtime.Object
+		registeredHandlers []string /*url path*/
+		expectReady        bool
+	}{
+		"Ready when as many source handlers as sources with sink": {
+			cachedSrcs: []runtime.Object{
+				newSourceWithSink("src1"),
+				newSourceWithSink("src2"),
+				newSourceWithoutSink("src3"),
+			},
+			registeredHandlers: []string{
+				"/test/src1",
+				"/test/src2",
+			},
+			expectReady: true,
+		},
+		"Ready when more source handlers than sources with sink": {
+			cachedSrcs: []runtime.Object{
+				newSourceWithSink("src1"),
+				newSourceWithoutSink("src2"),
+				newSourceWithoutSink("src3"),
+			},
+			registeredHandlers: []string{
+				"/test/src1",
+				"/test/src4",
+			},
+			expectReady: true,
+		},
+		"Not ready when less source handlers than sources with sink": {
+			cachedSrcs: []runtime.Object{
+				newSourceWithSink("src1"),
+				newSourceWithSink("src2"),
+				newSourceWithoutSink("src3"),
+			},
+			registeredHandlers: []string{
+				"/test/src1",
+				"/health", // expected to be ignored
+			},
+			expectReady: false,
+		},
+		"Not ready when no source handler is registered": {
+			cachedSrcs: []runtime.Object{
+				newSourceWithSink("src1"),
+			},
+			registeredHandlers: []string{
+				"/health", // expected to be ignored
+			},
+			expectReady: false,
+		},
+		"Not ready when informer cache is empty": {
+			cachedSrcs: []runtime.Object{},
+			registeredHandlers: []string{
+				"/test/src1",
+			},
+			expectReady: false,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ls := adaptesting.NewListers(adaptesting.NewScheme(), tc.cachedSrcs)
+			l := ls.GetAWSSNSSourceLister()
+
+			r := &router.Router{}
+			for _, h := range tc.registeredHandlers {
+				r.RegisterPath(h, nil)
+			}
+
+			c := probe.NewAdapterReadyChecker(l, r)
+
+			isReady, err := c.IsReady()
+			require.NoError(t, err, "IsReady shouldn't fail")
+
+			if tc.expectReady {
+				assert.True(t, isReady, "ReadinessChecker should be ready")
+			} else {
+				assert.False(t, isReady, "ReadinessChecker shouldn't be ready")
+			}
+		})
+	}
+}
+
+func newSourceWithSink(name string) *v1alpha1.AWSSNSSource {
+	src := newSourceWithoutSink(name)
+	src.Status.SinkURI = apis.HTTP("example.com")
+	return src
+}
+
+func newSourceWithoutSink(name string) *v1alpha1.AWSSNSSource {
+	return &v1alpha1.AWSSNSSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test", // irrelevant in the context of these tests
+			Name:      name,
+		},
+	}
+}

--- a/pkg/sources/adapter/common/router/router.go
+++ b/pkg/sources/adapter/common/router/router.go
@@ -42,6 +42,31 @@ func (r *Router) DeregisterPath(urlPath string) {
 	r.handlers.Delete(urlPath)
 }
 
+// HandlersCount returns the number of handlers that are currently registered.
+func (r *Router) HandlersCount(filters ...handlerMatcherFunc) int {
+	var count int
+
+	r.handlers.Range(func(urlPath, _ interface{}) bool {
+		for _, f := range filters {
+			if f(urlPath.(string)) {
+				return true
+			}
+		}
+
+		count++
+
+		return true
+	})
+
+	return count
+}
+
+// handlerMatcherFunc is a matcher that allows ignoring some of the handlers
+// inside HandlersCount() based on arbitrary predicates.
+// The function should return 'true' if the given urlPath matches the
+// predicate, in which case the handler is ignored.
+type handlerMatcherFunc func(urlPath string) bool
+
 // ServeHTTP implements http.Handler.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h, ok := r.handlers.Load(req.URL.Path)

--- a/pkg/sources/adapter/common/router/router_test.go
+++ b/pkg/sources/adapter/common/router/router_test.go
@@ -31,6 +31,8 @@ const headerHandlerName = "HANDLER"
 func TestRouter(t *testing.T) {
 	r := &Router{}
 
+	assert.Equal(t, 0, r.HandlersCount())
+
 	// new router responds with status NotFound
 
 	resp := recordResponse(t, r, "/")
@@ -40,6 +42,8 @@ func TestRouter(t *testing.T) {
 
 	r.RegisterPath("/foo", responder("foo"))
 	r.RegisterPath("/bar", responder("bar"))
+
+	assert.Equal(t, 2, r.HandlersCount())
 
 	assert.Equal(t, []string{"/bar", "/foo"}, handlersKeys(r))
 
@@ -54,11 +58,15 @@ func TestRouter(t *testing.T) {
 	r.DeregisterPath("/")
 	r.DeregisterPath("/baz")
 
+	assert.Equal(t, 2, r.HandlersCount())
+
 	assert.Equal(t, []string{"/bar", "/foo"}, handlersKeys(r))
 
 	// delete a registered path
 
 	r.DeregisterPath("/foo")
+
+	assert.Equal(t, 1, r.HandlersCount())
 
 	assert.Equal(t, []string{"/bar"}, handlersKeys(r))
 

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -48,6 +48,9 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, _ *apis.URL) *servin
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		// NOTE(antoineco): startupProbe isn't yet supported as of Knative 1.2
+		resource.Probe("/health", ""),
 	)
 }
 

--- a/pkg/sources/reconciler/common/resource/knservice_test.go
+++ b/pkg/sources/reconciler/common/resource/knservice_test.go
@@ -37,7 +37,8 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		EnvVar("TEST_ENV1", "val1"),
 		Port("h2c", 8080), // overrides previously defined port
 		Label("test.label/1", "val1"),
-		Probe("/health", "health"), // port is ignored
+		Probe("/health", "health"),             // port is ignored
+		StartupProbe("/initialized", "health"), // port is ignored
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
@@ -93,6 +94,15 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 											Path: "/health",
 										},
 									},
+								},
+								StartupProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/initialized",
+										},
+									},
+									PeriodSeconds:    1,
+									FailureThreshold: 60,
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{


### PR DESCRIPTION
Returns an error until a handler has been registered for _all_ source objects cached in the informer.

Prevents the reconciler from attempting to subscribe new instances before the HTTP handler is actually ready to serve.
Avoids multi-registrations as a result.

Fixes #29

---

Note: this is really meant to be used as a **startup** probe, but because Knative doesn't support it, it is set as a readiness probe instead.
This should have the same result though, because Knative doesn't actually set a `readinessProbe` on the user container. Instead, it passes the probe definition to the `queue-proxy` container as an environment variable, which uses it to perform a series of quick requests when the pod starts.

```console
$ kubectl get deployments/awssnssource-adapter-00001-deployment -o jsonpath='{.spec.template.spec.containers[?(@.name=="adapter")].readinessProbe}'
null
```

```console
$ kubectl get deployments/awssnssource-adapter-00001-deployment -o jsonpath='{.spec.template.spec.containers[?(@.name=="queue-proxy")].env[?(@.name=="SERVING_READINESS_PROBE")].value}'
{"httpGet":{"path":"/health","port":8080,"host":"127.0.0.1","scheme":"HTTP","httpHeaders":[{"name":"K-Kubelet-Probe","value":"queue"}]},"successThreshold":1}
```

Then, if I log every request to the internal Router for debugging purposes:

```console
$ kubectl logs deployments/awssnssource-adapter-00001-deployment adapter -f
2022/01/31 14:52:59 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:00 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:01 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:02 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:03 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:04 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:05 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:06 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:07 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:08 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
2022/01/31 14:53:09 GET "/health" map[Accept-Encoding:[gzip] Connection:[close] K-Kubelet-Probe:[queue] User-Agent:[kube-probe//]]
...
```