### PR TITLE
Exclude non-API packages from docs generation

### DIFF
--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -54,12 +54,8 @@ fail() {
 install_go_bin() {
     local pkg
     pkg="$1"
-    (
-        cd "$(mktemp -d)"
-        go mod init tmp
-        go get -u "$pkg"
-        # will be downloaded to "$(go env GOPATH)/bin/$(basename $pkg)"
-    )
+    go install "$pkg"
+    # will be downloaded to "$(go env GOPATH)/bin/$(basename $pkg)"
 }
 
 repo_tarball_url() {
@@ -112,6 +108,10 @@ cleanup() {
     fi
 }
 
+# The 'extglob' flag is used by the Bash parser. Functions are parsed ahead of execution, therefore the flag must be set
+# before the code containing extended globs is parsed.
+# See also https://stackoverflow.com/a/49283991
+shopt -s extglob
 
 main() {
     if [[ -n "${GOPATH:-}" ]]; then
@@ -154,7 +154,7 @@ main() {
 
     mkdir -p "$OUTPUT_DIR/"
 
-    array=(${triggermesh_root}/pkg/apis/*/)
+    array=(${triggermesh_root}/pkg/apis/!(common)/)
     for dir in "${array[@]}"
     do
         local group output

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -9,11 +9,11 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
-            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
         },
         {
             "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/types.UID$",
-            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/types#UID"
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
@@ -34,6 +34,14 @@
         {
             "typeMatchPrefix": "^knative\\.dev/networking/pkg/apis/networking",
             "docsURLTemplate": "https://pkg.go.dev/knative.dev/networking/pkg/apis/networking#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/triggermesh/triggermesh/pkg/apis/common",
+            "docsURLTemplate": "https://pkg.go.dev/github.com/triggermesh/triggermesh/pkg/apis/common/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/triggermesh/triggermesh/pkg/apis",
+            "docsURLTemplate": "https://pkg.go.dev/github.com/triggermesh/triggermesh/pkg/apis#{{.TypeIdentifier}}"
         },
         {
             "typeMatchPrefix": "^time\\.Duration$",


### PR DESCRIPTION
Fixes #151
Fixes #716

`pkg/apis/common` is similar to `pkg/apis/duck` in Knative: it doesn't contain real API resources.
Knative generates docs for those types anyway ([example](https://knative.dev/docs/reference/api/eventing-api/#duck.knative.dev%2fv1)), which has the advantage of embedding their internal types seamlessly inside the Knative docs ([example](https://knative.dev/docs/reference/api/eventing-api/#duck.knative.dev/v1.ChannelableSpec)).
However, I have a feeling that this would require extra work on our side since we split our docs into one page per _API group_, as opposed to one page per project like Knative does (and `common` would be treated as its own API group).

Instead, I added rules that generate valid external links to https://pkg.go.dev for all types inside `pkg/apis/common` and its sub-packages ([example](https://pkg.go.dev/github.com/triggermesh/triggermesh/pkg/apis#ARN)). This fixes the few un-linked types which we currently have in our docs:

![image](https://user-images.githubusercontent.com/3299086/162041645-d81b15eb-b10b-46a5-b699-64bcf7d57572.png)

Last but not least, I updated the script to install the `ahmetb/gen-crd-api-reference-docs` command via `go install`
instead of `go get`. The latter was deprecated in Go 1.17 for installing executables (see #135).