### PR TITLE
Make Bumblebee's Handler implement Adapter interface

### DIFF
--- a/cmd/transformation-adapter/main.go
+++ b/cmd/transformation-adapter/main.go
@@ -17,50 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"log"
+	"knative.dev/eventing/pkg/adapter/v2"
 
-	"github.com/kelseyhightower/envconfig"
-
-	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation"
 )
 
-type envConfig struct {
-	// Sink URL where to send cloudevents
-	Sink string `envconfig:"K_SINK"`
-
-	// Transformation specifications
-	TransformationContext string `envconfig:"TRANSFORMATION_CONTEXT"`
-	TransformationData    string `envconfig:"TRANSFORMATION_DATA"`
-}
-
 func main() {
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		log.Fatalf("Failed to process env var: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	trnContext, trnData := []v1alpha1.Transform{}, []v1alpha1.Transform{}
-	err := json.Unmarshal([]byte(env.TransformationContext), &trnContext)
-	if err != nil {
-		log.Fatalf("Cannot unmarshal Context Transformation variable: %v", err)
-	}
-	err = json.Unmarshal([]byte(env.TransformationData), &trnData)
-	if err != nil {
-		log.Fatalf("Cannot unmarshal Data Transformation variable: %v", err)
-	}
-
-	handler, err := transformation.NewHandler(trnContext, trnData)
-	if err != nil {
-		log.Fatalf("Cannot create transformation handler: %v", err)
-	}
-
-	if err := handler.Start(ctx, env.Sink); err != nil {
-		log.Fatalf("Transformation handler: %v", err)
-	}
+	adapter.Main("transformation-adapter", transformation.NewEnvConfig, transformation.NewHandler)
 }


### PR DESCRIPTION
In order to implement custom metrics, we should be able to access the standard environment variables propagated by Knative, such as `NAME` and `NAMESPACE`.

This PR is a refactoring that prepares the component for the introduction of those custom metrics.

It simply moves the initialization logic that is currently inside the `main()` to `NewHandler()`, so that we can consume the aforementioned environment variables during the Handler's initialization.