### PR TITLE
Use sudo to install OS packages in the CodeQL CI workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,7 +46,7 @@ jobs:
 
     # Install C libraries required by the XSLT transformation adapter
     - name: Install C libraries for XSLT transformation
-      run: apt-get install -y --no-install-recommends libxml2-dev libxslt1-dev liblzma-dev zlib1g-dev
+      run: sudo apt-get install -y --no-install-recommends libxml2-dev libxslt1-dev liblzma-dev zlib1g-dev
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
I forgot to add `sudo` in #706 (🤦), so the CodeQL workflow is still failing, this time with the following error:

```
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```