### PR TITLE
Add support for setting adapter tolerations

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Log Group to source data from. The expected format is documented at
                   https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -84,6 +84,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               region:
                 description: Code of the AWS region to source metrics from. Available region codes are documented in the
                   AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -84,6 +84,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the CodeCommit repository to receive events from.
                   The expected format is documented at

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Amazon Cognito Identity Pool to receive notifications from.
                   The expected format is documented at

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Amazon Cognito User Pool to receive notifications from. The expected format is
                   documented at

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the DynamoDB table to receive modification events from. The expected format is
                   documented at

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Kinesis stream to receive data from. The expected format is documented at
                   https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonkinesis.html#amazonkinesis-resources-for-iam-policies.

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Amazon RDS database instance to receive metrics for. The expected format is
                   documented at

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -88,6 +88,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: |-
                   ARN of the Amazon S3 bucket to receive notifications from. The expected format is documented at

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Amazon SNS topic to consume messages from. The expected format is documented at
                   https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               arn:
                 description: ARN of the Amazon SQS queue to consume messages from. The expected format is documented at
                   https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -84,6 +84,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               subscriptionID:
                 description: The ID of the Azure subscription which activity logs to subscribe to.
                 type: string

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -91,6 +91,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               storageAccountID:
                 description: |-
                   Resource ID of the Storage Account to receive events for.

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -82,6 +82,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               scope:
                 description: |-
                   The resource ID the event subscription applies to.

--- a/config/300-azureeventhubsource.yaml
+++ b/config/300-azureeventhubsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               eventHubID:
                 description: |-
                   Resource ID of the Event Hubs instance.

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               auth:
                 description: Authentication method to interact with the Azure IOT Hub.
                 type: object

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               accountName:
                 description: Name of the storage account.
                 type: string

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               queueID:
                 description: |-
                   The resource ID the Service Bus Queue to subscribe to.

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               topicID:
                 description: |-
                   The resource ID the Service Bus Topic to subscribe to.

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               serviceName:
                 description: The name of the API service performing the operation. For example, "pubsub.googleapis.com".
                 type: string

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               billingAccountId:
                 description: The identifier for the Cloud Billing account owning the budget.
                   Example, 01D4EE-079462-DFD6EC.

--- a/config/300-googlecloudiotsource.yaml
+++ b/config/300-googlecloudiotsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               registry:
                 description: Full resource name of the Registry.
                 type: string

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               topic:
                 description: Full resource name of the Pub/Sub topic to subscribe to, in the format
                   "projects/{project_name}/topics/{topic_name}".

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               repository:
                 description: Full resource name of the Repository.
                 type: string

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               bucket:
                 description: Name of the Cloud Storage bucket to receive change notifications from. Must meet the naming
                   requirements described at https://cloud.google.com/storage/docs/naming-buckets

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -78,6 +78,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               eventType:
                 description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of
                   event related to the originating occurrence. Please refer to the CloudEvents specification for more

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -81,6 +81,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               connectionName:
                 description: IBM MQ server URI, e.g. ibm-mq.default.svc.cluster.local(1414).
                 type: string

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               oracleApiPrivateKey:
                 description: PEM encoded API private key that has access to the OCI metrics API.
                 type: object

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               auth:
                 description: Authentication method to interact with the Salesforce API.
                 type: object

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -86,6 +86,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               signingSecret:
                 description: Signing secret to authenticate Slack callbacks.
                 type: object

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -86,6 +86,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               sink:
                 description: The destination of events received by the webhook.
                 type: object

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -81,6 +81,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               eventType:
                 description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of
                   event related to the originating occurrence. Please refer to the CloudEvents specification for more

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               subdomain:
                 description: Name of the Zendesk subdomain.
                 type: string

--- a/config/301-alibabaosstarget.yaml
+++ b/config/301-alibabaosstarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               endpoint:
                 type: string
                 description: The domain name used to access the OSS.

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 description: API Key to interact with the Comprehend API. For more information about AWS
                   security credentials, please refer to the AWS General Reference at

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 type: object
                 description: API Key to interact with the Amazon DynamoDB API. For more information about AWS

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 description: API Key to interact with the Amazon EventBridge API. For more information about AWS
                   security credentials, please refer to the AWS General Reference at

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -88,6 +88,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 type: object
                 description: API Key to interact with the Amazon Kinesis API. For more information about AWS

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 type: object
                 description: API Key to interact with the Amazon Lambda API. For more information about AWS

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 type: object
                 description: API Key to interact with the Amazon S3 API. For more information about AWS

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 type: object
                 description: API Key to interact with the SNS API. For more information about AWS

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               awsApiKey:
                 description: API Key to interact with the Amazon SQS API. For more information about AWS
                   security credentials, please refer to the AWS General Reference at

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -91,6 +91,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               eventHubID:
                 description: |-
                   Resource ID of the Event Hubs instance.

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -85,6 +85,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               username:
                 description: Confluent account username when using SASL.
                 type: string

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -91,6 +91,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               apiKey:
                 type: object
                 description: Datadog API Key with access to receive metrics.

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -88,6 +88,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               indexName:
                 description: Elasticsearch index to stream the events to.
                 type: string

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -94,6 +94,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               defaultCollection:
                 description: Default firestore collection to stream events into.
                 type: string

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               bucketName:
                 description: GCP Storage bucket to stream events to. Must meet the naming
                   requirements described at https://cloud.google.com/storage/docs/naming-buckets

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               credentialsJson:
                 description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional
                   information, refer to https://cloud.google.com/docs/authentication/production.

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               id:
                 type: string
                 description: Googlesheet ID associated with the document being targeted.

--- a/config/301-hasuratarget.yaml
+++ b/config/301-hasuratarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               endpoint:
                 description: REST endpoint for the GraphQL instance.
                 type: string

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               response:
                 type: object
                 properties:

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               connectionName:
                 description: IBM MQ server URI, e.g. ibm-mq.default.svc.cluster.local(1414).
                 type: string

--- a/config/301-infratarget.yaml
+++ b/config/301-infratarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               script:
                 description: JavaScript code to invoke when an event comes in.
                 type: object

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -92,6 +92,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               auth:
                 type: object
                 description: Credentials to authenticate against the Jira instance.

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -85,6 +85,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               connection:
                 type: object
                 description: Connection information for LogzMetrics.

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               shippingToken:
                 description: API token used to authenticate the event being streamed.
                 type: object

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               oracleApiPrivateKey:
                 type: object
                 description: Oracle API Private Key to sign each request to the Oracle Cloud.

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               auth:
                 type: object
                 description: Attributes required to setup OAuth authentication with Salesforce. To create the

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               defaultFromName:
                 description: Default name to use for the from field when sending email via Sendgrid.
                 type: string

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               token:
                 type: object
                 description: Slack API token used to interface with Slack. Consult the Slack API documenation for

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -84,6 +84,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               endpoint:
                 type: string
                 description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are

--- a/config/301-tektontarget.yaml
+++ b/config/301-tektontarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               reapPolicy:
                 type: object
                 description: Specify when successful or failed jobs should remain before being cleand out.

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               defaultPhoneFrom:
                 description: Default phone number to send the message from.
                 type: string

--- a/config/301-uipathtarget.yaml
+++ b/config/301-uipathtarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               userKey:
                 description: UiPath user refresh token to support OAuth based authentication. For additional details,
                   refer to https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps.

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               subject:
                 description: Default subject line to use for tickets created using this target.
                 type: string

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               expression:
                 description: Google CEL-like expression string.
                 type: string

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               path:
                 type: string
                 description: JSONPath expression representing the key containing the data array to split. Defaults to

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -91,6 +91,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               runtime:
                 description: Function runtime name. Python, Ruby or Node runtimes are currently supported.
                 type: string

--- a/config/304-dataweavetransformation.yaml
+++ b/config/304-dataweavetransformation.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               dw_spell:
                 description: DataWeave spell used to transform incoming CloudEvents.
                 type: object

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               query:
                 description: The JSON Query to perform on the incoming event
                 type: string

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -83,6 +83,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               correlationKey:
                 description: Events correlation parameters.
                 type: object

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -88,6 +88,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               context:
                 description: CloudEvents Context attributes transformation spec.
                 type: array

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -90,6 +90,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               sink:
                 description: The destination of events transformed by this component.
                 type: object

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -89,6 +89,31 @@ spec:
                           specified, otherwise to an implementation-defined value. More info:
                           https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
               xslt:
                 description: XSLT used to transform incoming CloudEvents.
                 type: object

--- a/pkg/apis/common/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/common/v1alpha1/deepcopy_generated.go
@@ -38,6 +38,13 @@ func (in *AdapterOverrides) DeepCopyInto(out *AdapterOverrides) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/common/v1alpha1/types.go
+++ b/pkg/apis/common/v1alpha1/types.go
@@ -42,4 +42,6 @@ type AdapterOverrides struct {
 	Public *bool `json:"public,omitempty"`
 	// Resources limits and requirements applied on adapter container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Pod tolerations.
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -344,6 +344,10 @@ func adapterOverrideOptions(overrides *v1alpha1.AdapterOverrides) []resource.Obj
 		opts = append(opts, resource.Limits(toQuantity(overrides.Resources.Limits)))
 	}
 
+	for _, t := range overrides.Tolerations {
+		opts = append(opts, resource.Toleration(t))
+	}
+
 	return opts
 }
 

--- a/pkg/reconciler/resource/deployment_test.go
+++ b/pkg/reconciler/resource/deployment_test.go
@@ -50,6 +50,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		Requests(&cpuRes, &memRes),
 		Limits(&cpuRes, nil),
 		TerminationErrorToLogs,
+		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
 		SecretMount("test-vol1", "/path/to/file.ext", "test-secret", "someKey"),
 		ConfigMapMount("test-vol2", "/path/to/file.ext", "test-cmap", "someKey"),
 	)
@@ -81,6 +82,9 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "god-mode",
+					Tolerations: []corev1.Toleration{{
+						Key: "taint", Operator: "Exists",
+					}},
 					Containers: []corev1.Container{{
 						Name:  defaultContainerName,
 						Image: tImg,

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -47,6 +47,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		ServiceAccount("god-mode"),
 		Requests(&cpuRes, &memRes),
 		Limits(&cpuRes, nil),
+		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
 		SecretMount("test-vol1", "/path/to/file.ext", "test-secret", "someKey"),
 		ConfigMapMount("test-vol2", "/path/to/file.ext", "test-cmap", "someKey"),
 		VisibilityClusterLocal,
@@ -74,6 +75,9 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 					Spec: servingv1.RevisionSpec{
 						PodSpec: corev1.PodSpec{
 							ServiceAccountName: "god-mode",
+							Tolerations: []corev1.Toleration{{
+								Key: "taint", Operator: "Exists",
+							}},
 							Containers: []corev1.Container{{
 								Name:  defaultContainerName,
 								Image: tImg,

--- a/pkg/reconciler/resource/podspecable.go
+++ b/pkg/reconciler/resource/podspecable.go
@@ -72,6 +72,22 @@ func ServiceAccount(sa string) ObjectOption {
 	}
 }
 
+// Toleration sets a Toleration on a PodSpecable.
+func Toleration(t corev1.Toleration) ObjectOption {
+	return func(object interface{}) {
+		var tolerations *[]corev1.Toleration
+
+		switch o := object.(type) {
+		case *appsv1.Deployment:
+			tolerations = &o.Spec.Template.Spec.Tolerations
+		case *servingv1.Service:
+			tolerations = &o.Spec.Template.Spec.Tolerations
+		}
+
+		*tolerations = append(*tolerations, t)
+	}
+}
+
 // SecretMount adds a Secret volume and a corresponding mount to a PodSpecable.
 func SecretMount(name, target, secretName, secretKey string) ObjectOption {
 	return func(object interface{}) {


### PR DESCRIPTION
Addresses one of the features requested in #768.

Example:

```yaml
spec:
  # ...
  adapterOverrides:
    tolerations:
    - key: example-key
      operator: Exists
      effect: NoSchedule
```

Result:

```console
$ kubectl get deployment awssqssource-sample -o jsonpath='{.spec.template.spec.tolerations}'
[{"effect":"NoSchedule","key":"example-key","operator":"Exists"}]
```