### PR TITLE
Remove `shortNames` from CRDs

### DIFF
--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -38,8 +38,6 @@ spec:
     - all
     - triggermesh
     - routing
-    shortNames:
-    - fl
   versions:
   - name: v1alpha1
     served: true

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -38,8 +38,6 @@ spec:
     - all
     - triggermesh
     - routing
-    shortNames:
-    - spl
   versions:
   - name: v1alpha1
     served: true

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -38,8 +38,6 @@ spec:
     - all
     - triggermesh
     - extensions
-    shortNames:
-    - fn
   versions:
   - name: v1alpha1
     served: true

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -38,8 +38,6 @@ spec:
     - knative
     - eventing
     - transformations
-    shortNames:
-    - trn
   versions:
   - name: v1alpha1
     served: true

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -41,8 +41,6 @@ spec:
     - eventing
     - triggermesh
     - transformations
-    shortNames:
-    - xmltojsontrn
   versions:
   - name: v1alpha1
     served: true

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -40,8 +40,6 @@ spec:
     - eventing
     - triggermesh
     - transformations
-    shortNames:
-    - xslt
   versions:
   - name: v1alpha1
     served: true


### PR DESCRIPTION
shortNames aren't API-namespaced, which may cause errors of type `ShortNamesConflict` while deploying/updating TriggerMesh.