### PR TITLE
Copy Git objects in Docker build steps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 # Top level files and directories
+#
+# (!) The '.git' directory is purposely not excluded because the Go toolchain
+#     relies on its contents to embed VCS info into binaries.
+#
 /.assets/
 /.circleci/
-/.git/
 /.github/
 /docs/
 /hack/
@@ -15,10 +18,6 @@
 /CODEOWNERS
 /README.md
 /kustomization.yaml
-
-# Files copied to KO_DATA_PATH directory
-!/.git/HEAD
-!/.git/refs/
 
 # Patterns
 **/config/

--- a/cmd/dataweavetransformation-adapter/Dockerfile
+++ b/cmd/dataweavetransformation-adapter/Dockerfile
@@ -28,8 +28,9 @@ RUN go build -o /dataweavetransformation-adapter ./cmd/dataweavetransformation-a
 
 FROM debian:stable-slim
 
-# Ensure the /kodata entries are present
-COPY --from=builder /go/triggermesh/.git/ /kodata/
+# Ensure the /kodata entries used by Knative to augment the logger with the
+# current VCS revision are present.
+COPY --from=builder /go/triggermesh/.git/HEAD /go/triggermesh/.git/refs/ /kodata/
 ENV KO_DATA_PATH=/kodata
 
 WORKDIR /tmp/dw

--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -33,13 +33,14 @@ RUN go mod download
 
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter 
+RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter
 
 
 FROM debian:stable-slim
 
-# Ensure the /kodata entries are present
-COPY --from=builder /go/triggermesh/.git/ /kodata/
+# Ensure the /kodata entries used by Knative to augment the logger with the
+# current VCS revision are present.
+COPY --from=builder /go/triggermesh/.git/HEAD /go/triggermesh/.git/refs/ /kodata/
 ENV KO_DATA_PATH=/kodata
 
 WORKDIR /opt/mqm/

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -33,13 +33,14 @@ RUN go mod download
 
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget-adapter 
+RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget-adapter
 
 
 FROM debian:stable-slim
 
-# Ensure the /kodata entries are present
-COPY --from=builder /go/triggermesh/.git/ /kodata/
+# Ensure the /kodata entries used by Knative to augment the logger with the
+# current VCS revision are present.
+COPY --from=builder /go/triggermesh/.git/HEAD /go/triggermesh/.git/refs/ /kodata/
 ENV KO_DATA_PATH=/kodata
 
 WORKDIR /opt/mqm/

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -48,8 +48,9 @@ RUN go build -o /xslttransformation-adapter ./cmd/xslttransformation-adapter
 
 FROM gcr.io/distroless/base-debian11:nonroot
 
-# Ensure the /kodata entries are present
-COPY --from=builder /go/triggermesh/.git/ /kodata/
+# Ensure the /kodata entries used by Knative to augment the logger with the
+# current VCS revision are present.
+COPY --from=builder /go/triggermesh/.git/HEAD /go/triggermesh/.git/refs/ /kodata/
 ENV KO_DATA_PATH=/kodata
 
 # (!) COPY follows symlinks


### PR DESCRIPTION
This is a preparation step for updating to Go 1.18.

Go 1.18 [embeds VCS info](https://shibumi.dev/posts/go-18-feature/) into built binaries by default, based on the contents of the `.git` directory. (Ref. #673)
Without the `objects/` directory and `index` file, `go build` can't obtain the Git status and fails with:

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

Alternatively, we could disable VCS stamping, as the error message suggests.
I believe including VCS information might be useful in case some package wants to depend on that information for any reason, but I don't have strong opinions about it.