### PR TITLE
Add "metrics" port to all Deployment-based components

### DIFF
--- a/pkg/routing/reconciler/common/adapter.go
+++ b/pkg/routing/reconciler/common/adapter.go
@@ -36,7 +36,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/routing/reconciler/common/resource"
 )
 
-const metricsPrometheusPort uint16 = 9092
+const metricsPrometheusPortKsvc uint16 = 9092
 
 // ComponentName returns the component name for the given source object.
 func ComponentName(src kmeta.OwnerRefable) string {
@@ -83,7 +83,7 @@ func commonAdapterKnServiceOptions(src v1alpha1.Router) []resource.ObjectOption 
 		resource.ServiceAccount(MTAdapterObjectName(src)),
 
 		resource.EnvVar(envComponent, app),
-		resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
+		resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPortKsvc), 10)),
 	}
 }
 

--- a/pkg/sources/reconciler/common/adapter.go
+++ b/pkg/sources/reconciler/common/adapter.go
@@ -35,7 +35,12 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/common/resource"
 )
 
-const metricsPrometheusPort uint16 = 9092
+const (
+	metricsPrometheusPortName = "metrics"
+
+	metricsPrometheusPort     uint16 = 9090
+	metricsPrometheusPortKsvc uint16 = 9092
+)
 
 // ComponentName returns the component name for the given source object.
 func ComponentName(src kmeta.OwnerRefable) string {
@@ -123,6 +128,8 @@ func commonAdapterDeploymentOptions(src v1alpha1.EventSource) []resource.ObjectO
 		resource.ServiceAccount(ServiceAccountName(src)),
 
 		resource.EnvVar(envComponent, app),
+
+		resource.Port(metricsPrometheusPortName, int32(metricsPrometheusPort)),
 	}
 }
 
@@ -182,7 +189,7 @@ func commonAdapterKnServiceOptions(src v1alpha1.EventSource) []resource.ObjectOp
 		resource.ServiceAccount(MTAdapterObjectName(src)),
 
 		resource.EnvVar(envComponent, app),
-		resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
+		resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPortKsvc), 10)),
 	}
 }
 


### PR DESCRIPTION
Allows Prometheus to be conveniently configured to scrape all TriggerMesh-owned Pods containing this named port using a PodMonitor.

E.g.

```yaml
  selector:
    matchLabels:
      app.kubernetes.io/part-of: triggermesh
  podMetricsEndpoints:
  - port: metrics
```

Note: components backed by a Knative Service are scraped using a different method (using ServiceMonitors), because a Ksvc can only declare _one_ port.