### PR TITLE
Mitigate flaky E2E test for Azure Event Grid source by allowing Azure some time for setting up the System Topic

### DIFF
--- a/test/e2e/sources/azureblobstorage/main.go
+++ b/test/e2e/sources/azureblobstorage/main.go
@@ -163,6 +163,7 @@ var _ = Describe("Azure Blob Storage source", func() {
 				// topic upon creation of the Event Grid subscription by our reconciler (Blob Storage
 				// events are routed over Event Grid). The source shouldn't report Ready before this
 				// system topic is available, because events occuring prior to that are dropped.
+				// Ref. https://github.com/triggermesh/triggermesh/issues/446
 				time.Sleep(1 * time.Minute)
 			})
 		})
@@ -174,7 +175,7 @@ var _ = Describe("Azure Blob Storage source", func() {
 			// instead of
 			//   "When: a blob is created/deleted ..., Specify: the source generates ..."
 			// to avoid creating a separate set of Azure resources for each spec, which would significantly
-			// increases the duration of the test with no real benefit.
+			// increase the duration of the test with no real benefit.
 			Specify("the source generates events", func() {
 
 				By("creating a blob", func() {


### PR DESCRIPTION
Mitigates / closes #522

Temporary workaround until #446 is implemented.

I already included such workaround for the Azure Blob Storage source (\*) test in #445, but forgot to add it to the test for the Azure Event Grid source, which suffers from the same race issue.

_\* also based on Event Grid_