### PR TITLE
Fix duplicate "metrics" port in Amazon SQS source

### DIFF
--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -61,7 +61,6 @@ func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
-		resource.Port("metrics", 9090),
 
 		resource.StartupProbe("/health", healthPortName),
 


### PR DESCRIPTION
PR #573 enabled the injection of a "metrics" port in all event sources backed by a Deployment.

The SQS source already declared such port, so the reconciler tries to create a Deployment with a duplicate port, and fails.