### PR TITLE
Relax e2e test invocation by introducing CODEOWNERS

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,23 +1,17 @@
 name: End-to-End Testing
 
 on:
-  push:
-    # NOTE(antoineco): To avoid exposing repository secrets to user supplied
-    # code in pull requests, we only allow this workflow to run on the 'main'
-    # branch, where all code changes are expected to have been reviewed by
-    # maintainers.
-    #
-    # We may want to relax this in the future, on condition that safeguards are
-    # added to prevent the workflow from running automatically when an external
-    # contributor submits code changes inside the .github/workflows/ or
-    # test/e2e/ directories.
-    #
-    # Ref. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    branches: [ main ]
+  pull_request_review:
+    types: [submitted]
+    # Run the e2e test once the PR has been approved to allow for a final check before
+    # merging the PR. One of the contributers metioned in CODEOWNERS must approve the PR
+    # if it touches .github/ or test/e2e/ to prevent potential credential leakage.
 
 jobs:
 
   e2e-triggermesh:
+    if: github.event.review.state == 'approved'
+
     name: Test TriggerMesh components
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -6,6 +6,8 @@ on:
     # Run the e2e test once the PR has been approved to allow for a final check before
     # merging the PR. One of the contributers metioned in CODEOWNERS must approve the PR
     # if it touches .github/ or test/e2e/ to prevent potential credential leakage.
+  push:
+    branches: [main]
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,8 +1,10 @@
 name: End-to-End Testing
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    # Rely on default actions of opened, reopened, and syncrhonize to trigger a run
+  #pull_request_review:
+  #  types: [submitted]
     # Run the e2e test once the PR has been approved to allow for a final check before
     # merging the PR. One of the contributers metioned in CODEOWNERS must approve the PR
     # if it touches .github/ or test/e2e/ to prevent potential credential leakage.

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,13 +3,14 @@ name: End-to-End Testing
 on:
   pull_request_target:
     # Rely on default actions of opened, reopened, and syncrhonize to trigger a run
-  #pull_request_review:
-  #  types: [submitted]
+    # against the target repo to ensure the e2e tests function as intended.
+  pull_request_review:
+    types: [ submitted ]
     # Run the e2e test once the PR has been approved to allow for a final check before
     # merging the PR. One of the contributers metioned in CODEOWNERS must approve the PR
     # if it touches .github/ or test/e2e/ to prevent potential credential leakage.
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Reflect current maintainers allowed to approve pull requests that touch the .github
+# and test/e2e repos. This is the TriggerMesh engineering team
+
+/.github/	@triggermesh/engineering
+/test/e2e/	@triggermesh/engineering

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Reflect current maintainers allowed to approve pull requests that touch the .github
-# and test/e2e repos. This is the TriggerMesh engineering team
+# and test/e2e directories. This is the TriggerMesh engineering team.
 
-/.github/	@triggermesh/engineering
-/test/e2e/	@triggermesh/engineering
+/.github/workflows/   @triggermesh/engineering
+/test/e2e/            @triggermesh/engineering


### PR DESCRIPTION
Based on a conversation with @antoineco relax some of the requirements for running the e2e tests by introducing a `CODEOWNERS` file to reflect who will be allowed to approve a PR affecting `.github/` for workflows and `test/e2e` for introducing additional tests.  By default, only members of the TriggerMesh organization can approve changes to these repos.

The action tweak is documented in: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved