### PR TITLE
Enable Prometheus metrics exporter on port 9092 in all target adapters

### DIFF
--- a/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
@@ -374,6 +374,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/googlesheettarget/adapter.go
+++ b/pkg/targets/reconciler/googlesheettarget/adapter.go
@@ -105,16 +105,5 @@ func makeEnv(args *TargetAdapterArgs) []corev1.EnvVar {
 		Value: args.Target.Spec.DefaultPrefix,
 	}}
 
-	env = append(env, args.Configs.ToEnvVars()...)
-
-	// FIXME(antoineco): default metrics port 9090 overlaps with queue-proxy
-	// Requires fix from https://github.com/knative/pkg/pull/1411:
-	// {
-	//	Name: "METRICS_PROMETHEUS_PORT",
-	//	Value: "9092",
-	// }
-	return append(env, corev1.EnvVar{
-		Name:  source.EnvMetricsCfg,
-		Value: "",
-	})
+	return append(env, libreconciler.MakeObsEnv(args.Configs)...)
 }

--- a/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
@@ -349,8 +349,8 @@ func newAdapterService() *servingv1.Service {
 									}, {
 										Name: source.EnvTracingCfg,
 									}, {
-										// FIXME(antoineco): remove dupe. See target_adapter.go
-										Name: source.EnvMetricsCfg,
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/hasuratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler_test.go
@@ -322,6 +322,9 @@ func newAdapterService() *servingv1.Service {
 									}, {
 										Name: source.EnvTracingCfg,
 									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
+									}, {
 										Name:  "HASURA_ENDPOINT",
 										Value: tEndpointURL.String(),
 									}, {

--- a/pkg/targets/reconciler/httptarget/reconciler_test.go
+++ b/pkg/targets/reconciler/httptarget/reconciler_test.go
@@ -357,6 +357,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/infratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/infratarget/reconciler_test.go
@@ -351,6 +351,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/jiratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler_test.go
@@ -348,6 +348,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
@@ -325,6 +325,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/logztarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logztarget/reconciler_test.go
@@ -294,6 +294,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/reconcile_adapter.go
+++ b/pkg/targets/reconciler/reconcile_adapter.go
@@ -17,11 +17,13 @@ limitations under the License.
 package reconciler
 
 import (
-	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/kmeta"
+
+	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/resources"
 )
 
 // MakeServiceEnv Adds default environment variables
@@ -39,17 +41,10 @@ func MakeServiceEnv(name, namespace string) []corev1.EnvVar {
 
 // MakeObsEnv adds support for observability configs
 func MakeObsEnv(cfg source.ConfigAccessor) []corev1.EnvVar {
-	env := cfg.ToEnvVars()
-
-	// port already used by queue proxy
-	for i := range env {
-		if env[i].Name == source.EnvMetricsCfg {
-			env[i].Value = ""
-			break
-		}
-	}
-
-	return env
+	return append(cfg.ToEnvVars(), corev1.EnvVar{
+		Name:  "METRICS_PROMETHEUS_PORT",
+		Value: "9092",
+	})
 }
 
 // MakeGenericLabels returns generic labels set.

--- a/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
@@ -366,6 +366,9 @@ func newAdapterService() *servingv1.Service {
 										Name: source.EnvMetricsCfg,
 									}, {
 										Name: source.EnvTracingCfg,
+									}, {
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},

--- a/pkg/targets/reconciler/slacktarget/adapter.go
+++ b/pkg/targets/reconciler/slacktarget/adapter.go
@@ -92,18 +92,8 @@ func makeEnv(args *TargetAdapterArgs) []corev1.EnvVar {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: args.Target.Spec.Token.SecretKeyRef,
 			},
-		}}
+		},
+	}
 
-	env = append(env, args.Configs.ToEnvVars()...)
-
-	// FIXME(antoineco): default metrics port 9090 overlaps with queue-proxy
-	// Requires fix from https://github.com/knative/pkg/pull/1411:
-	// {
-	//	Name: "METRICS_PROMETHEUS_PORT",
-	//	Value: "9092",
-	// }
-	return append(env, corev1.EnvVar{
-		Name:  source.EnvMetricsCfg,
-		Value: "",
-	})
+	return append(env, libreconciler.MakeObsEnv(args.Configs)...)
 }

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -112,18 +112,7 @@ func makeAdapterKnService(o *v1alpha1.SplunkTarget, cfg *adapterConfig) *serving
 		})
 	}
 
-	env = append(env, cfg.configs.ToEnvVars()...)
-
-	// FIXME(antoineco): default metrics port 9090 overlaps with queue-proxy
-	// Requires fix from https://github.com/knative/pkg/pull/1411:
-	// {
-	//	Name: "METRICS_PROMETHEUS_PORT",
-	//	Value: "9092",
-	// }
-	env = append(env, corev1.EnvVar{
-		Name:  source.EnvMetricsCfg,
-		Value: "",
-	})
+	env = append(env, libreconciler.MakeObsEnv(cfg.configs)...)
 
 	svc := &servingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/targets/reconciler/splunktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler_test.go
@@ -350,8 +350,8 @@ func newAdapterService() *servingv1.Service {
 									}, {
 										Name: source.EnvTracingCfg,
 									}, {
-										// FIXME(antoineco): remove dupe. See adapter.go
-										Name: source.EnvMetricsCfg,
+										Name:  "METRICS_PROMETHEUS_PORT",
+										Value: "9092",
 									},
 								},
 							}},


### PR DESCRIPTION
- Do not set `K_METRICS_CONFIG` to `""` anymore.
    Let the reconciler pass it to the adapter, which will result in the metrics exporter being enabled in each adapter.

- Set `METRICS_PROMETHEUS_PORT` to `"9092"`.
    Avoids overlapping with the default port `9090` that is reserved by the `queue-proxy` container (in Ksvcs).