### PR TITLE
Revert addition of  hook

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,9 +1,6 @@
 name: End-to-End Testing
 
 on:
-  pull_request_target:
-    # Rely on default actions of opened, reopened, and syncrhonize to trigger a run
-    # against the target repo to ensure the e2e tests function as intended.
   pull_request_review:
     types: [ submitted ]
     # Run the e2e test once the PR has been approved to allow for a final check before


### PR DESCRIPTION
The addition of the `pull_request_target` hook was intended to allow for the e2e test to run using the credentials on the upstream repo, however it is not only _doesn't_ run, but may expose more of the environment then is intended. This PR will revert the hook addition ensure that it runs upon approval only.