### PR TITLE
Install required C libs in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -37,17 +37,21 @@ jobs:
         restore-keys: |
           ${{ github.job }}-${{ runner.os }}-go-
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: go
-
-    # Install IBM MQ redis client required by IBM MQ source and target adapters
+    # Install IBM MQ client required by IBM MQ source and target adapters
     - name: Install IBM MQ client
       run: |
         curl https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.3.0-IBM-MQC-Redist-LinuxX64.tar.gz -o mq.tar.gz
         mkdir -p /opt/mqm
         tar -C /opt/mqm -xzf mq.tar.gz
+
+    # Install C libraries required by the XSLT transformation adapter
+    - name: Install C libraries for XSLT transformation
+      run: apt-get install -y --no-install-recommends libxml2-dev libxslt1-dev liblzma-dev zlib1g-dev
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: go
 
     # The code compiled in this step is also the one being analyzed in the next
     # step, due to build tracing being enabled via the CODEQL_EXTRACTOR_GO_BUILD_TRACING

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -40,13 +40,13 @@ COPY --from=builder \
     /usr/lib/x86_64-linux-gnu/libxslt.so.1 \
     /usr/lib/x86_64-linux-gnu/libexslt.so.0 \
     /usr/lib/x86_64-linux-gnu/libicuuc.so.67 \
-    /usr/lib/x86_64-linux-gnu/libgcrypt.so.20 \
-    /lib/x86_64-linux-gnu/libgpg-error.so.0 \
     /lib/x86_64-linux-gnu/libz.so.1 \
     /lib/x86_64-linux-gnu/liblzma.so.5 \
+    /usr/lib/x86_64-linux-gnu/libgcrypt.so.20 \
     /usr/lib/x86_64-linux-gnu/libicudata.so.67 \
     /usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
     /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+    /lib/x86_64-linux-gnu/libgpg-error.so.0 \
     /usr/lib/x86_64-linux-gnu/
 
 COPY --from=builder /xslttransformation-adapter /


### PR DESCRIPTION
The CodeQL GitHub Actions workflow is currently failing due to missing C libraries on the CI runner: https://github.com/triggermesh/triggermesh/actions/runs/2083675403