### PR TITLE
Make Ksvcs public by removing their visibility label instead of setting an illegal label value

### DIFF
--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -26,11 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
-	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
@@ -197,7 +195,7 @@ func commonAdapterKnServiceOptions(rcl v1alpha1.Reconcilable) []resource.ObjectO
 	app := ComponentName(rcl)
 
 	objectOptions := []resource.ObjectOption{
-		resource.Label(network.VisibilityLabelKey, serving.VisibilityClusterLocal),
+		resource.VisibilityClusterLocal,
 
 		resource.Label(appNameLabel, app),
 		resource.Label(appComponentLabel, componentAdapter),

--- a/pkg/reconciler/resource/knservice.go
+++ b/pkg/reconciler/resource/knservice.go
@@ -18,12 +18,15 @@ package resource
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	network "knative.dev/networking/pkg"
+	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // NewKnService creates a Knative Service object.
 func NewKnService(ns, name string, opts ...ObjectOption) *servingv1.Service {
-	d := &servingv1.Service{
+	ks := &servingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
@@ -31,14 +34,27 @@ func NewKnService(ns, name string, opts ...ObjectOption) *servingv1.Service {
 	}
 
 	for _, opt := range opts {
-		opt(d)
+		opt(ks)
 	}
 
 	// ensure the container name is not empty
-	containers := d.Spec.Template.Spec.Containers
+	containers := ks.Spec.Template.Spec.Containers
 	if len(containers) == 1 && containers[0].Name == "" {
 		containers[0].Name = defaultContainerName
 	}
 
-	return d
+	return ks
+}
+
+// VisibilityClusterLocal makes the Knative Service only available on the
+// cluster's local network.
+func VisibilityClusterLocal(object interface{}) {
+	ks := object.(*servingv1.Service)
+	Label(network.VisibilityLabelKey, serving.VisibilityClusterLocal)(ks)
+}
+
+// VisibilityPublic makes the Knative Service available on the public internet.
+func VisibilityPublic(object interface{}) {
+	ks := object.(*servingv1.Service)
+	delete(ks.Labels, network.VisibilityLabelKey)
 }

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -46,6 +46,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		SecretMount("test-volume", "/path/to/file.ext", "test-secret", "someKey"),
+		VisibilityClusterLocal,
 	)
 
 	expectKsvc := &servingv1.Service{
@@ -53,8 +54,9 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 			Namespace: tNs,
 			Name:      tName,
 			Labels: map[string]string{
-				"test.label/1": "val1",
-				"test.label/2": "val2",
+				"test.label/1":                      "val1",
+				"test.label/2":                      "val2",
+				"networking.knative.dev/visibility": "cluster-local",
 			},
 		},
 		Spec: servingv1.ServiceSpec{

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -48,7 +47,7 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) *servingv1.Service {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),
-		resource.Label(network.VisibilityLabelKey, "public"),
+		resource.VisibilityPublic,
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		// NOTE(antoineco): startupProbe isn't yet supported as of Knative 1.2

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -59,7 +58,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.Label(network.VisibilityLabelKey, "public"),
+		resource.VisibilityPublic,
 
 		resource.EnvVars(makeSlackEnvs(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/reconciler/source"
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -48,7 +47,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.Label(network.VisibilityLabelKey, "public"),
+		resource.VisibilityPublic,
 
 		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
 		resource.EnvVar(common.EnvName, src.GetName()),

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -62,7 +61,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.Label(network.VisibilityLabelKey, "public"),
+		resource.VisibilityPublic,
 
 		resource.EnvVars(makeWebhookEnvs(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/reconciler/source"
-	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -48,7 +47,7 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) *servingv1.Service {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),
-		resource.Label(network.VisibilityLabelKey, "public"),
+		resource.VisibilityPublic,
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }

--- a/test/e2e/sources/webhook/main.go
+++ b/test/e2e/sources/webhook/main.go
@@ -87,7 +87,7 @@ var _ = Describe("Webhook source", func() {
 				sink = bridges.CreateEventDisplaySink(f.KubeClient, ns)
 			})
 
-			By("creating an WebhookSource object", func() {
+			By("creating a WebhookSource object", func() {
 				src, err := createSource(srcClient, ns, "test-", sink,
 					withEventType(eventType),
 					withEventSource(eventSource),


### PR DESCRIPTION
Fixes #718

"cluster-local" is the only value accepted by the Serving validation webhook. The proper way to make a Ksvc public is by ensuring that the label "networking.knative.dev/visibility" is not set.

_Apologizes for the trouble, I should have tested my previous PR in a full Serving installation, whereas I had disabled the webhook locally for a reason I can't remember._