### PR TITLE
Pin `go-licenses` version @v1.0.0

### DIFF
--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -74,7 +74,7 @@ jobs:
           ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Install go-licenses
-      run: go install github.com/google/go-licenses@latest
+      run: go install github.com/google/go-licenses@v1.0.0
 
     - name: Check third-party licenses
       run: |


### PR DESCRIPTION
Now that go-licenses officially has a release version, let's pin the version we use in the CI to avoid variances due to a floating `latest` revision.