### PR TITLE
Remove deprecated input in `golangci-lint` GitHub Action

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -25,8 +25,6 @@ jobs:
     # the Go setup, in case other steps are added to this job in the future.
     - name: Lint Go code
       uses: golangci/golangci-lint-action@v3
-      with:
-        skip-go-installation: true
 
   lint-config:
     name: Configuration Linting


### PR DESCRIPTION
Since v3, the Action doesn't install Go anymore. This operation is at the discretion of the user.

> Warning: Unexpected input(s) 'skip-go-installation', valid inputs are ['version', 'args', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-pkg-cache', 'skip-build-cache']