### PR TITLE
Set Iot Hub SKU to Basic in E2E test framework

### DIFF
--- a/test/e2e/framework/azure/iothub.go
+++ b/test/e2e/framework/azure/iothub.go
@@ -50,9 +50,8 @@ func CreateIOTHubComponents(ctx context.Context, subscriptionID, rg, region, nam
 		Location: &region,
 		Tags:     map[string]*string{E2EInstanceTagKey: to.StringPtr(name)},
 		SKU: &armiothub.SKUInfo{
-			Name:     armiothub.IotHubSKUF1.ToPtr(),
+			Name:     armiothub.IotHubSKUB1.ToPtr(),
 			Capacity: to.Int64Ptr(1),
-			Tier:     armiothub.IotHubSKUTierFree.ToPtr(),
 		},
 		Identity: &armiothub.ArmIdentity{
 			Type: armiothub.ResourceIdentityTypeNone.ToPtr(),


### PR DESCRIPTION
The free tier doesn't allow creating multiple instances, which causes failures while running multiple E2E test workflows in parallel.

Fixes #443

Proof that it works as expected, while running the same test twice in two different terminal windows:

![image](https://user-images.githubusercontent.com/3299086/156022390-49644812-a693-4d90-8666-86c5449ca1a7.png)