### PR TITLE
Use `strings.Replacer` instead of sequential `strings.Replace()`

### DIFF
--- a/pkg/sources/adapter/slacksource/slack_test.go
+++ b/pkg/sources/adapter/slacksource/slack_test.go
@@ -57,7 +57,7 @@ func TestSlackEvent(t *testing.T) {
 			body: read("this is not an expected message"),
 
 			expectedCode:     http.StatusBadRequest,
-			expectedContains: "could not unmarshall JSON request:",
+			expectedContains: "could not unmarshal JSON request:",
 		},
 
 		"not an expected message": {


### PR DESCRIPTION
Today, I learned about the existence of [`strings.Replacer`](https://pkg.go.dev/strings#Replacer) while browsing browsing the `net/http` stdlib package ([here](https://cs.opensource.google/go/go/+/refs/tags/go1.17.6:src/net/http/header.go;l=130)).
So I decided to improve the implementation of that exact string replacement which I pushed not long ago in #340.