### PR TITLE
Increase grace period for deletion of e2e namespaces

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -129,8 +129,8 @@ jobs:
       run: |
         declare -i e2e_ns_count=-1
 
-        # retry for max 120s (60*2s)
-        for _ in $(seq 1 60); do
+        # allow a grace period of max 300s (150*2s)
+        for _ in $(seq 1 150); do
             e2e_ns_count="$(kubectl get ns -l e2e-framework -o jsonpath='{.items}' | jq '. | length')"
             if ! ((e2e_ns_count)); then
                 break
@@ -142,3 +142,7 @@ jobs:
 
         # flush stderr
         echo >&2
+
+        # Final retrieval of E2E namespaces, gives us a chance to see whether
+        # some of them were still Terminating after the grace period.
+        kubectl get ns -l e2e-framework


### PR DESCRIPTION
I've seen cases where one or more E2E namespaces were still in a `Terminating` state 2 min after the end of the E2E test suite.
This PR increases the grace period to 5 min.

![image](https://user-images.githubusercontent.com/3299086/162608848-01e321ab-b8d3-482a-8e13-c92d6a638920.png)
