### PR TITLE
Report linter errors in both the GitHub Actions workflow logs and the Files Changed tab

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -25,6 +25,17 @@ jobs:
     # the Go setup, in case other steps are added to this job in the future.
     - name: Lint Go code
       uses: golangci/golangci-lint-action@v3
+      with:
+        # (hack) By default, errors are reported to the GitHub commit view only
+        # (or the "Files changed" tab on PRs). We also want errors to be logged
+        # with line numbers to the execution logs of the workflow.
+        #
+        # The args below result in the following flags being passed to the
+        # linter command, which works, quite surprisingly:
+        #   --out-format=github-actions --out-format=colored-line-number
+        #
+        # Ref. https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
+        args: "--out-${NO_FUTURE}format=colored-line-number"
 
   lint-config:
     name: Configuration Linting


### PR DESCRIPTION
I've heard a few times that it was confusing that linter errors were reported to the "Files Changed" tab of PRs, but not to the logs of the GitHub Actions workflow.

With this change, errors (with code location) are also printed to the logs of the GitHub Actions workflow.
To achieve that, we have to run the linter a second time in case of errors, which luckily is relatively fast due to caching.

Effect of caching:

![image](https://user-images.githubusercontent.com/3299086/163002326-987ee811-1a58-4e26-8b40-0299c0297463.png)

Files Changed view:

![image](https://user-images.githubusercontent.com/3299086/163002550-20b864c1-5662-427f-8626-f6f3852625bc.png)

Workflow logs view:

![image](https://user-images.githubusercontent.com/3299086/163002950-862bb0ed-9107-45ee-8452-02a3bf097173.png)