### PR TITLE
Introduce TriggerMesh aggregation roles

### DIFF
--- a/config/200-aggregation-admin-clusterroles.yaml
+++ b/config/200-aggregation-admin-clusterroles.yaml
@@ -1,0 +1,171 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All sources used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-sources-admin
+  labels:
+    rbac.triggermesh.io/sources-admin: "true"
+rules:
+- apiGroups:
+  - sources.knative.dev
+  - sources.eventing.knative.dev
+  - sources.eventing.triggermesh.dev
+  - sources.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+
+---
+
+# All targets used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-targets-admin
+  labels:
+    rbac.triggermesh.io/targets-admin: "true"
+rules:
+- apiGroups:
+  - targets.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - watch
+
+---
+
+# All Kantive eventing objects used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-knative-admin
+  labels:
+    rbac.triggermesh.io/knative-admin: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - eventing.knative.dev
+  - messaging.knative.dev
+  - messaging.triggermesh.dev
+  resources:
+  - brokers
+  - channels
+  - configurations
+  - revisions
+  - routes
+  - triggers
+  - subscriptions
+  - services
+  - kinesischannels
+  - inmemorychannels
+  - clusterchannelprovisioners
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+
+---
+
+# Kubernetes objects for TriggerMesh users
+# NOTE: dupe at config repo, label changed to
+#       match other labels pattern at ClusterRoles.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-kubernetes-admin
+  labels:
+    rbac.triggermesh.io/kubernetes-admin: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/exec
+  - services
+  - serviceaccounts
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+
+---
+
+# TriggerMesh bridges object
+# NOTE: dupe at config repo, label name
+#       changed to match other labels pattern.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-flow-admin
+  labels:
+    rbac.triggermesh.io/flow-admin: "true"
+rules:
+- apiGroups:
+  - flow.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - watch
+

--- a/config/200-aggregation-admin-clusterroles.yaml
+++ b/config/200-aggregation-admin-clusterroles.yaml
@@ -168,4 +168,3 @@ rules:
   - patch
   - delete
   - watch
-

--- a/config/200-aggregation-editor-clusterroles.yaml
+++ b/config/200-aggregation-editor-clusterroles.yaml
@@ -61,4 +61,3 @@ rules:
   - delete
   - deletecollection
   - watch
-

--- a/config/200-aggregation-editor-clusterroles.yaml
+++ b/config/200-aggregation-editor-clusterroles.yaml
@@ -1,0 +1,64 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Editors have same permissions as Admins on Kubernetes objects but
+# cannot manage Secrets
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-kubernetes-editor
+  labels:
+    rbac.triggermesh.io/kubernetes-editor: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/exec
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+  - watch
+

--- a/config/200-aggregation-viewer-clusterroles.yaml
+++ b/config/200-aggregation-viewer-clusterroles.yaml
@@ -1,0 +1,199 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All sources used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-sources-viewer
+  labels:
+    rbac.triggermesh.io/sources-viewer: "true"
+rules:
+- apiGroups:
+  - sources.knative.dev
+  - sources.eventing.knative.dev
+  - sources.eventing.triggermesh.dev
+  - sources.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# All targets used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-targets-viewer
+  labels:
+    rbac.triggermesh.io/targets-viewer: "true"
+rules:
+- apiGroups:
+  - targets.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# All extension objects used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-extensions-viewer
+  labels:
+    rbac.triggermesh.io/extensions-viewer: "true"
+rules:
+- apiGroups:
+  - extensions.triggermesh.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# All Knative eventing objects used at TriggerMesh
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-knative-viewer
+  labels:
+    rbac.triggermesh.io/knative-viewer: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - eventing.knative.dev
+  - messaging.knative.dev
+  - messaging.triggermesh.dev
+  resources:
+  - brokers
+  - channels
+  - configurations
+  - revisions
+  - routes
+  - triggers
+  - subscriptions
+  - services
+  - kinesischannels
+  - inmemorychannels
+  - clusterchannelprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# All Tekton elements that serve as basis for building pipelines
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-tekton-viewer
+  labels:
+    rbac.triggermesh.io/tekton-viewer: "true"
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineresources
+  - pipelineruns
+  - pipelines
+  - taskruns
+  - tasks
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# Kubernetes objects for TriggerMesh users
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-kubernetes-viewer
+  labels:
+    rbac.triggermesh.io/kubernetes-viewer: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# TriggerMesh bridges object
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-flow-viewer
+  labels:
+    rbac.triggermesh.io/flow-viewer: "true"
+rules:
+- apiGroups:
+  - flow.triggermesh.io
+  resources:
+  - bridges
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+# TriggerMesh transformation object
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: transformation-viewer
+  labels:
+    rbac.triggermesh.io/transformation-viewer: "true"
+rules:
+- apiGroups:
+  - flow.triggermesh.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Migrated the aggregated cluster roles used internally by TriggerMesh to provide a starting point for others wanting to add finer grained access controls to their sources or targets.

Closes triggermesh/triggermesh#715 