### PR TITLE
Function Kn service env variables

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -182,11 +182,11 @@ spec:
           value: ko://github.com/triggermesh/triggermesh/cmd/splitter-adapter
         # Function Runtimes
         - name: RUNTIME_KLR_PYTHON
-          value: gcr.io/triggermesh/knative-lambda-python37:v1.12.0
+          value: gcr.io/triggermesh/knative-lambda-python37:v1.15.3
         - name: RUNTIME_KLR_NODE
-          value: gcr.io/triggermesh/knative-lambda-node10:v1.12.0
+          value: gcr.io/triggermesh/knative-lambda-node10:v1.15.3
         - name: RUNTIME_KLR_RUBY
-          value: gcr.io/triggermesh/knative-lambda-ruby25:v1.12.0
+          value: gcr.io/triggermesh/knative-lambda-ruby25:v1.15.3
         # Type-specific options
         - name: TEKTONTARGET_REAPING_INTERVAL
           value: 2m

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -52,6 +53,8 @@ const (
 	klrEntrypoint       = "/opt/aws-custom-runtime"
 	functionNameLabel   = "extensions.triggermesh.io/function"
 	ceDefaultTypePrefix = "io.triggermesh.function."
+
+	metricsPrometheusPortKsvc uint16 = 9092
 )
 
 // Reconciler implements addressableservicereconciler.Interface for
@@ -228,6 +231,10 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *v1alpha1.Functio
 		resources.KnSvcImage(image),
 		resources.KnSvcMountCm(cm.Name, filename),
 		resources.KnSvcEntrypoint(klrEntrypoint),
+		resources.KnSvcEnvVar(resources.EnvName, f.Name),
+		resources.KnSvcEnvVar(resources.EnvNamespace, f.Namespace),
+		resources.KnSvcEnvVar(resources.EnvComponent, adapterName),
+		resources.KnSvcEnvVar(resources.EnvMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPortKsvc), 10)),
 		resources.KnSvcEnvVar(eventStoreEnv, f.Spec.EventStore.URI),
 		resources.KnSvcEnvVar("K_SINK", sink.String()),
 		resources.KnSvcEnvVar("_HANDLER", handler),

--- a/pkg/function/resources/env.go
+++ b/pkg/function/resources/env.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+// Common environment variables propagated to adapters.
+const (
+	EnvName                  = "NAME"
+	EnvNamespace             = "NAMESPACE"
+	EnvComponent             = "K_COMPONENT"
+	EnvMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
+)


### PR DESCRIPTION
Set Prometheus exporter-related environment variables in Function's Kn service.

Required by triggermesh/aws-custom-runtime#41
Related to triggermesh/aws-custom-runtime#40