### PR TITLE
IBM MQ Keystore mount sub-path fix

### DIFF
--- a/pkg/sources/reconciler/common/resource/container.go
+++ b/pkg/sources/reconciler/common/resource/container.go
@@ -268,7 +268,7 @@ func SecretMount(name string, target string, secret *corev1.SecretKeySelector) O
 			Name:      name,
 			ReadOnly:  true,
 			MountPath: target,
-			SubPath:   secret.Key,
+			SubPath:   path.Base(target),
 		}
 		volume := corev1.Volume{
 			Name: name,

--- a/pkg/targets/reconciler/resources/kservice.go
+++ b/pkg/targets/reconciler/resources/kservice.go
@@ -165,7 +165,7 @@ func SecretMount(name string, target string, secret *corev1.SecretKeySelector) K
 				Name:      name,
 				ReadOnly:  true,
 				MountPath: target,
-				SubPath:   secret.Key,
+				SubPath:   path.Base(target),
 			},
 		)
 		object.Spec.ConfigurationSpec.Template.Spec.Volumes = append(


### PR DESCRIPTION
The previous combination of Secret's `MountPath` and `SubPath` didn't work for keystore files named other than `key.kdb` and `key.sth`. This small fix makes the reconciler handle properly secrets with arbitrary key names.