### PR TITLE
Bump ko version to v0.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             - go-build-{{ arch }}-{{ checksum "go.sum" }}
       - run:
           name: Installing ko
-          command: go install github.com/google/ko@v0.9.3
+          command: go install github.com/google/ko@v0.11.1
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -89,7 +89,7 @@ jobs:
         kubectl -n knative-serving wait --timeout=1m --for=condition=Complete jobs.batch/default-domain
 
     - name: Install ko
-      run: go install github.com/google/ko@v0.9.3
+      run: go install github.com/google/ko@v0.11.1
 
     - name: Deploy TriggerMesh
       env:


### PR DESCRIPTION
Second take on #631, this time with a fix for the high parallelism that was causing OOM in CI workers.