### PR TITLE
ci: wait before attaching artifacts to releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,14 @@ jobs:
             PRE_RELEASE=${CIRCLE_TAG/${CIRCLE_TAG%-rc[0-9]*}/}
             github-release delete -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} 2>/dev/null ||:
             ./hack/release-notes.sh ${CIRCLE_TAG} | github-release release ${PRE_RELEASE:+-p} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -d -
+
+            # wait for github to report the release before attaching the artifacts
+            max_tries=5
+            for _ in $(seq 1 ${max_tries}); do
+              github-release info -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} >/dev/null && break
+              sleep 1
+            done
+
             for f in $(find /tmp/workspace/dist/ -type f); do
               github-release upload -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -n $(basename ${f}) -f ${f}
             done


### PR DESCRIPTION
the `release` job has been failing while attempting to attach release artifacts immediately after creating the release