### PR TITLE
Fix Synchronizer correlation key generator

### DIFF
--- a/pkg/flow/adapter/synchronizer/correlation.go
+++ b/pkg/flow/adapter/synchronizer/correlation.go
@@ -83,7 +83,7 @@ func (k *correlationKey) set(event *cloudevents.Event) string {
 // randString generates the random string with fixed length.
 func randString(length int) string {
 	k := make([]byte, length)
-	l := len(correlationKeycharset)
+	l := len(correlationKeycharset) - 1
 	for i := range k {
 		k[i] = correlationKeycharset[seededRand.Intn(l)]
 	}


### PR DESCRIPTION
Before this fix, `len` was used as a scope for a random letter index, i.e. for the set of characters `c` with length 3, we could try to access c[3], and that caused a panic. 