### PR TITLE
Convert xslttransform base image to Dockerfile build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,6 @@ jobs:
       - run:
           name: Installing ko
           command: go install github.com/google/ko@v0.9.3
-      - run:
-          # XSLTTransformation needs libxml2.
-          name: Install libxml2
-          command: sudo apt-get update && sudo apt-get install -y libxml2-dev
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Top level files and directories
+/.assets/
+/.circleci/
+/.git/
+/.github/
+/docs/
+/hack/
+!/hack/inc.Codegen.mk
+/packer/
+/schemas/
+/test/
+/.dockerignore
+/.golangci.yaml
+/.ko.yaml
+/CODEOWNERS
+/README.md
+/kustomization.yaml
+
+# Files copied to KO_DATA_PATH directory
+!/.git/HEAD
+!/.git/refs/
+
+# Patterns
+**/config/
+**/*.md
+**/*_test.go
+**/.gitignore
+**/Dockerfile
+
+# Binaries
+**/_output/

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,14 +2,9 @@
 # dynamic binary with a dependency on glibc.
 baseImageOverrides:
   github.com/triggermesh/triggermesh/cmd/confluenttarget-adapter: gcr.io/distroless/base:nonroot
-  github.com/triggermesh/triggermesh/cmd/xslttransformation-adapter: gcr.io/triggermesh/debian-libxml:v0.1.0
 
 builds:
 - id: confluenttarget-adapter
   main: ./cmd/confluenttarget-adapter
-  env:
-  - CGO_ENABLED=1
-- id: xslttransformation-adapter
-  main: ./cmd/xslttransformation-adapter
   env:
   - CGO_ENABLED=1

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ COMMANDS          := $(notdir $(wildcard cmd/*))
 
 # Commands and images that require custom build proccess
 CUSTOM_BUILD_BINARIES := confluenttarget-adapter ibmmqsource-adapter ibmmqtarget-adapter xslttransformation-adapter
-CUSTOM_BUILD_IMAGES   := ibmmqsource-adapter ibmmqtarget-adapter
+CUSTOM_BUILD_IMAGES   := ibmmqsource-adapter ibmmqtarget-adapter xslttransformation-adapter
 
 BIN_OUTPUT_DIR    ?= $(OUTPUT_DIR)
 DOCS_OUTPUT_DIR   ?= $(OUTPUT_DIR)

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -1,0 +1,44 @@
+# (!) Debian 11 'bullseye' must be used in both the builder and final image to
+# ensure the compatibility of the GNU libc.
+FROM golang:1.17-bullseye as builder
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libxml2 libxml2-dev
+
+WORKDIR ${GOPATH}/project
+
+COPY . .
+RUN go build -o /xslttransformation-adapter ./cmd/xslttransformation-adapter
+# ldd /xslttransformation-adapter
+# (i) Entries marked with a '*' are not included in the 'distroless:base' image.
+#     linux-vdso.so.1
+#   * libxml2.so.2 => /usr/lib/x86_64-linux-gnu/libxml2.so.2
+#     libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
+#     libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
+#     libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2
+#   * libicuuc.so.67 => /usr/lib/x86_64-linux-gnu/libicuuc.so.67
+#   * libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1
+#   * liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5
+#     libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6
+#     /lib64/ld-linux-x86-64.so.2
+#   * libicudata.so.67 => /usr/lib/x86_64-linux-gnu/libicudata.so.67
+#   * libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+#   * libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1
+
+FROM gcr.io/distroless/base-debian11:nonroot
+
+# (!) COPY follows symlinks
+COPY --from=builder \
+    /usr/lib/x86_64-linux-gnu/libxml2.so.2 \
+    /usr/lib/x86_64-linux-gnu/libicuuc.so.67 \
+    /lib/x86_64-linux-gnu/libz.so.1 \
+    /lib/x86_64-linux-gnu/liblzma.so.5 \
+    /usr/lib/x86_64-linux-gnu/libicudata.so.67 \
+    /usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
+    /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+    /usr/lib/x86_64-linux-gnu/
+
+COPY --from=builder /xslttransformation-adapter /
+
+ENTRYPOINT ["/xslttransformation-adapter"]

--- a/cmd/xslttransformation-adapter/Makefile
+++ b/cmd/xslttransformation-adapter/Makefile
@@ -1,0 +1,18 @@
+DOCKER		?= docker
+PLATFORM 	?= linux/amd64
+GOALS		:= build tag push test
+
+.PHONY: $(GOALS)
+
+build:
+	$(DOCKER) build -t $(IMAGE_TAG) -f Dockerfile $(CONTEXT) --platform $(PLATFORM)
+
+tag:
+	$(DOCKER) tag $(IMAGE_TAG) $(TAGS)
+
+push:
+	$(DOCKER) push --all-tags $(IMAGE_TAG)
+
+test:
+
+.SILENT:

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -169,8 +169,6 @@ spec:
           value: ko://github.com/triggermesh/triggermesh/cmd/transformation-adapter
         - name: XMLTOJSONTRANSFORMATION_IMAGE
           value: ko://github.com/triggermesh/triggermesh/cmd/xmltojsontransformation-adapter
-        - name: XSLTTRANSFORMATION_IMAGE
-          value: ko://github.com/triggermesh/triggermesh/cmd/xslttransformation-adapter
         - name: SYNCHRONIZER_ADAPTER_IMAGE
           value: ko://github.com/triggermesh/triggermesh/cmd/synchronizer-adapter
         # Routing adapters
@@ -193,6 +191,8 @@ spec:
           value: gcr.io/triggermesh/ibmmqsource-adapter:latest
         - name: IBMMQTARGET_ADAPTER_IMAGE
           value: gcr.io/triggermesh/ibmmqtarget-adapter:latest
+        - name: XSLTTRANSFORMATION_IMAGE
+          value: gcr.io/triggermesh/xslttransformation-adapter:latest
 
         securityContext:
           allowPrivilegeEscalation: false

--- a/hack/images/xslttransform/Dockerfile
+++ b/hack/images/xslttransform/Dockerfile
@@ -1,5 +1,0 @@
-FROM debian:11-slim
-
-RUN apt update && apt install -y --no-install-recommends libxml2 \
-      && rm -rf /var/lib/apt/lists/* \
-      && rm -rf /usr/share/

--- a/hack/images/xslttransform/README.md
+++ b/hack/images/xslttransform/README.md
@@ -1,9 +1,0 @@
-# XSLT Transform
-
-The XSLT Transform component needs libxml2 along with their transient dependencies installed.
-We are basing on a debian image to add libxml2 and using it at `.ko.yaml` for XSLT Transform.
-
-```console
-docker build . -t gcr.io/triggermesh/debian-libxml:v0.1.0
-docker push gcr.io/triggermesh/debian-libxml:v0.1.0
-```


### PR DESCRIPTION
```console
$ make -C ./cmd/xslttransformation-adapter build CONTEXT=~/go/src/github.com/triggermesh/triggermesh IMAGE_TAG=local/xslttransformation-adapter
make: Entering directory '/home/acotten/go/src/github.com/triggermesh/triggermesh/cmd/xslttransformation-adapter'
[+] Building 106.9s (15/15) FINISHED
 => [internal] load build definition from Dockerfile
 => => transferring dockerfile: 1.77kB
 => [internal] load .dockerignore
 => => transferring context: 424B
 => [internal] load metadata for gcr.io/distroless/base-debian11:nonroot
 => [internal] load metadata for docker.io/library/golang:1.17-bullseye
 => [auth] library/golang:pull token for registry-1.docker.io
 => [internal] load build context
 => => transferring context: 9.37MB
 => [builder 1/5] FROM docker.io/library/golang:1.17-bullseye@sha256:6f49eeaceb65a5e46d3e6199583beadbe3c8d028a225b680c5b34b4c13ec5105
 => => resolve docker.io/library/golang:1.17-bullseye@sha256:6f49eeaceb65a5e46d3e6199583beadbe3c8d028a225b680c5b34b4c13ec5105
 => => sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055 54.92MB / 54.92MB
 => => sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6 5.15MB / 5.15MB
 => => sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be 10.87MB / 10.87MB
 => => sha256:6f49eeaceb65a5e46d3e6199583beadbe3c8d028a225b680c5b34b4c13ec5105 1.86kB / 1.86kB
 => => sha256:18432b513315c80f80322d4b4743a2d856c8914819ae4191edfed94bc9ad959a 1.80kB / 1.80kB
 => => sha256:0659a535a7341c4ee3db57a062bccb894be691b1e480198f2570dea67f34fe66 7.04kB / 7.04kB
 => => sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02 54.58MB / 54.58MB
 => => sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36 85.81MB / 85.81MB
 => => sha256:159607df3745db4458d86f29bbfebb6af5aff1877e4ae9bf8a4be0e269989b49 134.90MB / 134.90MB
 => => sha256:debee5da592d2d2e96de757c5aff0cf0723782cf20a78682c7c85aa53064b702 157B / 157B
 => => extracting sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055
 => => extracting sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6
 => => extracting sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be
 => => extracting sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02
 => => extracting sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36
 => => extracting sha256:159607df3745db4458d86f29bbfebb6af5aff1877e4ae9bf8a4be0e269989b49
 => => extracting sha256:debee5da592d2d2e96de757c5aff0cf0723782cf20a78682c7c85aa53064b702
 => [stage-1 1/3] FROM gcr.io/distroless/base-debian11:nonroot@sha256:02f667185ccf78dbaaf79376b6904aea6d832638e1314387c2c2932f217ac5cb
 => => resolve gcr.io/distroless/base-debian11:nonroot@sha256:02f667185ccf78dbaaf79376b6904aea6d832638e1314387c2c2932f217ac5cb
 => => sha256:02f667185ccf78dbaaf79376b6904aea6d832638e1314387c2c2932f217ac5cb 1.67kB / 1.67kB
 => => sha256:432628806185195680c6d23d62428cc19f03745ad751780b79be8dbab38cb8bd 590B / 590B
 => => sha256:408c5eb84383126869b25a95b84ab603a92176ce61c9aece02590d0f5dc8686e 635B / 635B
 => => sha256:c6f4d1a13b699c8490910fd4fd6c7056b90fd0da3077e4f29b4bd27bf0bae6cd 7.98MB / 7.98MB
 => => extracting sha256:c6f4d1a13b699c8490910fd4fd6c7056b90fd0da3077e4f29b4bd27bf0bae6cd
 => [builder 2/5] RUN set -eux;     apt-get update;     apt-get install -y --no-install-recommends libxml2 libxml2-dev
 => [builder 3/5] WORKDIR /go/project
 => [builder 4/5] COPY . .
 => [builder 5/5] RUN go build -o /xslttransformation-adapter ./cmd/xslttransformation-adapter
 => [stage-1 2/3] COPY --from=builder     /usr/lib/x86_64-linux-gnu/libxml2.so.2     /usr/lib/x86_64-linux-gnu/libicuuc.so.67     /lib/x86_64-linux-gn
 => [stage-1 3/3] COPY --from=builder /xslttransformation-adapter /
 => exporting to image
 => => exporting layers
 => => writing image sha256:49470fb440c9ad507e562754e2bbb1189e5ca9acb67795adc3fd0edce34276b8
 => => naming to docker.io/local/xslttransformation-adapter
```

```console
$ docker image ls
REPOSITORY                                       TAG       IMAGE ID       CREATED         SIZE
local/xslttransformation-adapter                 latest    49470fb440c9   2 minutes ago   110MB
gcr.io/triggermesh/xslttransformation-adapter    latest    f9dd3ccc231d   3 months ago    173MB
```

```console
$ docker container run --rm -e XSLTTRANSFORMATION_ALLOW_XSLT_OVERRIDE=false local/xslttransformation-adapter --help
Usage of /xslttransformation-adapter:
  -disable-ha
        Whether to disable high-availability functionality for this component.
```