### PR TITLE
Bumblebee's "Parse" operation

### DIFF
--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -63,7 +63,7 @@ spec:
                     operation:
                       description: Name of the transformation operation.
                       type: string
-                      enum: ['add', 'delete', 'shift', 'store']
+                      enum: ['add', 'delete', 'shift', 'store', 'parse']
                     paths:
                       description: Key-value event pairs to apply the transformations on.
                       type: array
@@ -90,7 +90,7 @@ spec:
                     operation:
                       description: Name of the transformation operation.
                       type: string
-                      enum: ['add', 'delete', 'shift', 'store']
+                      enum: ['add', 'delete', 'shift', 'store', 'parse']
                     paths:
                       description: Key-value event pairs to apply the transformations on.
                       type: array

--- a/config/samples/bumblebee/parse-json/pingsource.yaml
+++ b/config/samples/bumblebee/parse-json/pingsource.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sources.knative.dev/v1
+kind: PingSource
+metadata:
+  name: ping-source
+spec:
+  schedule: "*/1 * * * *"
+  contentType: "application/json"
+  data: '{
+    "key1": "value1",
+    "metadata": {
+      "client": "{\"host\": \"localhost\",\"user-agent\": \"Mozilla/4.0\"}"
+    }
+  }'
+  sink:
+    ref:
+      apiVersion: flow.triggermesh.io/v1alpha1
+      kind: Transformation
+      name: string-json-transformation

--- a/config/samples/bumblebee/parse-json/sockeye.yaml
+++ b/config/samples/bumblebee/parse-json/sockeye.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: sockeye
+spec:
+  template:
+    spec:
+      containers:
+      - image: docker.io/n3wscott/sockeye:v0.7.0

--- a/config/samples/bumblebee/parse-json/transformation.yaml
+++ b/config/samples/bumblebee/parse-json/transformation.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: flow.triggermesh.io/v1alpha1
+kind: Transformation
+metadata:
+  name: string-json-transformation
+spec:
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: sockeye
+  data:
+  - operation: parse
+    paths:
+    - key: metadata.client
+      value: JSON
+  - operation: shift
+    paths:
+    - key: metadata.client.host:address

--- a/pkg/flow/adapter/transformation/common/convert/convert.go
+++ b/pkg/flow/adapter/transformation/common/convert/convert.go
@@ -92,6 +92,8 @@ func MergeJSONWithMap(source, appendix interface{}) interface{} {
 		source = resArr
 	case map[string]interface{}:
 		switch s := source.(type) {
+		case float64, bool, string:
+			return appendixValue
 		case nil:
 			source = make(map[string]interface{})
 			return MergeJSONWithMap(source, appendixValue)

--- a/pkg/flow/adapter/transformation/handler.go
+++ b/pkg/flow/adapter/transformation/handler.go
@@ -119,7 +119,7 @@ func (t *Handler) applyTransformations(event cloudevents.Event) (*cloudevents.Ev
 	}
 
 	// init indicates if we need to run initial step transformation
-	var init bool = true
+	var init = true
 	var errs []string
 
 	// Run init step such as load Pipeline variables first

--- a/pkg/flow/adapter/transformation/handler.go
+++ b/pkg/flow/adapter/transformation/handler.go
@@ -119,7 +119,7 @@ func (t *Handler) applyTransformations(event cloudevents.Event) (*cloudevents.Ev
 	}
 
 	// init indicates if we need to run initial step transformation
-	var init bool = false
+	var init bool = true
 	var errs []string
 
 	// Run init step such as load Pipeline variables first

--- a/pkg/flow/adapter/transformation/handler_test.go
+++ b/pkg/flow/adapter/transformation/handler_test.go
@@ -215,6 +215,80 @@ func TestReceiveAndTransform(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "Parse operation",
+			originalEvent: setData(t, newEvent(),
+				json.RawMessage(`{"key1":"value1","strJSON":"{\"foo\":123,\"bar\":\"value2\",\"baz\":[\"one\",\"two\",\"three\"]}"}`)),
+			expectedEventData: `{"key1":"value1","number":"three"}`,
+			data: []v1alpha1.Transform{
+				{
+					Operation: "parse",
+					Paths: []v1alpha1.Path{
+						{
+							Key:   "strJSON",
+							Value: "json",
+						},
+					},
+				}, {
+					Operation: "shift",
+					Paths: []v1alpha1.Path{
+						{
+							Key: "strJSON.baz[2]:number",
+						},
+					},
+				}, {
+					Operation: "delete",
+					Paths: []v1alpha1.Path{
+						{
+							Key: "strJSON",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Ignore errors", //ensure that errored transformation won't affect the event
+			originalEvent: setData(t, newEvent(),
+				json.RawMessage(`{"key1":"value1","object":{"foo":"bar"}}`)),
+			expectedEventData: `{"key1":"value1","object":{"foo":"bar"}}`,
+			data: []v1alpha1.Transform{
+				{
+					Operation: "parse",
+					Paths: []v1alpha1.Path{
+						{
+							Key:   "bad-value-type",
+							Value: "jnos",
+						}, {
+							Key:   "Non-existing-key",
+							Value: "json",
+						},
+					},
+				}, {
+					Operation: "shift",
+					Paths: []v1alpha1.Path{
+						{
+							Key: "Non-existing-key:key1",
+						}, {
+							Key: "object.non-existing-key:key2",
+						},
+					},
+				}, {
+					Operation: "delete",
+					Paths: []v1alpha1.Path{
+						{
+							Key: "Non-existing-key",
+						},
+					},
+				}, {
+					Operation: "store",
+					Paths: []v1alpha1.Path{
+						{
+							Key:   "$var1",
+							Value: "Non-existing-key",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/flow/adapter/transformation/pipeline.go
+++ b/pkg/flow/adapter/transformation/pipeline.go
@@ -19,6 +19,7 @@ package transformation
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
@@ -77,32 +78,19 @@ func (p *Pipeline) setStorage(s *storage.Storage) {
 	}
 }
 
-// InitStep runs Transformations that are marked as InitStep.
-func (p *Pipeline) initStep(data []byte) ([]byte, error) {
+// Apply applies Pipeline transformations.
+func (p *Pipeline) apply(data []byte, init bool) ([]byte, error) {
 	var err error
+	var errs []string
 	for _, v := range p.Transformers {
-		if !v.InitStep() {
-			continue
-		}
-		data, err = v.Apply(data)
-		if err != nil {
-			return data, err
+		if init == v.InitStep() {
+			if data, err = v.Apply(data); err != nil {
+				errs = append(errs, err.Error())
+			}
 		}
 	}
-	return data, nil
-}
-
-// Apply applies Pipeline transformations.
-func (p *Pipeline) apply(data []byte) ([]byte, error) {
-	var err error
-	for _, v := range p.Transformers {
-		if v.InitStep() {
-			continue
-		}
-		data, err = v.Apply(data)
-		if err != nil {
-			return data, err
-		}
+	if len(errs) != 0 {
+		return data, fmt.Errorf(strings.Join(errs, ","))
 	}
 	return data, nil
 }

--- a/pkg/flow/adapter/transformation/transformer/parse/parse.go
+++ b/pkg/flow/adapter/transformation/transformer/parse/parse.go
@@ -82,26 +82,15 @@ func (p *Parse) Apply(data []byte) ([]byte, error) {
 		if err := json.Unmarshal(data, &event); err != nil {
 			return data, err
 		}
-		value := readValue(event, path)
-		jsonValue, err := parseJSON(value)
+		jsonValue, err := parseJSON(readValue(event, path))
 		if err != nil {
-			fmt.Println(err)
 			return data, err
 		}
 		newObject := convert.SliceToMap(strings.Split(p.Path, "."), jsonValue)
-		fmt.Printf("Merged Appendix is: %+v\n", newObject)
-		result := convert.MergeJSONWithMap(event, newObject)
-		fmt.Printf("Result JSON is: %+v\n", result)
-		data, err = json.Marshal(result)
-		if err != nil {
-			return data, err
-		}
+		return json.Marshal(convert.MergeJSONWithMap(event, newObject))
 	default:
 		return data, fmt.Errorf("parse operation does not support %q type of value", p.Value)
 	}
-
-	fmt.Printf("Result Object is: %s\n", data)
-	return data, nil
 }
 
 func parseJSON(data interface{}) (interface{}, error) {

--- a/pkg/flow/adapter/transformation/transformer/parse/parse.go
+++ b/pkg/flow/adapter/transformation/transformer/parse/parse.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parse
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/convert"
+	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
+	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/transformer"
+)
+
+var _ transformer.Transformer = (*Parse)(nil)
+
+// Parse object implements Transformer interface.
+type Parse struct {
+	Path  string
+	Value string
+
+	variables *storage.Storage
+}
+
+// InitStep is used to figure out if this operation should
+// run before main Transformations. For example, Store
+// operation needs to run first to load all Pipeline variables.
+var InitStep bool = true
+
+// operationName is used to identify this transformation.
+var operationName string = "parse"
+
+// Register adds this transformation to the map which will
+// be used to create Transformation pipeline.
+func Register(m map[string]transformer.Transformer) {
+	m[operationName] = &Parse{}
+}
+
+// SetStorage sets a shared Storage with Pipeline variables.
+func (p *Parse) SetStorage(storage *storage.Storage) {
+	p.variables = storage
+}
+
+// InitStep returns "true" if this Transformation should run
+// as init step.
+func (p *Parse) InitStep() bool {
+	return InitStep
+}
+
+// New returns a new instance of Parse object.
+func (p *Parse) New(key, value string) transformer.Transformer {
+	return &Parse{
+		Path:  key,
+		Value: value,
+
+		variables: p.variables,
+	}
+}
+
+// Apply is a main method of Transformation that parse JSON values
+// into variables that can be used by other Transformations in a pipeline.
+func (p *Parse) Apply(data []byte) ([]byte, error) {
+	path := convert.SliceToMap(strings.Split(p.Path, "."), "")
+
+	switch p.Value {
+	case "json", "JSON":
+		var event interface{}
+		if err := json.Unmarshal(data, &event); err != nil {
+			return data, err
+		}
+		value := readValue(event, path)
+		jsonValue, err := parseJSON(value)
+		if err != nil {
+			fmt.Println(err)
+			return data, err
+		}
+		newObject := convert.SliceToMap(strings.Split(p.Path, "."), jsonValue)
+		fmt.Printf("Merged Appendix is: %+v\n", newObject)
+		result := convert.MergeJSONWithMap(event, newObject)
+		fmt.Printf("Result JSON is: %+v\n", result)
+		data, err = json.Marshal(result)
+		if err != nil {
+			return data, err
+		}
+	default:
+		return data, fmt.Errorf("parse operation does not support %q type of value", p.Value)
+	}
+
+	fmt.Printf("Result Object is: %s\n", data)
+	return data, nil
+}
+
+func parseJSON(data interface{}) (interface{}, error) {
+	str, ok := data.(string)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast the value to string type")
+	}
+	var object interface{}
+	if err := json.Unmarshal([]byte(str), &object); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal value: %w", err)
+	}
+	return object, nil
+}
+
+func readValue(source interface{}, path map[string]interface{}) interface{} {
+	var result interface{}
+	for k, v := range path {
+		switch value := v.(type) {
+		case float64, bool, string:
+			sourceMap, ok := source.(map[string]interface{})
+			if !ok {
+				break
+			}
+			result = sourceMap[k]
+		case []interface{}:
+			if k != "" {
+				// array is inside the object
+				// {"foo":[{},{},{}]}
+				sourceMap, ok := source.(map[string]interface{})
+				if !ok {
+					break
+				}
+				source, ok = sourceMap[k]
+				if !ok {
+					break
+				}
+			}
+			// array is a root object
+			// [{},{},{}]
+			sourceArr, ok := source.([]interface{})
+			if !ok {
+				break
+			}
+
+			index := len(value) - 1
+			if index >= len(sourceArr) {
+				break
+			}
+			result = readValue(sourceArr[index], value[index].(map[string]interface{}))
+		case map[string]interface{}:
+			sourceMap, ok := source.(map[string]interface{})
+			if !ok {
+				break
+			}
+			if _, ok := sourceMap[k]; !ok {
+				break
+			}
+			result = readValue(sourceMap[k], value)
+		}
+	}
+	return result
+}

--- a/pkg/flow/adapter/transformation/transformer/shift/shift.go
+++ b/pkg/flow/adapter/transformation/transformer/shift/shift.go
@@ -95,9 +95,11 @@ func (s *Shift) Apply(data []byte) ([]byte, error) {
 			return data, nil
 		}
 	}
+	if value == nil {
+		return data, nil
+	}
 
 	newPath := convert.SliceToMap(strings.Split(s.NewPath, "."), value)
-
 	result := convert.MergeJSONWithMap(newEvent, newPath)
 	output, err := json.Marshal(result)
 	if err != nil {


### PR DESCRIPTION
In this PR "Parse" operation is added to the Bumblebee transformations list. This operation allows parsing of an event's string values into JSON objects. Parse example case is below.

The event contains the following data:
```
{
    ...
    "metadata": {
        "client": "{\"host\": \"localhost\", \"user-agent\": \"Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)\"}"
    }
}
```
Bumblebee spec:
```
  - operation: parse
    paths:
    - key: metadata.client
      value: JSON
  - operation: shift
    paths:
    - key: metadata.client.host:address
```
Resulting event:
```
{
    ...
    "address": "localhost",
    "metadata": {
        "client": {
            "user-agent": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)"
        }
    }
}
```

---

Aside from the new "parse" operation, this PR clarifies the transformation errors handling - if the error appears as a result of a broken transformation operation and it does not affect Cloudevent client, the event still will be delivered to the destination while the error only logged in the adapter container. If in the sequence of transformations one is failing, the rest of the operations are still going to be applied to the event.
If in the future we face the scenario where the aforementioned approach is failing, we may add per-transformation switches to mark critical and non-critical operations.

Closes #613 