### PR TITLE
Function and Bumblebee quiet reconciliation

### DIFF
--- a/pkg/flow/reconciler/transformation/reconciler.go
+++ b/pkg/flow/reconciler/transformation/reconciler.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -57,12 +56,6 @@ const (
 	metricsPrometheusPortKsvc uint16 = 9092
 	envMetricsPrometheusPort         = "METRICS_PROMETHEUS_PORT"
 )
-
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason AddressableServiceReconciled.
-func newReconciledNormal(namespace, name string) reconciler.Event {
-	return reconciler.NewEvent(corev1.EventTypeNormal, "TransformationReconciled", "Transformation reconciled: \"%s/%s\"", namespace, name)
-}
 
 // Reconciler implements addressableservicereconciler.Interface for
 // Transformation resources.
@@ -118,7 +111,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trn *v1alpha1.Transforma
 	trn.Status.CloudEventAttributes = r.createCloudEventAttributes(&trn.Spec)
 
 	logger.Debug("Transformation reconciled")
-	return newReconciledNormal(trn.Namespace, trn.Name)
+	return nil
 }
 
 func (r *Reconciler) reconcileKnService(ctx context.Context, trn *v1alpha1.Transformation) (*servingv1.Service, error) {

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -77,12 +77,6 @@ type Reconciler struct {
 // Check that our Reconciler implements Interface
 var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason AddressableServiceReconciled.
-func newReconciledNormal(namespace, name string) reconciler.Event {
-	return reconciler.NewEvent(corev1.EventTypeNormal, "FunctionReconciled", "Function reconciled: \"%s/%s\"", namespace, name)
-}
-
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.Function) reconciler.Event {
 	logger := logging.FromContext(ctx)
@@ -151,7 +145,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.Function) re
 	}
 
 	logger.Debug("Function reconciled")
-	return newReconciledNormal(o.Namespace, o.Name)
+	return nil
 }
 
 func (r *Reconciler) resolveSink(ctx context.Context, f *v1alpha1.Function) (*apis.URL, error) {


### PR DESCRIPTION
Do not produce `%v reconciled` events for Function and Bumblebee resources.
Explained in and closes #676.