### PR TITLE
Reconcile adapters even if names differ

### DIFF
--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -194,6 +194,11 @@ func (r *GenericDeploymentReconciler) getOrCreateAdapter(ctx context.Context, de
 func (r *GenericDeploymentReconciler) syncAdapterDeployment(ctx context.Context,
 	currentAdapter, desiredAdapter *appsv1.Deployment) (*appsv1.Deployment, error) {
 
+	// We may have found an existing adapter object that is owned by the
+	// component instance, but under a different name, e.g. created by an
+	// older version of TriggerMesh.
+	desiredAdapter.Name = currentAdapter.Name
+
 	if semantic.Semantic.DeepEqual(desiredAdapter, currentAdapter) {
 		return currentAdapter, nil
 	}
@@ -343,6 +348,11 @@ func (r *GenericServiceReconciler) getOrCreateAdapter(ctx context.Context, desir
 // against its current state in the running cluster.
 func (r *GenericServiceReconciler) syncAdapterService(ctx context.Context,
 	currentAdapter, desiredAdapter *servingv1.Service) (*servingv1.Service, error) {
+
+	// We may have found an existing adapter object that is owned by the
+	// component instance, but under a different name, e.g. created by an
+	// older version of TriggerMesh.
+	desiredAdapter.Name = currentAdapter.Name
 
 	if semantic.Semantic.DeepEqual(desiredAdapter, currentAdapter) {
 		return currentAdapter, nil

--- a/pkg/reconciler/testing/reconcile.go
+++ b/pkg/reconciler/testing/reconcile.go
@@ -210,6 +210,34 @@ func TestReconcileAdapter(t *testing.T, ctor Ctor, rcl v1alpha1.Reconcilable, ad
 			},
 		},
 		{
+			Name: "Everything is up-to-date",
+			Key:  tKey,
+			Ctx:  skipCtx,
+			Objects: []runtime.Object{
+				newAddressable(),
+				newComponentInstance(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
+				newAdapter(ready),
+			},
+			WantUpdates: nil,
+			WantEvents:  nil,
+		},
+		{
+			Name: "Adapter exists under a different name",
+			Key:  tKey,
+			Ctx:  skipCtx,
+			Objects: []runtime.Object{
+				newAddressable(),
+				newComponentInstance(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
+				newAdapter(ready, rename),
+			},
+			WantUpdates: nil,
+			WantEvents:  nil,
+		},
+		{
 			Name: "Switch from sink to replies",
 			Key:  tKey,
 			Ctx:  skipCtx,
@@ -640,13 +668,23 @@ func notReady(object runtime.Object) {
 	}
 }
 
-// bumpImage adds a static suffix to the Deployment's image.
+// bumpImage adds a static suffix to the adapter's image.
 func bumpImage(object runtime.Object) {
 	switch o := object.(type) {
 	case *appsv1.Deployment:
 		o.Spec.Template.Spec.Containers[0].Image += "-test"
 	case *servingv1.Service:
 		o.Spec.Template.Spec.Containers[0].Image += "-test"
+	}
+}
+
+// rename changes the name of the adapter.
+func rename(object runtime.Object) {
+	switch o := object.(type) {
+	case *appsv1.Deployment:
+		o.Name += "-oldname"
+	case *servingv1.Service:
+		o.Name += "-oldname"
 	}
 }
 


### PR DESCRIPTION
Fixes #685

Besides the unit test included in this PR, I tested the fix in a real cluster following the procedure below:

1. Create a `XMLToJSONTransformation` object called `foo`.
    (The type of component is irrelevant. I picked this one simply because it doesn't require config, credentials, etc.)

1. **Rename** the Ksvc `xmltojsontransformation-foo`, created by the generic reconciler, to just `foo`.
    (Delete and re-create because metadata.name is immutable.)

1. Observe that the reconciliation fails and that the following Kubernetes event is emitted:
    ```
    Events:
      Type     Reason               Age    From                                Message
      ----     ------               ----   ----                                -------
      Warning  FailedAdapterUpdate  78s    xmltojsontransformation-controller  Failed to update adapter Service "xmltojsontransformation-foo": services.serving.knative.dev "xmltojsontransformation-foo" not found
    ```

1. Re-deploy `trigermesh-controller` with the fix from this branch applied.


1. Observe that the reconciliation succeeds and that the following Kubernetes event is emitted:
    ```
    Events:
      Type     Reason         Age    From                                Message
      ----     ------         ----   ----                                -------
      Normal   UpdateAdapter  17s    xmltojsontransformation-controller  Updated adapter Service "foo"
    ```