### PR TITLE
Add missing pkgs to Makefile for test goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ GOTEST            ?= gotestsum --junitfile $(TEST_OUTPUT_DIR)/$(KREPO)-unit-test
 
 GOMODULE           = github.com/triggermesh/triggermesh
 
-GOPKGS             = ./cmd/... ./pkg/apis/... ./pkg/function/... ./pkg/routing/... ./pkg/sources/... ./pkg/targets/... ./pkg/flow/...
+GOPKGS             = ./cmd/... ./pkg/apis/... ./pkg/flow/... ./pkg/function/... ./pkg/metrics/... ./pkg/mturl/... ./pkg/reconciler/... ./pkg/routing/... ./pkg/sources/... ./pkg/status/... ./pkg/targets/...
 GOPKGS_SKIP_TESTS  = $(GOMODULE)/pkg/sources/reconciler/ibmmqsource \
                      $(GOMODULE)/pkg/targets/reconciler/ibmmqtarget \
                      $(GOMODULE)/pkg/sources/adapter/ibmmqsource/mq \

--- a/pkg/reconciler/semantic/semantic_test.go
+++ b/pkg/reconciler/semantic/semantic_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,16 +33,16 @@ import (
 )
 
 const (
-	fixtureDeploymentPath     = "../../../../../test/fixtures/deployment.json"
-	fixtureKnServicePath      = "../../../../../test/fixtures/knService.json"
-	fixtureServiceAccountPath = "../../../../../test/fixtures/serviceAccount.json"
+	fixtureDeploymentPath     = "../../../test/fixtures/deployment.json"
+	fixtureKnServicePath      = "../../../test/fixtures/knService.json"
+	fixtureServiceAccountPath = "../../../test/fixtures/serviceAccount.json"
 )
 
 func TestDeploymentEqual(t *testing.T) {
 	current := &appsv1.Deployment{}
 	loadFixture(t, fixtureDeploymentPath, current)
 
-	assert.GreaterOrEqual(t, len(current.Labels), 2,
+	require.GreaterOrEqual(t, len(current.Labels), 2,
 		"Test suite requires a reference object with at least 2 labels to run properly")
 
 	assert.True(t, deploymentEqual(nil, nil), "Two nil elements should be equal")
@@ -116,7 +117,7 @@ func TestKnServiceEqual(t *testing.T) {
 	current := &servingv1.Service{}
 	loadFixture(t, fixtureKnServicePath, current)
 
-	assert.GreaterOrEqual(t, len(current.Labels), 2,
+	require.GreaterOrEqual(t, len(current.Labels), 2,
 		"Test suite requires a reference object with at least 2 labels to run properly")
 
 	assert.True(t, knServiceEqual(nil, nil), "Two nil elements should be equal")
@@ -191,9 +192,9 @@ func TestServiceAccountEqual(t *testing.T) {
 	current := &corev1.ServiceAccount{}
 	loadFixture(t, fixtureServiceAccountPath, current)
 
-	assert.GreaterOrEqual(t, len(current.Labels), 2,
+	require.GreaterOrEqual(t, len(current.Labels), 2,
 		"Test suite requires a reference object with at least 2 labels to run properly")
-	assert.Nil(t, current.AutomountServiceAccountToken,
+	require.Nil(t, current.AutomountServiceAccountToken,
 		"Test suite requires a reference object with a nil automountServiceAccountTokent attribute to run properly")
 
 	assert.True(t, serviceAccountEqual(nil, nil), "Two nil elements should be equal")


### PR DESCRIPTION
I realized that our Makefile was outdated when I tried to run a test manually (`pkg/reconciler/semantic`) and that test failed, indicating that it was not executed in the CI.