### PR TITLE
Add kodata to dockerfiles

### DIFF
--- a/cmd/dataweavetransformation-adapter/Dockerfile
+++ b/cmd/dataweavetransformation-adapter/Dockerfile
@@ -1,10 +1,24 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.17-bullseye as builder
 
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends unzip
 
-WORKDIR ${GOPATH}/project
+WORKDIR /go/triggermesh
 ENV DW_VERSION="1.0.19"
 
 RUN  curl -sSLO https://github.com/mulesoft-labs/data-weave-cli/releases/download/v$DW_VERSION/dw-$DW_VERSION-Linux && \
@@ -14,10 +28,14 @@ RUN go build -o /dataweavetransformation-adapter ./cmd/dataweavetransformation-a
 
 FROM debian:stable-slim
 
+# Ensure the /kodata entries are present
+COPY --from=builder /go/triggermesh/.git/ /kodata/
+ENV KO_DATA_PATH=/kodata
+
 WORKDIR /tmp/dw
 ENV DW_HOME=/tmp/dw
 
 COPY --from=builder /dataweavetransformation-adapter /
-COPY --from=builder /go/project/dw /usr/local/bin/.
+COPY --from=builder /go/triggermesh/dw /usr/local/bin/.
 
 ENTRYPOINT ["/dataweavetransformation-adapter"]

--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.17-bullseye as builder
 
 RUN apt-get update && \
@@ -23,6 +37,10 @@ RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource
 
 
 FROM debian:stable-slim
+
+# Ensure the /kodata entries are present
+COPY --from=builder /go/triggermesh/.git/ /kodata/
+ENV KO_DATA_PATH=/kodata
 
 WORKDIR /opt/mqm/
 COPY --from=builder /opt/mqm .

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.17-bullseye as builder
 
 RUN apt-get update && \
@@ -23,6 +37,10 @@ RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget
 
 
 FROM debian:stable-slim
+
+# Ensure the /kodata entries are present
+COPY --from=builder /go/triggermesh/.git/ /kodata/
+ENV KO_DATA_PATH=/kodata
 
 WORKDIR /opt/mqm/
 COPY --from=builder /opt/mqm .

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # (!) Debian 11 'bullseye' must be used in both the builder and final image to
 # ensure the compatibility of the GNU libc.
 FROM golang:1.17-bullseye as builder
@@ -7,7 +21,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends libxml2-dev libxslt1-dev liblzma-dev zlib1g-dev
 
 
-WORKDIR ${GOPATH}/project
+WORKDIR /go/triggermesh
 
 COPY . .
 RUN go build -o /xslttransformation-adapter ./cmd/xslttransformation-adapter
@@ -33,6 +47,10 @@ RUN go build -o /xslttransformation-adapter ./cmd/xslttransformation-adapter
 
 
 FROM gcr.io/distroless/base-debian11:nonroot
+
+# Ensure the /kodata entries are present
+COPY --from=builder /go/triggermesh/.git/ /kodata/
+ENV KO_DATA_PATH=/kodata
 
 # (!) COPY follows symlinks
 COPY --from=builder \


### PR DESCRIPTION
Update the remaining dockerfiles to not only include the missing copyright, but also ensure the `/kodata` directory is available and populated to ensure knative logging captures the commit ID.

Additionally, true up the workdir for builds to have a common location to facilitate the bringing over of the git data.

Closes #701 