### PR TITLE
Increase receive timeout for Event Grid E2E test

### DIFF
--- a/test/e2e/sources/azureeventgrid/main.go
+++ b/test/e2e/sources/azureeventgrid/main.go
@@ -163,9 +163,9 @@ var _ = Describe("Azure Event Grid source", func() {
 			})
 
 			Specify("the source generates an event", func() {
-				// There can be a significant delay (1-4 min) between the moment an Azure resource is
+				// There can be a significant delay (1-10 min) between the moment an Azure resource is
 				// created and Event Grid emits the corresponding 'ResourceWriteSuccess' event.
-				const receiveTimeout = 4 * time.Minute
+				const receiveTimeout = 10 * time.Minute
 				const pollInterval = 500 * time.Millisecond
 
 				var receivedEvents []cloudevents.Event


### PR DESCRIPTION
It's hard for me to imagine that Azure loses our `ResourceWriteSuccess` event during E2E tests, and I'm also confident that there is no timing issue with this source since the rewrite in #611.

We know that Azure's Activity Logs are sometimes emitted with a 10 min (!) delay, so I wouldn't be surprised if Azure was simply slow in this context too. Therefore, I suggest we increase the receive timeout in this test.