### PR TITLE
Install Eventing in KinD cluster

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -42,6 +42,7 @@ jobs:
     - name: KinD Cluster
       uses: container-tools/kind-action@v1
       with:
+        knative_eventing: v1.0.0
         knative_serving: v1.0.0
         knative_kourier: v1.0.0
         # ko loads images directly into KinD's container runtime when


### PR DESCRIPTION
#720 introduced an e2e test helper which leverages Eventing's `Channel` and `Subscription` resources.
Unfortunately, our current CI pipeline doesn't deploy Eventing to the KinD cluster used in e2e tests, so tests are currently failing with the following error:

```
Error creating Channel: the server could not find the requested resource
```