### PR TITLE
Enable support for discardCEContext and send CloudEvent data as a JSON payload for the Azure Event Hubs target

### DIFF
--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -66,7 +66,7 @@ spec:
                 type: string
                 pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
               discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in objects created in S3.
+                description: Whether to omit CloudEvent context attributes in objects created in Azure Event Hub.
                   When this property is false (default), the entire CloudEvent payload is included.
                   When this property is true, only the CloudEvent data is included.
                 type: boolean

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -65,6 +65,11 @@ spec:
                     /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
                 type: string
                 pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in objects created in S3.
+                  When this property is false (default), the entire CloudEvent payload is included.
+                  When this property is true, only the CloudEvent data is included.
+                type: boolean
               auth:
                 description: Authentication method to interact with the Azure Event Hubs REST API.
                 type: object

--- a/pkg/apis/targets/v1alpha1/azureeventhubs_types.go
+++ b/pkg/apis/targets/v1alpha1/azureeventhubs_types.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
@@ -61,7 +62,7 @@ type AzureEventHubsTargetSpec struct {
 	// EventOptions for targets
 	EventOptions *EventOptions `json:"eventOptions,omitempty"`
 
-	DiscardCEContext bool `json:"discardCEContext"`
+	DiscardCEContext bool `json:"discardCloudEventContext"`
 }
 
 // AzureEventHubsTargetStatus communicates the observed state of the AzureEventHubsTarget (from the controller).

--- a/test/e2e/targets/azureeventhubs/main.go
+++ b/test/e2e/targets/azureeventhubs/main.go
@@ -211,7 +211,7 @@ var _ = Describe("Azure Event Hubs target", func() {
 				By("creating an AzureEventHubsTarget object", func() {
 					tgt, err := createTarget(tgtClient, ns, "test-",
 						withServicePrincipal(),
-						withoutCloudEvents(),
+						withDiscardCEContextEnabled(),
 						withEventHubID(subscriptionID, rg, ns, ns))
 
 					Expect(err).ToNot(HaveOccurred())
@@ -289,12 +289,7 @@ var _ = Describe("Azure Event Hubs target", func() {
 
 				By("verifying the sent event", func() {
 					Expect(len(payload)).To(BeNumerically(">", 0))
-
-					// NOTE: The payload will be a stringified version of the CloudEvent
-					Expect(payload).To(ContainSubstring(string(event.Data())))
-					Expect(payload).ToNot(ContainSubstring("type: " + event.Type()))
-					Expect(payload).ToNot(ContainSubstring("source: " + event.Source()))
-					Expect(payload).ToNot(ContainSubstring("id: " + event.ID()))
+					Expect(payload).To(Equal(string(event.Data())))
 				})
 			})
 		})
@@ -376,7 +371,7 @@ func withEventHubID(subscriptionID, resourceGroup, eventHubNS, eventHub string) 
 	}
 }
 
-func withoutCloudEvents() targetOption {
+func withDiscardCEContextEnabled() targetOption {
 	return func(tgt *unstructured.Unstructured) {
 		if err := unstructured.SetNestedField(tgt.Object, true, "spec", "discardCloudEventContext"); err != nil {
 			framework.FailfWithOffset(2, "Failed to set spec.discardCloudEventContext field: %s", err)

--- a/test/e2e/targets/azureeventhubs/main.go
+++ b/test/e2e/targets/azureeventhubs/main.go
@@ -18,6 +18,7 @@ package azureeventhubs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -190,12 +191,110 @@ var _ = Describe("Azure Event Hubs target", func() {
 
 				By("verifying the sent event", func() {
 					Expect(len(payload)).To(BeNumerically(">", 0))
+					var ce cloudevents.Event
+
+					err := json.Unmarshal(payload, &ce)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(ce.Data()).To(ContainSubstring(string(event.Data())))
+					Expect(ce.ID()).To(Equal(event.ID()))
+					Expect(ce.Type()).To(Equal(event.Type()))
+					Expect(ce.Subject()).To(Equal(event.Subject()))
+				})
+			})
+		})
+
+		When("the spec contains default settings and the CloudEvent Context disabled", func() {
+			var tgtURL *url.URL
+
+			BeforeEach(func() {
+				By("creating an AzureEventHubsTarget object", func() {
+					tgt, err := createTarget(tgtClient, ns, "test-",
+						withServicePrincipal(),
+						withoutCloudEvents(),
+						withEventHubID(subscriptionID, rg, ns, ns))
+
+					Expect(err).ToNot(HaveOccurred())
+
+					tgt = ducktypes.WaitUntilReady(f.DynamicClient, tgt)
+					tgtURL = ducktypes.Address(tgt)
+					Expect(tgtURL).ToNot(BeNil())
+				})
+			})
+
+			It("receives an event on the Event Hub", func() {
+				var event *cloudevents.Event
+				var partitionIDs []string
+				var eventHandler eventhubs.Handler
+				var evCtx context.Context // Used to set a timeout for reading events
+				var payload []byte
+
+				eventReceivedChannel := make(chan bool)
+
+				By("retrieving Event Hub partition details", func() {
+					info, err := hub.GetRuntimeInformation(ctx)
+					Expect(err).NotTo(HaveOccurred())
+
+					partitionIDs = info.PartitionIDs
+					Expect(len(partitionIDs)).To(BeNumerically(">", 0))
+				})
+
+				By("setting up a handler to verify the received event", func() {
+					eventHandler = func(ctx context.Context, ev *eventhubs.Event) error {
+						payload = ev.Data
+
+						// Pass the bool to the channel to terminate the receiver
+						eventReceivedChannel <- true
+
+						return nil
+					}
+				})
+
+				By("starting the handler to consume events", func() {
+					// Set a context with a timeout to ensure the event handler isn't waiting forever
+					var evCancel context.CancelFunc // Used to cancel the reading context
+					evCtx, evCancel = context.WithTimeout(ctx, time.Second*15)
+
+					for _, pID := range partitionIDs {
+						_, err := hub.Receive(
+							ctx,
+							pID,
+							eventHandler,
+							eventhubs.ReceiveWithStartingOffset(persist.StartOfStream),
+						)
+
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					DeferCleanup(func() {
+						evCancel()
+					})
+				})
+
+				By("sending an event", func() {
+					event = e2ece.NewHelloEvent(f)
+
+					j := e2ece.RunEventSender(f.KubeClient, ns, tgtURL.String(), event)
+					apps.WaitForCompletion(f.KubeClient, j)
+				})
+
+				By("waiting for the event to be received", func() {
+					// don't exit till event is received by handler or times out
+					select {
+					case <-eventReceivedChannel:
+					case <-evCtx.Done():
+						framework.FailfWithOffset(2, "timed out while waiting for event")
+					}
+				})
+
+				By("verifying the sent event", func() {
+					Expect(len(payload)).To(BeNumerically(">", 0))
 
 					// NOTE: The payload will be a stringified version of the CloudEvent
 					Expect(payload).To(ContainSubstring(string(event.Data())))
-					Expect(payload).To(ContainSubstring("type: " + event.Type()))
-					Expect(payload).To(ContainSubstring("source: " + event.Source()))
-					Expect(payload).To(ContainSubstring("id: " + event.ID()))
+					Expect(payload).ToNot(ContainSubstring("type: " + event.Type()))
+					Expect(payload).ToNot(ContainSubstring("source: " + event.Source()))
+					Expect(payload).ToNot(ContainSubstring("id: " + event.ID()))
 				})
 			})
 		})
@@ -273,6 +372,14 @@ func withEventHubID(subscriptionID, resourceGroup, eventHubNS, eventHub string) 
 	return func(tgt *unstructured.Unstructured) {
 		if err := unstructured.SetNestedField(tgt.Object, eventHubID, "spec", "eventHubID"); err != nil {
 			framework.FailfWithOffset(2, "Failed to set spec.eventHubID field: %s", err)
+		}
+	}
+}
+
+func withoutCloudEvents() targetOption {
+	return func(tgt *unstructured.Unstructured) {
+		if err := unstructured.SetNestedField(tgt.Object, true, "spec", "discardCloudEventContext"); err != nil {
+			framework.FailfWithOffset(2, "Failed to set spec.discardCloudEventContext field: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
While working on the E2E test for the Azure Event Hubs target, noticed that the option to discard CloudEventwas not included with the config, and therefore the target defaulted to sending the full CloudEvent payload. Additionally, the CloudEvent payload was being sent as a human readable string instead of a marshalled JSON payload that is machine readable.

Closes #517 