### PR TITLE
Bump to Go 1.18 in CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   gomod-cache:
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     steps:
       - checkout
       - go/mod-download-cached
@@ -17,7 +17,7 @@ jobs:
   test:
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     steps:
       - checkout
       - go/load-cache
@@ -75,7 +75,7 @@ jobs:
   gen-apidocs:
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     parameters:
       committer_name:
         type: string
@@ -116,7 +116,7 @@ jobs:
   publish-image:
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     resource_class: xlarge
     steps:
       - checkout
@@ -133,7 +133,7 @@ jobs:
             - go-build-{{ arch }}-{{ checksum "go.sum" }}
       - run:
           name: Installing ko
-          command: go install github.com/google/ko@v0.11.1
+          command: go install github.com/google/ko@v0.11.2
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true
@@ -169,7 +169,7 @@ jobs:
     description: Patches target cluster configuration
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     parameters:
       cluster:
         type: string
@@ -221,7 +221,7 @@ jobs:
   release:
     executor:
       name: go/default
-      tag: '1.17'
+      tag: '1.18'
     steps:
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3
@@ -90,7 +90,7 @@ jobs:
         kubectl -n knative-serving wait --timeout=1m --for=condition=Complete jobs.batch/default-domain
 
     - name: Install ko
-      run: go install github.com/google/ko@v0.11.1
+      run: go install github.com/google/ko@v0.11.2
 
     - name: Deploy TriggerMesh
       env:

--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     # This action takes care of caching/restoring modules and build caches.
     # Therefore, this step should remain the first one that is executed after
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/cmd/dataweavetransformation-adapter/Dockerfile
+++ b/cmd/dataweavetransformation-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 RUN set -eux; \
     apt-get update; \

--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -14,7 +14,7 @@
 
 # (!) Debian 11 'bullseye' must be used in both the builder and final image to
 # ensure the compatibility of the GNU libc.
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
Our dependencies are starting to adopt Go generics (`Azure/azure-sdk-for-go` leading the way), so I suggest we start updating our own automation to use Go 1.18.

I am purposely not updating `go.mod` in this PR, because TriggerMesh still builds with Go 1.17 on the current `main`.
I think we should bump the version inside `go.mod` only on the next update of Azure SDK for Go (or any other dependency that uses generics).