### PR TITLE
Set year to 2022 in all license headers

### DIFF
--- a/cmd/alibabaosstarget-adapter/main.go
+++ b/cmd/alibabaosstarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscloudwatchlogssource-adapter/main.go
+++ b/cmd/awscloudwatchlogssource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscloudwatchsource-adapter/main.go
+++ b/cmd/awscloudwatchsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscodecommitsource-adapter/main.go
+++ b/cmd/awscodecommitsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscognitoidentitysource-adapter/main.go
+++ b/cmd/awscognitoidentitysource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscognitouserpoolsource-adapter/main.go
+++ b/cmd/awscognitouserpoolsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awscomprehendtarget-adapter/main.go
+++ b/cmd/awscomprehendtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awsdynamodbsource-adapter/main.go
+++ b/cmd/awsdynamodbsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awsdynamodbtarget-adapter/main.go
+++ b/cmd/awsdynamodbtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awskinesissource-adapter/main.go
+++ b/cmd/awskinesissource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awskinesistarget-adapter/main.go
+++ b/cmd/awskinesistarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awslambdatarget-adapter/main.go
+++ b/cmd/awslambdatarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awsperformanceinsightssource-adapter/main.go
+++ b/cmd/awsperformanceinsightssource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awss3target-adapter/main.go
+++ b/cmd/awss3target-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awssnssource-adapter/main.go
+++ b/cmd/awssnssource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awssnstarget-adapter/main.go
+++ b/cmd/awssnstarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awssqssource-adapter/main.go
+++ b/cmd/awssqssource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/awssqstarget-adapter/main.go
+++ b/cmd/awssqstarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/azureeventhubsource-adapter/main.go
+++ b/cmd/azureeventhubsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/azureeventhubstarget-adapter/main.go
+++ b/cmd/azureeventhubstarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/azureiothubsource-adapter/main.go
+++ b/cmd/azureiothubsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/azurequeuestoragesource-adapter/main.go
+++ b/cmd/azurequeuestoragesource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/azureservicebussource-adapter/main.go
+++ b/cmd/azureservicebussource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/confluenttarget-adapter/main.go
+++ b/cmd/confluenttarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/datadogtarget-adapter/main.go
+++ b/cmd/datadogtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/elasticsearchtarget-adapter/main.go
+++ b/cmd/elasticsearchtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/filter-adapter/main.go
+++ b/cmd/filter-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/googlecloudfirestoretarget-adapter/main.go
+++ b/cmd/googlecloudfirestoretarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/googlecloudpubsubsource-adapter/main.go
+++ b/cmd/googlecloudpubsubsource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/googlecloudstoragetarget-adapter/main.go
+++ b/cmd/googlecloudstoragetarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/googlecloudworkflowstarget-adapter/main.go
+++ b/cmd/googlecloudworkflowstarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/googlesheettarget-adapter/main.go
+++ b/cmd/googlesheettarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hasuratarget-adapter/main.go
+++ b/cmd/hasuratarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/httppollersource-adapter/main.go
+++ b/cmd/httppollersource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/httptarget-adapter/main.go
+++ b/cmd/httptarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ibmmqsource-adapter/main.go
+++ b/cmd/ibmmqsource-adapter/main.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ibmmqtarget-adapter/main.go
+++ b/cmd/ibmmqtarget-adapter/main.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/infratarget-adapter/main.go
+++ b/cmd/infratarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/jiratarget-adapter/main.go
+++ b/cmd/jiratarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/logztarget-adapter/main.go
+++ b/cmd/logztarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ocimetricssource-adapter/main.go
+++ b/cmd/ocimetricssource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/opentelemetrytarget-adapter/main.go
+++ b/cmd/opentelemetrytarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/oracletarget-adapter/main.go
+++ b/cmd/oracletarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/salesforcesource-adapter/main.go
+++ b/cmd/salesforcesource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/salesforcetarget-adapter/main.go
+++ b/cmd/salesforcetarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/sendgridtarget-adapter/main.go
+++ b/cmd/sendgridtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/slacksource-adapter/main.go
+++ b/cmd/slacksource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/slacktarget-adapter/main.go
+++ b/cmd/slacktarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/splitter-adapter/main.go
+++ b/cmd/splitter-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/splunktarget-adapter/main.go
+++ b/cmd/splunktarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/tektontarget-adapter/main.go
+++ b/cmd/tektontarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/triggermesh-webhook/main.go
+++ b/cmd/triggermesh-webhook/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/twiliosource-adapter/main.go
+++ b/cmd/twiliosource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/twiliotarget-adapter/main.go
+++ b/cmd/twiliotarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/uipathtarget-adapter/main.go
+++ b/cmd/uipathtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/webhooksource-adapter/main.go
+++ b/cmd/webhooksource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/xslttransformation-adapter/main.go
+++ b/cmd/xslttransformation-adapter/main.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/zendesksource-adapter/main.go
+++ b/cmd/zendesksource-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/zendesktarget-adapter/main.go
+++ b/cmd/zendesktarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/200-clusterrole-webhook.yaml
+++ b/config/200-clusterrole-webhook.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/202-clusterrolebinding-webhook.yaml
+++ b/config/202-clusterrolebinding-webhook.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureeventhubsource.yaml
+++ b/config/300-azureeventhubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudiotsource.yaml
+++ b/config/300-googlecloudiotsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-alibabaosstarget.yaml
+++ b/config/301-alibabaosstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-hasuratarget.yaml
+++ b/config/301-hasuratarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-infratarget.yaml
+++ b/config/301-infratarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-tektontarget.yaml
+++ b/config/301-tektontarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-uipathtarget.yaml
+++ b/config/301-uipathtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/namespace/100-namespace.yaml
+++ b/config/namespace/100-namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/broker.yaml
+++ b/config/samples/bumblebee/broker.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/multi-target/github-transformation.yaml
+++ b/config/samples/bumblebee/multi-target/github-transformation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/multi-target/githubsource.yaml
+++ b/config/samples/bumblebee/multi-target/githubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/multi-target/googlesheet-target.yaml
+++ b/config/samples/bumblebee/multi-target/googlesheet-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/multi-target/slack-target.yaml
+++ b/config/samples/bumblebee/multi-target/slack-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/parse-json/pingsource.yaml
+++ b/config/samples/bumblebee/parse-json/pingsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/parse-json/transformation.yaml
+++ b/config/samples/bumblebee/parse-json/transformation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/simple-event/event-display.yaml
+++ b/config/samples/bumblebee/simple-event/event-display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/simple-event/pingsource.yaml
+++ b/config/samples/bumblebee/simple-event/pingsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/simple-event/transformation.yaml
+++ b/config/samples/bumblebee/simple-event/transformation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/bumblebee/simple-event/triggers.yaml
+++ b/config/samples/bumblebee/simple-event/triggers.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/100-broker.yaml
+++ b/config/samples/flows/xslttransformation/replier/100-broker.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/200-event-display.yaml
+++ b/config/samples/flows/xslttransformation/replier/200-event-display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/200-xslttransform.yaml
+++ b/config/samples/flows/xslttransformation/replier/200-xslttransform.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/300-trigger-event-display.yaml
+++ b/config/samples/flows/xslttransformation/replier/300-trigger-event-display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/300-triggers-xslttransform.yaml
+++ b/config/samples/flows/xslttransformation/replier/300-triggers-xslttransform.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/flows/xslttransformation/replier/400-curl.yaml
+++ b/config/samples/flows/xslttransformation/replier/400-curl.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/functions/nodejs.yaml
+++ b/config/samples/functions/nodejs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/functions/python.yaml
+++ b/config/samples/functions/python.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/functions/ruby.yaml
+++ b/config/samples/functions/ruby.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/routing/filter.yaml
+++ b/config/samples/routing/filter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/routing/splitter.yaml
+++ b/config/samples/routing/splitter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscloudwatchlogssource.yaml
+++ b/config/samples/sources/awscloudwatchlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscloudwatchsource.yaml
+++ b/config/samples/sources/awscloudwatchsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscodecommitsource.yaml
+++ b/config/samples/sources/awscodecommitsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscognitoidentitysource.yaml
+++ b/config/samples/sources/awscognitoidentitysource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awscognitouserpoolsource.yaml
+++ b/config/samples/sources/awscognitouserpoolsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awsdynamodbsource.yaml
+++ b/config/samples/sources/awsdynamodbsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awskinesissource.yaml
+++ b/config/samples/sources/awskinesissource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awss3source.yaml
+++ b/config/samples/sources/awss3source.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awssnssource.yaml
+++ b/config/samples/sources/awssnssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/awssqssource.yaml
+++ b/config/samples/sources/awssqssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureactivitylogssource.yaml
+++ b/config/samples/sources/azureactivitylogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureblobstoragesource.yaml
+++ b/config/samples/sources/azureblobstoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureeventgridsource.yaml
+++ b/config/samples/sources/azureeventgridsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureeventhubsource.yaml
+++ b/config/samples/sources/azureeventhubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureiothubsource.yaml
+++ b/config/samples/sources/azureiothubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azurequeuestoragesource.yaml
+++ b/config/samples/sources/azurequeuestoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureservicebusqueuesource.yaml
+++ b/config/samples/sources/azureservicebusqueuesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/azureservicebustopicsource.yaml
+++ b/config/samples/sources/azureservicebustopicsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudauditlogssource.yaml
+++ b/config/samples/sources/googlecloudauditlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudbillingsource.yaml
+++ b/config/samples/sources/googlecloudbillingsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudiotsource.yaml
+++ b/config/samples/sources/googlecloudiotsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudpubsubsource.yaml
+++ b/config/samples/sources/googlecloudpubsubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudsourcerepositoriessource.yaml
+++ b/config/samples/sources/googlecloudsourcerepositoriessource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/googlecloudstoragesource.yaml
+++ b/config/samples/sources/googlecloudstoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/httppollersource.yaml
+++ b/config/samples/sources/httppollersource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/ibmmq-server.yaml
+++ b/config/samples/sources/ibmmq-server.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/ibmmqsource.yaml
+++ b/config/samples/sources/ibmmqsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/ocimetricssource.yaml
+++ b/config/samples/sources/ocimetricssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/salesforcesource.yaml
+++ b/config/samples/sources/salesforcesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/slacksource.yaml
+++ b/config/samples/sources/slacksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/twiliosource.yaml
+++ b/config/samples/sources/twiliosource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/webhooksource.yaml
+++ b/config/samples/sources/webhooksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/sources/zendesksource.yaml
+++ b/config/samples/sources/zendesksource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/synchronizer/sample.yaml
+++ b/config/samples/synchronizer/sample.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/100-secret.yaml
+++ b/config/samples/targets/alibabaoss/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/200-target.yaml
+++ b/config/samples/targets/alibabaoss/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/alibabaoss/300-trigger.yaml
+++ b/config/samples/targets/alibabaoss/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/100-secret.yaml
+++ b/config/samples/targets/aws/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-dynamodb-target.yaml
+++ b/config/samples/targets/aws/200-aws-dynamodb-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-kinesis-target.yaml
+++ b/config/samples/targets/aws/200-aws-kinesis-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-lambda-target.yaml
+++ b/config/samples/targets/aws/200-aws-lambda-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-sns-target.yaml
+++ b/config/samples/targets/aws/200-aws-sns-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/200-aws-sqs-target.yaml
+++ b/config/samples/targets/aws/200-aws-sqs-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/aws/300-trigger.yaml
+++ b/config/samples/targets/aws/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/100-secret.yaml
+++ b/config/samples/targets/awscomprehend/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/200-aws-comprehend-target.yaml
+++ b/config/samples/targets/awscomprehend/200-aws-comprehend-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/awscomprehend/300-trigger.yaml
+++ b/config/samples/targets/awscomprehend/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/azureeventhubstarget/azureeventhubstarget.yaml
+++ b/config/samples/targets/azureeventhubstarget/azureeventhubstarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/100-secret.yaml
+++ b/config/samples/targets/confluent/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/200-target.yaml
+++ b/config/samples/targets/confluent/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/confluent/300-trigger.yaml
+++ b/config/samples/targets/confluent/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/100-secret.yaml
+++ b/config/samples/targets/datadog/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/200-target.yaml
+++ b/config/samples/targets/datadog/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/datadog/300-trigger.yaml
+++ b/config/samples/targets/datadog/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/100-secret.yaml
+++ b/config/samples/targets/elasticsearch/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/200-elasticsearch-target.yaml
+++ b/config/samples/targets/elasticsearch/200-elasticsearch-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/elasticsearch/300-trigger.yaml
+++ b/config/samples/targets/elasticsearch/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/100-secret.yaml
+++ b/config/samples/targets/googlecloudfirestore/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/200-target.yaml
+++ b/config/samples/targets/googlecloudfirestore/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudfirestore/300-trigger.yaml
+++ b/config/samples/targets/googlecloudfirestore/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/100-secret.yaml
+++ b/config/samples/targets/googlecloudstorage/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/200-target.yaml
+++ b/config/samples/targets/googlecloudstorage/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudstorage/300-trigger.yaml
+++ b/config/samples/targets/googlecloudstorage/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/100-secret.yaml
+++ b/config/samples/targets/googlecloudworkflows/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/200-target.yaml
+++ b/config/samples/targets/googlecloudworkflows/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlecloudworkflows/300-trigger.yaml
+++ b/config/samples/targets/googlecloudworkflows/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/100-secret.yaml
+++ b/config/samples/targets/googlesheet/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/200-target.yaml
+++ b/config/samples/targets/googlesheet/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/googlesheet/300-trigger.yaml
+++ b/config/samples/targets/googlesheet/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/100-secret.yaml
+++ b/config/samples/targets/hasura/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/200-target.yaml
+++ b/config/samples/targets/hasura/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/hasura/300-trigger.yaml
+++ b/config/samples/targets/hasura/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/calendarific.yaml
+++ b/config/samples/targets/http/calendarific.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/covid19.yaml
+++ b/config/samples/targets/http/covid19.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/http/twitter-oauth.yaml
+++ b/config/samples/targets/http/twitter-oauth.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/ibmmq/ibmmq-server.yaml
+++ b/config/samples/targets/ibmmq/ibmmq-server.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/ibmmq/ibmmq-target.yaml
+++ b/config/samples/targets/ibmmq/ibmmq-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/infra/manage-fields.yaml
+++ b/config/samples/targets/infra/manage-fields.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/100-secret.yaml
+++ b/config/samples/targets/jira/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/200-target.yaml
+++ b/config/samples/targets/jira/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/300-display.yaml
+++ b/config/samples/targets/jira/300-display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/jira/400-eventing.yaml
+++ b/config/samples/targets/jira/400-eventing.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/100-secret.yaml
+++ b/config/samples/targets/logz/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/200-target.yaml
+++ b/config/samples/targets/logz/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logz/300-trigger.yaml
+++ b/config/samples/targets/logz/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logzmetrics/100-secret.yaml
+++ b/config/samples/targets/logzmetrics/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logzmetrics/200-target.yaml
+++ b/config/samples/targets/logzmetrics/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/logzmetrics/300-trigger.yaml
+++ b/config/samples/targets/logzmetrics/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/100-secret.yaml
+++ b/config/samples/targets/oracle/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/200-oracle-target.yaml
+++ b/config/samples/targets/oracle/200-oracle-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/oracle/300-trigger.yaml
+++ b/config/samples/targets/oracle/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/salesforce/salesforce-display-response.yaml
+++ b/config/samples/targets/salesforce/salesforce-display-response.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/100-secret.yaml
+++ b/config/samples/targets/sendgrid/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/200-target.yaml
+++ b/config/samples/targets/sendgrid/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/sendgrid/300-trigger.yaml
+++ b/config/samples/targets/sendgrid/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/100-secret.yaml
+++ b/config/samples/targets/slack/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/200-target.yaml
+++ b/config/samples/targets/slack/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/slack/300-trigger.yaml
+++ b/config/samples/targets/slack/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/splunk/splunktarget.yaml
+++ b/config/samples/targets/splunk/splunktarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/tekton/200-target.yaml
+++ b/config/samples/targets/tekton/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/100-secret.yaml
+++ b/config/samples/targets/twilio/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/200-twilio-target.yaml
+++ b/config/samples/targets/twilio/200-twilio-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/twilio/300-trigger.yaml
+++ b/config/samples/targets/twilio/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/100-secret.yaml
+++ b/config/samples/targets/uipath/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/200-target.yaml
+++ b/config/samples/targets/uipath/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/uipath/300-trigger.yaml
+++ b/config/samples/targets/uipath/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/100-secret.yaml
+++ b/config/samples/targets/zendesk/100-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/200-target.yaml
+++ b/config/samples/targets/zendesk/200-target.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/targets/zendesk/300-trigger.yaml
+++ b/config/samples/targets/zendesk/300-trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/crd-annotations-check.sh
+++ b/hack/crd-annotations-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -7,7 +7,7 @@
 #
 # Based on the Knative same file at https://github.com/knative/docs/
 #
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/kodata-check.sh
+++ b/hack/kodata-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/rbac-check/clusterroles.go
+++ b/hack/rbac-check/clusterroles.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/components.go
+++ b/hack/rbac-check/components.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/crd_files.go
+++ b/hack/rbac-check/crd_files.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/diff.go
+++ b/hack/rbac-check/diff.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/fs.go
+++ b/hack/rbac-check/fs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/main.go
+++ b/hack/rbac-check/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/rbac-check/main_test.go
+++ b/hack/rbac-check/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/main.go
+++ b/hack/targetgen/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/cmd/newtarget-adapter/main.go
+++ b/hack/targetgen/scaffolding/cmd/newtarget-adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/config/301-newtarget.yaml
+++ b/hack/targetgen/scaffolding/config/301-newtarget.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/apis/targets/v1alpha1/newtarget_lifecycle.go
+++ b/hack/targetgen/scaffolding/pkg/apis/targets/v1alpha1/newtarget_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/apis/targets/v1alpha1/newtarget_types.go
+++ b/hack/targetgen/scaffolding/pkg/apis/targets/v1alpha1/newtarget_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/targets/adapter/newtarget/adapter.go
+++ b/hack/targetgen/scaffolding/pkg/targets/adapter/newtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/adapter.go
+++ b/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/controller.go
+++ b/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/controller_test.go
+++ b/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/reconciler.go
+++ b/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -2,7 +2,7 @@
 // +build tools
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/apis/aws_arn.go
+++ b/pkg/apis/aws_arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/aws_arn_test.go
+++ b/pkg/apis/aws_arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/duration.go
+++ b/pkg/apis/duration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/duration_test.go
+++ b/pkg/apis/duration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/function_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/function_defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/function_lifecycle.go
+++ b/pkg/apis/extensions/v1alpha1/function_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/function_types.go
+++ b/pkg/apis/extensions/v1alpha1/function_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/function_validation.go
+++ b/pkg/apis/extensions/v1alpha1/function_validation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/register.go
+++ b/pkg/apis/flow/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/common_lifecycle_test.go
+++ b/pkg/apis/flow/v1alpha1/common_lifecycle_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/common_validation_test.go
+++ b/pkg/apis/flow/v1alpha1/common_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/doc.go
+++ b/pkg/apis/flow/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/register_test.go
+++ b/pkg/apis/flow/v1alpha1/register_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/transformation_defaults.go
+++ b/pkg/apis/flow/v1alpha1/transformation_defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/xslt_defaults_test.go
+++ b/pkg/apis/flow/v1alpha1/xslt_defaults_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/flow/v1alpha1/xslt_validation_test.go
+++ b/pkg/apis/flow/v1alpha1/xslt_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/register.go
+++ b/pkg/apis/routing/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/routing/v1alpha1/common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/common_types.go
+++ b/pkg/apis/routing/v1alpha1/common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/conditions.go
+++ b/pkg/apis/routing/v1alpha1/conditions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/doc.go
+++ b/pkg/apis/routing/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/filter_defaults.go
+++ b/pkg/apis/routing/v1alpha1/filter_defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/filter_lifecycle.go
+++ b/pkg/apis/routing/v1alpha1/filter_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/filter_types.go
+++ b/pkg/apis/routing/v1alpha1/filter_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/filter_validation.go
+++ b/pkg/apis/routing/v1alpha1/filter_validation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/interfaces.go
+++ b/pkg/apis/routing/v1alpha1/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/register.go
+++ b/pkg/apis/routing/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/register_test.go
+++ b/pkg/apis/routing/v1alpha1/register_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/splitter_defaults.go
+++ b/pkg/apis/routing/v1alpha1/splitter_defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/splitter_lifecycle.go
+++ b/pkg/apis/routing/v1alpha1/splitter_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/splitter_types.go
+++ b/pkg/apis/routing/v1alpha1/splitter_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/routing/v1alpha1/splitter_validation.go
+++ b/pkg/apis/routing/v1alpha1/splitter_validation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/azure.go
+++ b/pkg/apis/sources/azure.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/register.go
+++ b/pkg/apis/sources/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/aws_common_lifecyle.go
+++ b/pkg/apis/sources/v1alpha1/aws_common_lifecyle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/aws_common_types.go
+++ b/pkg/apis/sources/v1alpha1/aws_common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscodecommit_types.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitoidentity_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscognitoidentity_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitoidentity_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitouserpool_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscognitouserpool_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
+++ b/pkg/apis/sources/v1alpha1/awscognitouserpool_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awskinesis_types.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awss3_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awss3_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssns_types.go
+++ b/pkg/apis/sources/v1alpha1/awssns_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azure_common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azure_common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azure_common_types.go
+++ b/pkg/apis/sources/v1alpha1/azure_common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azure_common_types_test.go
+++ b/pkg/apis/sources/v1alpha1/azure_common_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureactivitylogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureactivitylogs_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
+++ b/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureeventhub_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureeventhub_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureeventhub_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventhub_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureiothubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/azureiothubsource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureiothubusource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureiothubusource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azurequeuestorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azurequeuestorage_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureservicebusqueue_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebusqueue_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureservicebusqueue_types.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebusqueue_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_types.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/common_types.go
+++ b/pkg/apis/sources/v1alpha1/common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/conditions.go
+++ b/pkg/apis/sources/v1alpha1/conditions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/doc.go
+++ b/pkg/apis/sources/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloud_common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloud_common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloud_common_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloud_common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloud_common_types_test.go
+++ b/pkg/apis/sources/v1alpha1/googlecloud_common_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_types_test.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudpubsub_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudpubsub_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/httppollersource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/httppollersource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/httppollersource_types.go
+++ b/pkg/apis/sources/v1alpha1/httppollersource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/ibmmq_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/ibmmq_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/ibmmq_types.go
+++ b/pkg/apis/sources/v1alpha1/ibmmq_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/interfaces.go
+++ b/pkg/apis/sources/v1alpha1/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/ocimetricssource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/ocimetricssource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/ocimetricssource_types.go
+++ b/pkg/apis/sources/v1alpha1/ocimetricssource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/register.go
+++ b/pkg/apis/sources/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/salesforce_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/salesforce_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/salesforce_types.go
+++ b/pkg/apis/sources/v1alpha1/salesforce_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/slacksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/slacksource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/slacksource_types.go
+++ b/pkg/apis/sources/v1alpha1/slacksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/twiliosource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/twiliosource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/twiliosource_types.go
+++ b/pkg/apis/sources/v1alpha1/twiliosource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/webhooksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/webhooksource_types.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/sources/v1alpha1/zendesksource_types.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/interfaces.go
+++ b/pkg/apis/targets/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/register.go
+++ b/pkg/apis/targets/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/alibabaoss_types.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_dynamodb_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_dynamodb_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_kinesis_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_lambda_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_lambda_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_s3_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_sns_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sns_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/aws_sqs_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/azure_common_types.go
+++ b/pkg/apis/targets/v1alpha1/azure_common_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/azure_common_types_test.go
+++ b/pkg/apis/targets/v1alpha1/azure_common_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/azureeventhubs_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/azureeventhubs_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/azureeventhubs_types.go
+++ b/pkg/apis/targets/v1alpha1/azureeventhubs_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/conditions.go
+++ b/pkg/apis/targets/v1alpha1/conditions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/confluent_types.go
+++ b/pkg/apis/targets/v1alpha1/confluent_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/datadog_types.go
+++ b/pkg/apis/targets/v1alpha1/datadog_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/doc.go
+++ b/pkg/apis/targets/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlecloudworkflows_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudworkflows_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/googlesheet_types.go
+++ b/pkg/apis/targets/v1alpha1/googlesheet_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/hasura_types.go
+++ b/pkg/apis/targets/v1alpha1/hasura_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/http_types.go
+++ b/pkg/apis/targets/v1alpha1/http_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/ibmmq_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/ibmmq_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/ibmmq_types.go
+++ b/pkg/apis/targets/v1alpha1/ibmmq_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/infra_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/infra_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/infra_types.go
+++ b/pkg/apis/targets/v1alpha1/infra_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/jira_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/jira_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/jira_types.go
+++ b/pkg/apis/targets/v1alpha1/jira_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logz_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/logz_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logz_types.go
+++ b/pkg/apis/targets/v1alpha1/logz_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logzmetrics_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/logzmetrics_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/logzmetrics_types.go
+++ b/pkg/apis/targets/v1alpha1/logzmetrics_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/oracle_types.go
+++ b/pkg/apis/targets/v1alpha1/oracle_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/register_test.go
+++ b/pkg/apis/targets/v1alpha1/register_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/salesforce_types.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/sendgrid_types.go
+++ b/pkg/apis/targets/v1alpha1/sendgrid_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/slack_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/slack_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/slack_types.go
+++ b/pkg/apis/targets/v1alpha1/slack_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/splunk_types.go
+++ b/pkg/apis/targets/v1alpha1/splunk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/tekton_types.go
+++ b/pkg/apis/targets/v1alpha1/tekton_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/twilio_types.go
+++ b/pkg/apis/targets/v1alpha1/twilio_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/uipath_types.go
+++ b/pkg/apis/targets/v1alpha1/uipath_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/targets/v1alpha1/zendesk_types.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/flow/reconciler/testing/doc.go
+++ b/pkg/flow/reconciler/testing/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/function/controller.go
+++ b/pkg/function/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/function/resources/configmap.go
+++ b/pkg/function/resources/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/function/resources/knservice.go
+++ b/pkg/function/resources/knservice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/function/semantic/semantic.go
+++ b/pkg/function/semantic/semantic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/common/controller/controller.go
+++ b/pkg/routing/adapter/common/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/common/env/env.go
+++ b/pkg/routing/adapter/common/env/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/routing/adapter/common/sharedmain/sharedmain.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/filter/adapter.go
+++ b/pkg/routing/adapter/filter/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/filter/controller.go
+++ b/pkg/routing/adapter/filter/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/filter/reconciler.go
+++ b/pkg/routing/adapter/filter/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/filter/storage.go
+++ b/pkg/routing/adapter/filter/storage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/splitter/adapter.go
+++ b/pkg/routing/adapter/splitter/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/splitter/controller.go
+++ b/pkg/routing/adapter/splitter/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/adapter/splitter/reconciler.go
+++ b/pkg/routing/adapter/splitter/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/eventfilter/cel/cel.go
+++ b/pkg/routing/eventfilter/cel/cel.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/eventfilter/cel/cel_test.go
+++ b/pkg/routing/eventfilter/cel/cel_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/eventfilter/cel/filter.go
+++ b/pkg/routing/eventfilter/cel/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/eventfilter/filter.go
+++ b/pkg/routing/eventfilter/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/base_test.go
+++ b/pkg/routing/reconciler/common/base_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/doc.go
+++ b/pkg/routing/reconciler/common/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/env.go
+++ b/pkg/routing/reconciler/common/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/event/event.go
+++ b/pkg/routing/reconciler/common/event/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/event/event_test.go
+++ b/pkg/routing/reconciler/common/event/event_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/events.go
+++ b/pkg/routing/reconciler/common/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/labels.go
+++ b/pkg/routing/reconciler/common/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/reconcile.go
+++ b/pkg/routing/reconciler/common/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/container.go
+++ b/pkg/routing/reconciler/common/resource/container.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/container_test.go
+++ b/pkg/routing/reconciler/common/resource/container_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/doc.go
+++ b/pkg/routing/reconciler/common/resource/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/knservice.go
+++ b/pkg/routing/reconciler/common/resource/knservice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/knservice_test.go
+++ b/pkg/routing/reconciler/common/resource/knservice_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/object.go
+++ b/pkg/routing/reconciler/common/resource/object.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/resource/podspecable.go
+++ b/pkg/routing/reconciler/common/resource/podspecable.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/routing.go
+++ b/pkg/routing/reconciler/common/routing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/semantic/semantic.go
+++ b/pkg/routing/reconciler/common/semantic/semantic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/skip/skip.go
+++ b/pkg/routing/reconciler/common/skip/skip.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/common/status.go
+++ b/pkg/routing/reconciler/common/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/filter/adapter.go
+++ b/pkg/routing/reconciler/filter/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/filter/controller.go
+++ b/pkg/routing/reconciler/filter/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/filter/reconciler.go
+++ b/pkg/routing/reconciler/filter/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/splitter/adapter.go
+++ b/pkg/routing/reconciler/splitter/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/splitter/controller.go
+++ b/pkg/routing/reconciler/splitter/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/reconciler/splitter/reconciler.go
+++ b/pkg/routing/reconciler/splitter/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/status/status.go
+++ b/pkg/routing/status/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/status/status_test.go
+++ b/pkg/routing/status/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/routing/testing/event/event.go
+++ b/pkg/routing/testing/event/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchsource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscodecommitsource/adapter.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscodecommitsource/adapter_test.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitoidentitysource/events.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awskinesissource/adapter.go
+++ b/pkg/sources/adapter/awskinesissource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awskinesissource/adapter_test.go
+++ b/pkg/sources/adapter/awskinesissource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/adapter.go
+++ b/pkg/sources/adapter/awssnssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/adapter_test.go
+++ b/pkg/sources/adapter/awssnssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/controller.go
+++ b/pkg/sources/adapter/awssnssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/controller_test.go
+++ b/pkg/sources/adapter/awssnssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/events.go
+++ b/pkg/sources/adapter/awssnssource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/handler/handler.go
+++ b/pkg/sources/adapter/awssnssource/handler/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/handler/handler_test.go
+++ b/pkg/sources/adapter/awssnssource/handler/handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/reconciler.go
+++ b/pkg/sources/adapter/awssnssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/reconciler_test.go
+++ b/pkg/sources/adapter/awssnssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/status/clock.go
+++ b/pkg/sources/adapter/awssnssource/status/clock.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/status/condition.go
+++ b/pkg/sources/adapter/awssnssource/status/condition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/status/doc.go
+++ b/pkg/sources/adapter/awssnssource/status/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssnssource/status/patcher.go
+++ b/pkg/sources/adapter/awssnssource/status/patcher.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/adapter.go
+++ b/pkg/sources/adapter/awssqssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/adapter_test.go
+++ b/pkg/sources/adapter/awssqssource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/cloudevents.go
+++ b/pkg/sources/adapter/awssqssource/cloudevents.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/delete.go
+++ b/pkg/sources/adapter/awssqssource/delete.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/process.go
+++ b/pkg/sources/adapter/awssqssource/process.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/receive.go
+++ b/pkg/sources/adapter/awssqssource/receive.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/awssqssource/stats_reporter.go
+++ b/pkg/sources/adapter/awssqssource/stats_reporter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureeventhubsource/adapter_test.go
+++ b/pkg/sources/adapter/azureeventhubsource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureeventhubsource/process.go
+++ b/pkg/sources/adapter/azureeventhubsource/process.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureeventhubsource/process_test.go
+++ b/pkg/sources/adapter/azureeventhubsource/process_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureeventhubsource/trace/trace.go
+++ b/pkg/sources/adapter/azureeventhubsource/trace/trace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureeventhubsource/trace/trace_test.go
+++ b/pkg/sources/adapter/azureeventhubsource/trace/trace_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureiothubsource/adapter.go
+++ b/pkg/sources/adapter/azureiothubsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/adapter/azurequeuestoragesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureservicebussource/trace/trace.go
+++ b/pkg/sources/adapter/azureservicebussource/trace/trace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/azureservicebussource/trace/trace_test.go
+++ b/pkg/sources/adapter/azureservicebussource/trace/trace_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/aws_arn.go
+++ b/pkg/sources/adapter/common/aws_arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/aws_arn_test.go
+++ b/pkg/sources/adapter/common/aws_arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/aws_endpoint.go
+++ b/pkg/sources/adapter/common/aws_endpoint.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/backoff.go
+++ b/pkg/sources/adapter/common/backoff.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/backoff_test.go
+++ b/pkg/sources/adapter/common/backoff_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/controller/controller.go
+++ b/pkg/sources/adapter/common/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/doc.go
+++ b/pkg/sources/adapter/common/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/env/env.go
+++ b/pkg/sources/adapter/common/env/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/health/health.go
+++ b/pkg/sources/adapter/common/health/health.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/health/health_test.go
+++ b/pkg/sources/adapter/common/health/health_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/router/router.go
+++ b/pkg/sources/adapter/common/router/router.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/router/router_test.go
+++ b/pkg/sources/adapter/common/router/router_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/sources/adapter/common/sharedmain/sharedmain.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/cloudevents.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/cloudevents.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/errors.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/errors.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/errors_test.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/errors_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/process.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/process.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/process_test.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/process_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/resource_name.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/resource_name.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/googlecloudpubsubsource/resource_name_test.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/resource_name_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/httppollersource/adapter.go
+++ b/pkg/sources/adapter/httppollersource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/httppollersource/env.go
+++ b/pkg/sources/adapter/httppollersource/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/httppollersource/httppoller.go
+++ b/pkg/sources/adapter/httppollersource/httppoller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/httppollersource/httppoller_test.go
+++ b/pkg/sources/adapter/httppollersource/httppoller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ibmmqsource/config.go
+++ b/pkg/sources/adapter/ibmmqsource/config.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ibmmqsource/mq/config.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/config.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
+++ b/pkg/sources/adapter/ibmmqsource/mq/mqutil.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ocimetricssource/adapter.go
+++ b/pkg/sources/adapter/ocimetricssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ocimetricssource/env.go
+++ b/pkg/sources/adapter/ocimetricssource/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/ocimetricssource/ocimetrics.go
+++ b/pkg/sources/adapter/ocimetricssource/ocimetrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/adapter.go
+++ b/pkg/sources/adapter/salesforcesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/auth/authenticator.go
+++ b/pkg/sources/adapter/salesforcesource/auth/authenticator.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/auth/fake/authenticator.go
+++ b/pkg/sources/adapter/salesforcesource/auth/fake/authenticator.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/auth/jwt.go
+++ b/pkg/sources/adapter/salesforcesource/auth/jwt.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/client/bayeux.go
+++ b/pkg/sources/adapter/salesforcesource/client/bayeux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/client/bayeux_test.go
+++ b/pkg/sources/adapter/salesforcesource/client/bayeux_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/client/types.go
+++ b/pkg/sources/adapter/salesforcesource/client/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/salesforcesource/env.go
+++ b/pkg/sources/adapter/salesforcesource/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/adapter.go
+++ b/pkg/sources/adapter/slacksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/env.go
+++ b/pkg/sources/adapter/slacksource/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/event.go
+++ b/pkg/sources/adapter/slacksource/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/signing.go
+++ b/pkg/sources/adapter/slacksource/signing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/slack.go
+++ b/pkg/sources/adapter/slacksource/slack.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/slacksource/slack_test.go
+++ b/pkg/sources/adapter/slacksource/slack_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/testing/controller.go
+++ b/pkg/sources/adapter/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/testing/doc.go
+++ b/pkg/sources/adapter/testing/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/testing/factory.go
+++ b/pkg/sources/adapter/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/testing/listers.go
+++ b/pkg/sources/adapter/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/twiliosource/adapter.go
+++ b/pkg/sources/adapter/twiliosource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/twiliosource/types.go
+++ b/pkg/sources/adapter/twiliosource/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/adapter.go
+++ b/pkg/sources/adapter/webhooksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/webhooksource/webhook_test.go
+++ b/pkg/sources/adapter/webhooksource/webhook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/adapter.go
+++ b/pkg/sources/adapter/zendesksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/adapter_test.go
+++ b/pkg/sources/adapter/zendesksource/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/controller.go
+++ b/pkg/sources/adapter/zendesksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/controller_test.go
+++ b/pkg/sources/adapter/zendesksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/events.go
+++ b/pkg/sources/adapter/zendesksource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/handler/events.go
+++ b/pkg/sources/adapter/zendesksource/handler/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/handler/handler.go
+++ b/pkg/sources/adapter/zendesksource/handler/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/handler/handler_test.go
+++ b/pkg/sources/adapter/zendesksource/handler/handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/reconciler.go
+++ b/pkg/sources/adapter/zendesksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/adapter/zendesksource/reconciler_test.go
+++ b/pkg/sources/adapter/zendesksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/auth/azure/autorest.go
+++ b/pkg/sources/auth/azure/autorest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/auth/errors.go
+++ b/pkg/sources/auth/errors.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/auth/errors_test.go
+++ b/pkg/sources/auth/errors_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/creds.go
+++ b/pkg/sources/aws/creds.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/creds_test.go
+++ b/pkg/sources/aws/creds_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/iam/iam.go
+++ b/pkg/sources/aws/iam/iam.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/s3/s3.go
+++ b/pkg/sources/aws/s3/s3.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/aws/sqs/sqs.go
+++ b/pkg/sources/aws/sqs/sqs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/azure/insights/client.go
+++ b/pkg/sources/client/azure/insights/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/azure/servicebustopics/client.go
+++ b/pkg/sources/client/azure/servicebustopics/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/azure/storage/client.go
+++ b/pkg/sources/client/azure/storage/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/auditlogs/client.go
+++ b/pkg/sources/client/gcloud/auditlogs/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/billing/client.go
+++ b/pkg/sources/client/gcloud/billing/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/iot/client.go
+++ b/pkg/sources/client/gcloud/iot/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/pubsub/client.go
+++ b/pkg/sources/client/gcloud/pubsub/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/repositories/client.go
+++ b/pkg/sources/client/gcloud/repositories/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/gcloud/storage/client.go
+++ b/pkg/sources/client/gcloud/storage/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/s3/client.go
+++ b/pkg/sources/client/s3/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/client/sns/client.go
+++ b/pkg/sources/client/sns/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/cloudevents/overrides.go
+++ b/pkg/sources/cloudevents/overrides.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/cloudevents/overrides_test.go
+++ b/pkg/sources/cloudevents/overrides_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/reconciler.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/reconciler.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/sources/reconciler/awscodecommitsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/controller.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/controller_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/reconciler.go
+++ b/pkg/sources/reconciler/awscodecommitsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/reconciler.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/reconciler.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/reconciler.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/controller.go
+++ b/pkg/sources/reconciler/awskinesissource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/controller_test.go
+++ b/pkg/sources/reconciler/awskinesissource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/reconciler.go
+++ b/pkg/sources/reconciler/awskinesissource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/sources/reconciler/awskinesissource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awsperformanceinsightssource/reconciler.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/bucket.go
+++ b/pkg/sources/reconciler/awss3source/bucket.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/controller.go
+++ b/pkg/sources/reconciler/awss3source/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/controller_test.go
+++ b/pkg/sources/reconciler/awss3source/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/events.go
+++ b/pkg/sources/reconciler/awss3source/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/queue.go
+++ b/pkg/sources/reconciler/awss3source/queue.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awss3source/reconciler.go
+++ b/pkg/sources/reconciler/awss3source/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/controller.go
+++ b/pkg/sources/reconciler/awssnssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/controller_test.go
+++ b/pkg/sources/reconciler/awssnssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/events.go
+++ b/pkg/sources/reconciler/awssnssource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/reconciler.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/subscription.go
+++ b/pkg/sources/reconciler/awssnssource/subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssnssource/subscription_test.go
+++ b/pkg/sources/reconciler/awssnssource/subscription_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/controller.go
+++ b/pkg/sources/reconciler/awssqssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/controller_test.go
+++ b/pkg/sources/reconciler/awssqssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/reconciler.go
+++ b/pkg/sources/reconciler/awssqssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssqssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/controller.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/controller_test.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/diagsettings_test.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/diagsettings_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/events.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/reconciler.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureactivitylogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/controller.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/controller_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/event_hub.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_hub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/events.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventgridsource/controller.go
+++ b/pkg/sources/reconciler/azureeventgridsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventgridsource/controller_test.go
+++ b/pkg/sources/reconciler/azureeventgridsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventgridsource/equality.go
+++ b/pkg/sources/reconciler/azureeventgridsource/equality.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventgridsource/equality_test.go
+++ b/pkg/sources/reconciler/azureeventgridsource/equality_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventhubsource/controller.go
+++ b/pkg/sources/reconciler/azureeventhubsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventhubsource/controller_test.go
+++ b/pkg/sources/reconciler/azureeventhubsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventhubsource/reconciler.go
+++ b/pkg/sources/reconciler/azureeventhubsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureeventhubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureeventhubsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureiothubsource/controller.go
+++ b/pkg/sources/reconciler/azureiothubsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureiothubsource/controller_test.go
+++ b/pkg/sources/reconciler/azureiothubsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureiothubsource/reconciler.go
+++ b/pkg/sources/reconciler/azureiothubsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureiothubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureiothubsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azurequeuestoragesource/controller.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azurequeuestoragesource/reconciler.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebusqueuesource/controller.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebusqueuesource/reconciler.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebusqueuesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/controller.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/controller_test.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/events.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/reconciler.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/azureservicebustopicsource/subscription.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/base_test.go
+++ b/pkg/sources/reconciler/common/base_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/doc.go
+++ b/pkg/sources/reconciler/common/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/env.go
+++ b/pkg/sources/reconciler/common/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/event/event.go
+++ b/pkg/sources/reconciler/common/event/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/event/event_test.go
+++ b/pkg/sources/reconciler/common/event/event_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/events.go
+++ b/pkg/sources/reconciler/common/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/labels.go
+++ b/pkg/sources/reconciler/common/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/reconcile.go
+++ b/pkg/sources/reconciler/common/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/deployment.go
+++ b/pkg/sources/reconciler/common/resource/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/doc.go
+++ b/pkg/sources/reconciler/common/resource/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/knservice.go
+++ b/pkg/sources/reconciler/common/resource/knservice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/knservice_test.go
+++ b/pkg/sources/reconciler/common/resource/knservice_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/object.go
+++ b/pkg/sources/reconciler/common/resource/object.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/podspecable.go
+++ b/pkg/sources/reconciler/common/resource/podspecable.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/resource/serviceAccount.go
+++ b/pkg/sources/reconciler/common/resource/serviceAccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/semantic/semantic.go
+++ b/pkg/sources/reconciler/common/semantic/semantic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/skip/skip.go
+++ b/pkg/sources/reconciler/common/skip/skip.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/common/status.go
+++ b/pkg/sources/reconciler/common/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/auditlogs.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/auditlogs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/controller.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/events.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/filterbuilder.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/filterbuilder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/billing.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/billing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/events.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/events.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/iot.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/iot.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudiotsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/events.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudpubsubsource/subscription.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/events.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/repositories.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/repositories.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/controller.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/events.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/notif_config.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/notif_config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/httppollersource/adapter.go
+++ b/pkg/sources/reconciler/httppollersource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/httppollersource/controller.go
+++ b/pkg/sources/reconciler/httppollersource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/httppollersource/controller_test.go
+++ b/pkg/sources/reconciler/httppollersource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/httppollersource/reconciler.go
+++ b/pkg/sources/reconciler/httppollersource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/httppollersource/reconciler_test.go
+++ b/pkg/sources/reconciler/httppollersource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ibmmqsource/controller.go
+++ b/pkg/sources/reconciler/ibmmqsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ibmmqsource/reconciler.go
+++ b/pkg/sources/reconciler/ibmmqsource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ocimetricssource/adapter.go
+++ b/pkg/sources/reconciler/ocimetricssource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ocimetricssource/controller.go
+++ b/pkg/sources/reconciler/ocimetricssource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ocimetricssource/controller_test.go
+++ b/pkg/sources/reconciler/ocimetricssource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ocimetricssource/reconciler.go
+++ b/pkg/sources/reconciler/ocimetricssource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/ocimetricssource/reconciler_test.go
+++ b/pkg/sources/reconciler/ocimetricssource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/salesforcesource/adapter.go
+++ b/pkg/sources/reconciler/salesforcesource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/salesforcesource/controller.go
+++ b/pkg/sources/reconciler/salesforcesource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/salesforcesource/controller_test.go
+++ b/pkg/sources/reconciler/salesforcesource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/salesforcesource/reconciler.go
+++ b/pkg/sources/reconciler/salesforcesource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/salesforcesource/reconciler_test.go
+++ b/pkg/sources/reconciler/salesforcesource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/controller.go
+++ b/pkg/sources/reconciler/slacksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/controller_test.go
+++ b/pkg/sources/reconciler/slacksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/reconciler.go
+++ b/pkg/sources/reconciler/slacksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/slacksource/reconciler_test.go
+++ b/pkg/sources/reconciler/slacksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/aws.go
+++ b/pkg/sources/reconciler/testing/aws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/controller.go
+++ b/pkg/sources/reconciler/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/doc.go
+++ b/pkg/sources/reconciler/testing/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/factory.go
+++ b/pkg/sources/reconciler/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/listers.go
+++ b/pkg/sources/reconciler/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/reconcile.go
+++ b/pkg/sources/reconciler/testing/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/testing/utils.go
+++ b/pkg/sources/reconciler/testing/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/twiliosource/controller.go
+++ b/pkg/sources/reconciler/twiliosource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/twiliosource/controller_test.go
+++ b/pkg/sources/reconciler/twiliosource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/twiliosource/reconciler.go
+++ b/pkg/sources/reconciler/twiliosource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/twiliosource/reconciler_test.go
+++ b/pkg/sources/reconciler/twiliosource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/controller.go
+++ b/pkg/sources/reconciler/webhooksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/controller_test.go
+++ b/pkg/sources/reconciler/webhooksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/reconciler.go
+++ b/pkg/sources/reconciler/webhooksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/webhooksource/reconciler_test.go
+++ b/pkg/sources/reconciler/webhooksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/controller.go
+++ b/pkg/sources/reconciler/zendesksource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/controller_test.go
+++ b/pkg/sources/reconciler/zendesksource/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/events.go
+++ b/pkg/sources/reconciler/zendesksource/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/reconciler.go
+++ b/pkg/sources/reconciler/zendesksource/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/reconciler_test.go
+++ b/pkg/sources/reconciler/zendesksource/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/reconciler/zendesksource/zendesk.go
+++ b/pkg/sources/reconciler/zendesksource/zendesk.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/routing/routing.go
+++ b/pkg/sources/routing/routing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/routing/routing_test.go
+++ b/pkg/sources/routing/routing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/secret/secret.go
+++ b/pkg/sources/secret/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/secret/secret_test.go
+++ b/pkg/sources/secret/secret_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/status/status.go
+++ b/pkg/sources/status/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/status/status_test.go
+++ b/pkg/sources/status/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/testing/event/event.go
+++ b/pkg/sources/testing/event/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sources/testing/structs/structs.go
+++ b/pkg/sources/testing/structs/structs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/alibabaosstarget/adapter.go
+++ b/pkg/targets/adapter/alibabaosstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/alibabaosstarget/config.go
+++ b/pkg/targets/adapter/alibabaosstarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awscomphrehendtarget/adapter.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awscomphrehendtarget/config.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awscomphrehendtarget/types.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awsdynamodbtarget/adapter.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awsdynamodbtarget/arn.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awsdynamodbtarget/arn_test.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awsdynamodbtarget/config.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awskinesistarget/adapter.go
+++ b/pkg/targets/adapter/awskinesistarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awskinesistarget/arn.go
+++ b/pkg/targets/adapter/awskinesistarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awskinesistarget/arn_test.go
+++ b/pkg/targets/adapter/awskinesistarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awskinesistarget/config.go
+++ b/pkg/targets/adapter/awskinesistarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awslambdatarget/adapter.go
+++ b/pkg/targets/adapter/awslambdatarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awslambdatarget/arn.go
+++ b/pkg/targets/adapter/awslambdatarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awslambdatarget/arn_test.go
+++ b/pkg/targets/adapter/awslambdatarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awslambdatarget/config.go
+++ b/pkg/targets/adapter/awslambdatarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awss3target/adapter.go
+++ b/pkg/targets/adapter/awss3target/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awss3target/arn.go
+++ b/pkg/targets/adapter/awss3target/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awss3target/arn_test.go
+++ b/pkg/targets/adapter/awss3target/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awss3target/config.go
+++ b/pkg/targets/adapter/awss3target/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssnstarget/adapter.go
+++ b/pkg/targets/adapter/awssnstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssnstarget/arn.go
+++ b/pkg/targets/adapter/awssnstarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssnstarget/arn_test.go
+++ b/pkg/targets/adapter/awssnstarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssnstarget/config.go
+++ b/pkg/targets/adapter/awssnstarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssqstarget/adapter.go
+++ b/pkg/targets/adapter/awssqstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssqstarget/arn.go
+++ b/pkg/targets/adapter/awssqstarget/arn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssqstarget/arn_test.go
+++ b/pkg/targets/adapter/awssqstarget/arn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/awssqstarget/config.go
+++ b/pkg/targets/adapter/awssqstarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/doc.go
+++ b/pkg/targets/adapter/cloudevents/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/replier.go
+++ b/pkg/targets/adapter/cloudevents/replier.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/replier_options.go
+++ b/pkg/targets/adapter/cloudevents/replier_options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/replier_test.go
+++ b/pkg/targets/adapter/cloudevents/replier_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/response_header.go
+++ b/pkg/targets/adapter/cloudevents/response_header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/cloudevents/response_options.go
+++ b/pkg/targets/adapter/cloudevents/response_options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/confluenttarget/adapter_test.go
+++ b/pkg/targets/adapter/confluenttarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/confluenttarget/config.go
+++ b/pkg/targets/adapter/confluenttarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/confluenttarget/kafka.go
+++ b/pkg/targets/adapter/confluenttarget/kafka.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/datadogtarget/adapter.go
+++ b/pkg/targets/adapter/datadogtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/datadogtarget/config.go
+++ b/pkg/targets/adapter/datadogtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/datadogtarget/types.go
+++ b/pkg/targets/adapter/datadogtarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/elasticsearchtarget/adapter.go
+++ b/pkg/targets/adapter/elasticsearchtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/elasticsearchtarget/config.go
+++ b/pkg/targets/adapter/elasticsearchtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/elasticsearchtarget/config_test.go
+++ b/pkg/targets/adapter/elasticsearchtarget/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudfirestoretarget/config.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudfirestoretarget/types.go
+++ b/pkg/targets/adapter/googlecloudfirestoretarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudstoragetarget/config.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudstoragetarget/types.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudworkflowstarget/config.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlecloudworkflowstarget/types.go
+++ b/pkg/targets/adapter/googlecloudworkflowstarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlesheettarget/adapter.go
+++ b/pkg/targets/adapter/googlesheettarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlesheettarget/adapter_test.go
+++ b/pkg/targets/adapter/googlesheettarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlesheettarget/config.go
+++ b/pkg/targets/adapter/googlesheettarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/googlesheettarget/types.go
+++ b/pkg/targets/adapter/googlesheettarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/hasuratarget/adapter.go
+++ b/pkg/targets/adapter/hasuratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/hasuratarget/config.go
+++ b/pkg/targets/adapter/hasuratarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/httptarget/adapter_test.go
+++ b/pkg/targets/adapter/httptarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/httptarget/config.go
+++ b/pkg/targets/adapter/httptarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/httptarget/types.go
+++ b/pkg/targets/adapter/httptarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/ibmmqtarget/adapter.go
+++ b/pkg/targets/adapter/ibmmqtarget/adapter.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/ibmmqtarget/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/config.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/ibmmqtarget/mq/config.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/config.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
+++ b/pkg/targets/adapter/ibmmqtarget/mq/mqutil.go
@@ -1,7 +1,7 @@
 //go:build !noclibs
 
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/infratarget/adapter.go
+++ b/pkg/targets/adapter/infratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/infratarget/adapter_test.go
+++ b/pkg/targets/adapter/infratarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/infratarget/config.go
+++ b/pkg/targets/adapter/infratarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/infratarget/vm/javascript/javascript_vm.go
+++ b/pkg/targets/adapter/infratarget/vm/javascript/javascript_vm.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/infratarget/vm/vm.go
+++ b/pkg/targets/adapter/infratarget/vm/vm.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/jiratarget/adapter.go
+++ b/pkg/targets/adapter/jiratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/jiratarget/adapter_test.go
+++ b/pkg/targets/adapter/jiratarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/jiratarget/config.go
+++ b/pkg/targets/adapter/jiratarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/jiratarget/types.go
+++ b/pkg/targets/adapter/jiratarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/logztarget/adapter.go
+++ b/pkg/targets/adapter/logztarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/logztarget/config.go
+++ b/pkg/targets/adapter/logztarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/opentelemetrytarget/adapter.go
+++ b/pkg/targets/adapter/opentelemetrytarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/opentelemetrytarget/config.go
+++ b/pkg/targets/adapter/opentelemetrytarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/opentelemetrytarget/config_test.go
+++ b/pkg/targets/adapter/opentelemetrytarget/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/opentelemetrytarget/types.go
+++ b/pkg/targets/adapter/opentelemetrytarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/opentelemetrytarget/types_test.go
+++ b/pkg/targets/adapter/opentelemetrytarget/types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/oracletarget/adapter.go
+++ b/pkg/targets/adapter/oracletarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/oracletarget/config.go
+++ b/pkg/targets/adapter/oracletarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/salesforcetarget/adapter.go
+++ b/pkg/targets/adapter/salesforcetarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/salesforcetarget/auth/jwt.go
+++ b/pkg/targets/adapter/salesforcetarget/auth/jwt.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/salesforcetarget/client/client.go
+++ b/pkg/targets/adapter/salesforcetarget/client/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/salesforcetarget/client/types.go
+++ b/pkg/targets/adapter/salesforcetarget/client/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/salesforcetarget/config.go
+++ b/pkg/targets/adapter/salesforcetarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/sendgridtarget/adapter.go
+++ b/pkg/targets/adapter/sendgridtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/sendgridtarget/config.go
+++ b/pkg/targets/adapter/sendgridtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/sendgridtarget/types.go
+++ b/pkg/targets/adapter/sendgridtarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/slacktarget/adapter.go
+++ b/pkg/targets/adapter/slacktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/slacktarget/config.go
+++ b/pkg/targets/adapter/slacktarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/slacktarget/slack/methods.go
+++ b/pkg/targets/adapter/slacktarget/slack/methods.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/slacktarget/slack/webapi.go
+++ b/pkg/targets/adapter/slacktarget/slack/webapi.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/slacktarget/slack/webapi_test.go
+++ b/pkg/targets/adapter/slacktarget/slack/webapi_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/splunktarget/adapter.go
+++ b/pkg/targets/adapter/splunktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/splunktarget/adapter_test.go
+++ b/pkg/targets/adapter/splunktarget/adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/tektontarget/adapter.go
+++ b/pkg/targets/adapter/tektontarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/tektontarget/config.go
+++ b/pkg/targets/adapter/tektontarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/test/test_cloudevents.go
+++ b/pkg/targets/adapter/test/test_cloudevents.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/twiliotarget/adapter.go
+++ b/pkg/targets/adapter/twiliotarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/twiliotarget/config.go
+++ b/pkg/targets/adapter/twiliotarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/twiliotarget/types.go
+++ b/pkg/targets/adapter/twiliotarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/uipathtarget/adapter.go
+++ b/pkg/targets/adapter/uipathtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/uipathtarget/config.go
+++ b/pkg/targets/adapter/uipathtarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/uipathtarget/types.go
+++ b/pkg/targets/adapter/uipathtarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/zendesktarget/adapter.go
+++ b/pkg/targets/adapter/zendesktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/zendesktarget/config.go
+++ b/pkg/targets/adapter/zendesktarget/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/adapter/zendesktarget/types.go
+++ b/pkg/targets/adapter/zendesktarget/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/adapter.go
+++ b/pkg/targets/reconciler/alibabaosstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/controller.go
+++ b/pkg/targets/reconciler/alibabaosstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/controller_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/reconciler.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/adapter.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/controller.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/controller_test.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awscomprehendtarget/reconciler.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awsdynamodbtarget/controller.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awsdynamodbtarget/controller_test.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awsdynamodbtarget/reconciler.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awsdynamodbtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awskinesistarget/adapter.go
+++ b/pkg/targets/reconciler/awskinesistarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awskinesistarget/controller.go
+++ b/pkg/targets/reconciler/awskinesistarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awskinesistarget/controller_test.go
+++ b/pkg/targets/reconciler/awskinesistarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awskinesistarget/reconciler.go
+++ b/pkg/targets/reconciler/awskinesistarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awskinesistarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awskinesistarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awslambdatarget/adapter.go
+++ b/pkg/targets/reconciler/awslambdatarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awslambdatarget/controller.go
+++ b/pkg/targets/reconciler/awslambdatarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awslambdatarget/controller_test.go
+++ b/pkg/targets/reconciler/awslambdatarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awslambdatarget/reconciler.go
+++ b/pkg/targets/reconciler/awslambdatarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awslambdatarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awslambdatarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awss3target/adapter.go
+++ b/pkg/targets/reconciler/awss3target/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awss3target/controller.go
+++ b/pkg/targets/reconciler/awss3target/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awss3target/controller_test.go
+++ b/pkg/targets/reconciler/awss3target/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awss3target/reconciler.go
+++ b/pkg/targets/reconciler/awss3target/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssnstarget/adapter.go
+++ b/pkg/targets/reconciler/awssnstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssnstarget/controller.go
+++ b/pkg/targets/reconciler/awssnstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssnstarget/controller_test.go
+++ b/pkg/targets/reconciler/awssnstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssnstarget/reconciler.go
+++ b/pkg/targets/reconciler/awssnstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssqstarget/adapter.go
+++ b/pkg/targets/reconciler/awssqstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssqstarget/controller.go
+++ b/pkg/targets/reconciler/awssqstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssqstarget/controller_test.go
+++ b/pkg/targets/reconciler/awssqstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/awssqstarget/reconciler.go
+++ b/pkg/targets/reconciler/awssqstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/azureeventhubstarget/adapter.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/azureeventhubstarget/controller.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/azureeventhubstarget/controller_test.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/azureeventhubstarget/reconciler.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/common/stateful.go
+++ b/pkg/targets/reconciler/common/stateful.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/adapter.go
+++ b/pkg/targets/reconciler/confluenttarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/controller.go
+++ b/pkg/targets/reconciler/confluenttarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/controller_test.go
+++ b/pkg/targets/reconciler/confluenttarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/confluenttarget/reconciler.go
+++ b/pkg/targets/reconciler/confluenttarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/adapter.go
+++ b/pkg/targets/reconciler/datadogtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/controller.go
+++ b/pkg/targets/reconciler/datadogtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/controller_test.go
+++ b/pkg/targets/reconciler/datadogtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/datadogtarget/reconciler.go
+++ b/pkg/targets/reconciler/datadogtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/adapter.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/controller.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/controller_test.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/elasticsearchtarget/reconciler.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudstoragetarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/controller_test.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/adapter.go
+++ b/pkg/targets/reconciler/googlesheettarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/controller.go
+++ b/pkg/targets/reconciler/googlesheettarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/controller_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/reconciler.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/adapter.go
+++ b/pkg/targets/reconciler/hasuratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/controller.go
+++ b/pkg/targets/reconciler/hasuratarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/controller_test.go
+++ b/pkg/targets/reconciler/hasuratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/reconciler.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/hasuratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/adapter.go
+++ b/pkg/targets/reconciler/httptarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/controller.go
+++ b/pkg/targets/reconciler/httptarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/controller_test.go
+++ b/pkg/targets/reconciler/httptarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/reconciler.go
+++ b/pkg/targets/reconciler/httptarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/httptarget/reconciler_test.go
+++ b/pkg/targets/reconciler/httptarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/ibmmqtarget/adapter.go
+++ b/pkg/targets/reconciler/ibmmqtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/ibmmqtarget/controller.go
+++ b/pkg/targets/reconciler/ibmmqtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/ibmmqtarget/reconciler.go
+++ b/pkg/targets/reconciler/ibmmqtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/adapter.go
+++ b/pkg/targets/reconciler/infratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/controller.go
+++ b/pkg/targets/reconciler/infratarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/controller_test.go
+++ b/pkg/targets/reconciler/infratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/reconciler.go
+++ b/pkg/targets/reconciler/infratarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/infratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/infratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/adapter.go
+++ b/pkg/targets/reconciler/jiratarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/controller.go
+++ b/pkg/targets/reconciler/jiratarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/controller_test.go
+++ b/pkg/targets/reconciler/jiratarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/reconciler.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/jiratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logzmetricstarget/adapter.go
+++ b/pkg/targets/reconciler/logzmetricstarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logzmetricstarget/controller.go
+++ b/pkg/targets/reconciler/logzmetricstarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logzmetricstarget/controller_test.go
+++ b/pkg/targets/reconciler/logzmetricstarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logzmetricstarget/reconciler.go
+++ b/pkg/targets/reconciler/logzmetricstarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/adapter.go
+++ b/pkg/targets/reconciler/logztarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/controller.go
+++ b/pkg/targets/reconciler/logztarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/controller_test.go
+++ b/pkg/targets/reconciler/logztarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/reconciler.go
+++ b/pkg/targets/reconciler/logztarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/logztarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logztarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/adapter.go
+++ b/pkg/targets/reconciler/oracletarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/controller.go
+++ b/pkg/targets/reconciler/oracletarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/controller_test.go
+++ b/pkg/targets/reconciler/oracletarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/oracletarget/reconciler.go
+++ b/pkg/targets/reconciler/oracletarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/adapter.go
+++ b/pkg/targets/reconciler/salesforcetarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/controller.go
+++ b/pkg/targets/reconciler/salesforcetarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/controller_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/reconciler.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/adapter.go
+++ b/pkg/targets/reconciler/sendgridtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/controller.go
+++ b/pkg/targets/reconciler/sendgridtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/controller_test.go
+++ b/pkg/targets/reconciler/sendgridtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/sendgridtarget/reconciler.go
+++ b/pkg/targets/reconciler/sendgridtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/adapter.go
+++ b/pkg/targets/reconciler/slacktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/controller.go
+++ b/pkg/targets/reconciler/slacktarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/controller_test.go
+++ b/pkg/targets/reconciler/slacktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/slacktarget/reconciler.go
+++ b/pkg/targets/reconciler/slacktarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/controller.go
+++ b/pkg/targets/reconciler/splunktarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/controller_test.go
+++ b/pkg/targets/reconciler/splunktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/reconciler.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/splunktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/adapter.go
+++ b/pkg/targets/reconciler/tektontarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/controller.go
+++ b/pkg/targets/reconciler/tektontarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/reaper.go
+++ b/pkg/targets/reconciler/tektontarget/reaper.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/tektontarget/reconciler.go
+++ b/pkg/targets/reconciler/tektontarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/controller.go
+++ b/pkg/targets/reconciler/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/doc.go
+++ b/pkg/targets/reconciler/testing/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/factory.go
+++ b/pkg/targets/reconciler/testing/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/listers.go
+++ b/pkg/targets/reconciler/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/testing/utils.go
+++ b/pkg/targets/reconciler/testing/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/adapter.go
+++ b/pkg/targets/reconciler/twiliotarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/controller.go
+++ b/pkg/targets/reconciler/twiliotarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/controller_test.go
+++ b/pkg/targets/reconciler/twiliotarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/twiliotarget/reconciler.go
+++ b/pkg/targets/reconciler/twiliotarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/adapter.go
+++ b/pkg/targets/reconciler/uipathtarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/controller.go
+++ b/pkg/targets/reconciler/uipathtarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/controller_test.go
+++ b/pkg/targets/reconciler/uipathtarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/uipathtarget/reconciler.go
+++ b/pkg/targets/reconciler/uipathtarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/adapter.go
+++ b/pkg/targets/reconciler/zendesktarget/adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/controller.go
+++ b/pkg/targets/reconciler/zendesktarget/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/controller_test.go
+++ b/pkg/targets/reconciler/zendesktarget/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/targets/reconciler/zendesktarget/reconciler.go
+++ b/pkg/targets/reconciler/zendesktarget/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/apps/deployments.go
+++ b/test/e2e/framework/apps/deployments.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/apps/doc.go
+++ b/test/e2e/framework/apps/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/apps/logs.go
+++ b/test/e2e/framework/apps/logs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/aws.go
+++ b/test/e2e/framework/aws/aws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/codecommit/codecommit.go
+++ b/test/e2e/framework/aws/codecommit/codecommit.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/cognitouserpool/cognitouserpool.go
+++ b/test/e2e/framework/aws/cognitouserpool/cognitouserpool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/dynamodb/dynamodb.go
+++ b/test/e2e/framework/aws/dynamodb/dynamodb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/sns/sns.go
+++ b/test/e2e/framework/aws/sns/sns.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/aws/sqs/sqs.go
+++ b/test/e2e/framework/aws/sqs/sqs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/bridges/doc.go
+++ b/test/e2e/framework/bridges/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/bridges/sink.go
+++ b/test/e2e/framework/bridges/sink.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/ducktypes/addressable.go
+++ b/test/e2e/framework/ducktypes/addressable.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/ducktypes/doc.go
+++ b/test/e2e/framework/ducktypes/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/ducktypes/util.go
+++ b/test/e2e/framework/ducktypes/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/ducktypes/wait.go
+++ b/test/e2e/framework/ducktypes/wait.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/flags.go
+++ b/test/e2e/framework/flags.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/gcloud/gcloud.go
+++ b/test/e2e/framework/gcloud/gcloud.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/gcloud/pubsub/pubsub.go
+++ b/test/e2e/framework/gcloud/pubsub/pubsub.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/gcloud/repositories/repositories.go
+++ b/test/e2e/framework/gcloud/repositories/repositories.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/http/http.go
+++ b/test/e2e/framework/http/http.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/init.go
+++ b/test/e2e/framework/init.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/log.go
+++ b/test/e2e/framework/log.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/namespaces.go
+++ b/test/e2e/framework/namespaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/iam/gcloud_iam_roles.yaml
+++ b/test/e2e/iam/gcloud_iam_roles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 TriggerMesh Inc.
+# Copyright 2022 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awscodecommit/main.go
+++ b/test/e2e/sources/awscodecommit/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awscognitouserpool/main.go
+++ b/test/e2e/sources/awscognitouserpool/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awsdynamodb/main.go
+++ b/test/e2e/sources/awsdynamodb/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awskinesis/main.go
+++ b/test/e2e/sources/awskinesis/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awssns/main.go
+++ b/test/e2e/sources/awssns/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/awssqs/main.go
+++ b/test/e2e/sources/awssqs/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/googlecloudauditlogs/main.go
+++ b/test/e2e/sources/googlecloudauditlogs/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/googlecloudpubsub/main.go
+++ b/test/e2e/sources/googlecloudpubsub/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/googlecloudsourcerepositories/main.go
+++ b/test/e2e/sources/googlecloudsourcerepositories/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/googlecloudstorage/main.go
+++ b/test/e2e/sources/googlecloudstorage/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/sources/webhook/main.go
+++ b/test/e2e/sources/webhook/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 TriggerMesh Inc.
+Copyright 2022 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This has been a recurring reason for comments in pull requests, and nobody can realistically remember to look at those headers every time they open a file. So I suggest that we bump the year everywhere once for all and be done with it until next year.

**Disclaimer:** bumping the year in copyright headers after the initial creation of a source file is not a requirement of the Apache license, as far as I know. Although I can't find clear guidance anywhere, here are a few resources I've been looking at:

> Governance committee recommendation: [...] Remove the year from Copyright line to avoid maintenance overhead
> -- https://github.com/open-telemetry/community/issues/113#issuecomment-595377568

> Notice identifies the year of first publication, [...]
> -- https://opensource.com/article/20/10/copyright-notices-open-source-software

> The date on the notice establishes how far back the claim is made. This means if you update the date, you are no longer claiming the copyright for the original date [...]
> -- https://stackoverflow.com/a/2391555/4716370

> The copyright date states the date the content is published. It doesn't matter what date your notice claims, the actual publish date is when the clock starts ticking.
> -- https://www.reddit.com/r/webdev/comments/1p9tao/auto_updating_the_year_on_copyright_notices/

Of course, there are a lot of nuances to take into account in the discussions referenced by the above links. But the bottom line is, I think we should stop nit picking on this.