### PR TITLE
Increase parallelism of Ginkgo tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -117,7 +117,7 @@ jobs:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      run: ginkgo -p -slow-spec-threshold=10m -randomize-all ./test/e2e/
+      run: ginkgo -procs=$(($(nproc)*2)) -slow-spec-threshold=10m -randomize-all ./test/e2e/
 
     # The KinD cluster can get shut down before all API objects created during
     # E2E tests have been terminated, which leaks cloud resources depending on


### PR DESCRIPTION
GitHub Actions workers run on [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series#dsv2-series) Azure VMs, which have only 2 CPU cores.

By default, when parallel tests are enabled with the `-p` flag, Ginkgo uses the number of available CPU cores to determine the number of "nodes" (parallel tests) to run.
We want to double that number because our tests aren't compute intensive at all, and some of them spend a long time doing nothing, simply waiting for cloud resources to be set up, or for an event to arrive.

With this change, Ginkgo can run **4** tests in parallel instead of 2:

```
Running in parallel across 4 processes
```