### PR TITLE
Make source adapters backed by a Ksvc public

### DIFF
--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -47,6 +48,7 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) *servingv1.Service {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),
+		resource.Label(network.VisibilityLabelKey, "public"),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		// NOTE(antoineco): startupProbe isn't yet supported as of Knative 1.2

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -57,6 +58,8 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
+
+		resource.Label(network.VisibilityLabelKey, "public"),
 
 		resource.EnvVars(makeSlackEnvs(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/reconciler/source"
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -46,6 +47,8 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) *servingv1.Service {
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
+
+		resource.Label(network.VisibilityLabelKey, "public"),
 
 		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
 		resource.EnvVar(common.EnvName, src.GetName()),

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -60,6 +61,8 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
+
+		resource.Label(network.VisibilityLabelKey, "public"),
 
 		resource.EnvVars(makeWebhookEnvs(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/reconciler/source"
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -47,6 +48,7 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) *servingv1.Service {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),
+		resource.Label(network.VisibilityLabelKey, "public"),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }

--- a/test/e2e/framework/http/http.go
+++ b/test/e2e/framework/http/http.go
@@ -30,34 +30,34 @@ import (
 	"github.com/triggermesh/triggermesh/test/e2e/framework"
 )
 
-// PostJSONRequest send an arbitraty JSON payload to an endpoint.
+// PostJSONRequest send an arbitrary JSON payload to an endpoint.
 func PostJSONRequest(url string, payload interface{}) {
 	p, err := json.Encode(context.Background(), payload)
 	if err != nil {
-		framework.FailfWithOffset(2, "Error JSON encoding payload: %s", err)
+		framework.FailfWithOffset(2, "Error encoding payload to JSON: %s", err)
 	}
 
 	res, err := http.Post(url, "application/json", bytes.NewBuffer(p))
 	if err != nil {
-		framework.FailfWithOffset(2, "Error Posting to %s: %s", url, err)
+		framework.FailfWithOffset(2, "Error POSTing to %s: %s", url, err)
 	}
 
 	if res.StatusCode >= 400 {
-		framework.FailfWithOffset(2, "Posting to %s returned error code %d", url, res.StatusCode)
+		framework.FailfWithOffset(2, "POSTing to %s returned error code %d", url, res.StatusCode)
 	}
 }
 
-// PostJSONRequestWithRetries send an arbitraty JSON payload to an endpoint.
+// PostJSONRequestWithRetries send an arbitrary JSON payload to an endpoint.
 func PostJSONRequestWithRetries(interval, timeout time.Duration, url string, payload interface{}) {
 	if err := wait.Poll(interval, timeout, postJSONRequestSucceed(url, payload)); err != nil {
-		framework.FailfWithOffset(2, "Error Posting to %s: %s", url, err)
+		framework.FailfWithOffset(2, "Error POSTing to %s: %s", url, err)
 	}
 }
 
 func postJSONRequestSucceed(url string, payload interface{}) wait.ConditionFunc {
 	p, err := json.Encode(context.Background(), payload)
 	if err != nil {
-		framework.FailfWithOffset(2, "Error JSON encoding payload: %s", err)
+		framework.FailfWithOffset(2, "Error encoding payload to JSON: %s", err)
 	}
 	return func() (bool, error) {
 		res, err := http.Post(url, "application/json", bytes.NewBuffer(p))
@@ -65,7 +65,7 @@ func postJSONRequestSucceed(url string, payload interface{}) wait.ConditionFunc 
 			return false, nil
 		}
 		if res.StatusCode >= 400 {
-			return false, fmt.Errorf("posting to %s returned error code %d", url, res.StatusCode)
+			return false, fmt.Errorf("POSTing to %s returned error code %d", url, res.StatusCode)
 		}
 		return true, nil
 	}

--- a/test/e2e/sources/webhook/main.go
+++ b/test/e2e/sources/webhook/main.go
@@ -101,7 +101,7 @@ var _ = Describe("Webhook source", func() {
 			})
 		})
 
-		When("an HTTP request is received", func() {
+		When("an HTTP request is sent to the source's endpoint", func() {
 			BeforeEach(func() {
 				http.PostJSONRequestWithRetries(5*time.Second, 1*time.Minute, srcURL.String(), testPayload)
 			})


### PR DESCRIPTION
Fixes #712

#704 introduced a change that makes Knative Services private by default:

https://github.com/triggermesh/triggermesh/blob/46464eca0ae139fb424fe4b4605e5969603bc281/pkg/reconciler/adapter.go#L200

In 95% of the cases this is what we want, but there are a few exceptions that require setting the visibility of the Ksvc to _public_, namely in components that expose a public webhook:

- Webhook source
- Slack source
- Amazon SNS source
- Zendesk source
- Twilio source