### PR TITLE
Update Google Source Repositories source to accept reference to Service Account for publishing to Pub/Sub

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -107,6 +107,14 @@ jobs:
     - name: Export KUBECONFIG path
       run: echo "KUBECONFIG=${HOME}/.kube/config" >> $GITHUB_ENV
 
+    # Allows tests to authenticate with Google Cloud using the Google Cloud SDK,
+    # e.g. use 'gcloud' as a Git credential helper to interact with Google
+    # Cloud Source Repositories.
+    - name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: ${{ secrets.GCLOUD_SERVICEACCOUNT_KEY }}
+
     - name: Run e2e tests
       env:
         AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -124,6 +124,17 @@ spec:
                       https://cloud.google.com/pubsub/docs/admin#resource_names
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$
+                required: [topic]
+              publishServiceAccount:
+                description: |-
+                  Email address of the service account used for publishing notifications to Pub/Sub. This service
+                  account needs to be in the same project as the repo, and to have the 'pubsub.topics.publish' IAM
+                  permission associated with it. It can (but doesn't have to) be the same service account as the
+                  'serviceAccountKey' attribute.
+
+                  If unspecified, it defaults to the Compute Engine default service account.
+                type: string
+                format: email
               serviceAccountKey:
                 description: Service account key used to authenticate the event source and allow it to interact with
                   Google Cloud APIs. Only the JSON format is supported.

--- a/config/samples/sources/googlecloudsourcerepositoriessource.yaml
+++ b/config/samples/sources/googlecloudsourcerepositoriessource.yaml
@@ -26,6 +26,8 @@ metadata:
 spec:
   repository: projects/my-project/repos/my-repo
 
+  publishServiceAccount: pubsub-publisher@my-project.iam.gserviceaccount.com
+
   serviceAccountKey:
     value: >-
       {

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -3017,6 +3017,11 @@ func (in *GoogleCloudSourceRepositoriesSourceSpec) DeepCopyInto(out *GoogleCloud
 	in.SourceSpec.DeepCopyInto(&out.SourceSpec)
 	out.Repository = in.Repository
 	in.PubSub.DeepCopyInto(&out.PubSub)
+	if in.PublishServiceAccount != nil {
+		in, out := &in.PublishServiceAccount, &out.PublishServiceAccount
+		*out = new(string)
+		**out = **in
+	}
 	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
@@ -54,6 +54,18 @@ type GoogleCloudSourceRepositoriesSourceSpec struct {
 	// Settings related to the Pub/Sub resources associated with the repo events.
 	PubSub GoogleCloudSourceRepositoriesSourcePubSubSpec `json:"pubsub"`
 
+	// Email address of the service account used for publishing
+	// notifications to Pub/Sub. This service account needs to be in the
+	// same project as the repo, and to have the 'pubsub.topics.publish'
+	// IAM permission associated with it. It can (but doesn't have to) be
+	// the same service account as the 'ServiceAccountKey' attribute.
+	//
+	// If unspecified, it defaults to the Compute Engine default service
+	// account.
+	//
+	// +optional
+	PublishServiceAccount *string `json:"publishServiceAccount,omitempty"`
+
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -36,7 +36,7 @@ import (
 type adapterConfig struct {
 	// Container image
 	// Uses the adapter for Google Cloud Pub/Sub instead of a source-specific image.
-	Image string `envconfig:"GOOGLECLOUDPUBSUBSOURCE_IMAGE" default:"gcr.io/triggermesh-private/googlecloudpubsubsource-adapter"`
+	Image string `envconfig:"GOOGLECLOUDPUBSUBSOURCE_IMAGE" default:"gcr.io/triggermesh/googlecloudpubsubsource-adapter"`
 	// Configuration accessor for logging/metrics/tracing
 	configs source.ConfigAccessor
 }

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
@@ -81,7 +81,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudS
 		return fmt.Errorf("failed to reconcile Pub/Sub resources: %w", err)
 	}
 
-	if err = ensureTopicAssociated(ctx, repoCli, topic); err != nil {
+	var publishServiceAccount string
+	if sa := o.Spec.PublishServiceAccount; sa != nil {
+		publishServiceAccount = *sa
+	}
+
+	if err = ensureTopicAssociated(ctx, repoCli, topic, publishServiceAccount); err != nil {
 		return fmt.Errorf("failed to reconcile Repo notification: %w", err)
 	}
 

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/repositories.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/repositories.go
@@ -36,7 +36,9 @@ import (
 // Required permissions:
 // - source.repos.updateRepoConfig
 // - iam.serviceAccounts.actAs
-func ensureTopicAssociated(ctx context.Context, cli *gsourcerepo.Service, topicResName *v1alpha1.GCloudResourceName) error {
+func ensureTopicAssociated(ctx context.Context, cli *gsourcerepo.Service,
+	topicResName *v1alpha1.GCloudResourceName, publishServiceAccount string) error {
+
 	if skip.Skip(ctx) {
 		return nil
 	}
@@ -50,8 +52,9 @@ func ensureTopicAssociated(ctx context.Context, cli *gsourcerepo.Service, topicR
 		Repo: &gsourcerepo.Repo{
 			PubsubConfigs: map[string]gsourcerepo.PubsubConfig{
 				topicResName.String(): {
-					Topic:         topicResName.String(),
-					MessageFormat: "JSON",
+					Topic:               topicResName.String(),
+					MessageFormat:       "JSON",
+					ServiceAccountEmail: publishServiceAccount,
 				},
 			},
 		},

--- a/test/e2e/iam/gcloud_iam_roles.yaml
+++ b/test/e2e/iam/gcloud_iam_roles.yaml
@@ -78,8 +78,8 @@ includedPermissions:
 ---
 
 # Permissions required by the reconciler and receive adapter of the Source Repositories event source.
-name: projects/cebuk-01/roles/CloudRepositoriesEventSource
-title: Cloud Repositories event source
+name: projects/cebuk-01/roles/CloudSourceRepositoriesEventSource
+title: Cloud Source Repositories event source
 description: Role suitable for use with the TriggerMesh event source for Cloud Source Repositories.
 includedPermissions:
 - iam.serviceAccounts.actAs

--- a/test/e2e/sources/googlecloudsourcerepositories/main.go
+++ b/test/e2e/sources/googlecloudsourcerepositories/main.go
@@ -18,6 +18,7 @@ package googlecloudsourcerepositories
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
@@ -60,7 +61,7 @@ const (
 	sourceResource = "googlecloudsourcerepositoriessources"
 )
 
-var _ = Describe("Google Cloud Repositories source", func() {
+var _ = Describe("Google Cloud Source Repositories source", func() {
 	f := framework.New("googlecloudsourcerepositoriessource")
 
 	var ns string
@@ -68,6 +69,7 @@ var _ = Describe("Google Cloud Repositories source", func() {
 	var srcClient dynamic.ResourceInterface
 
 	var repoName string
+	var repoURL string
 	var serviceaccountKey string
 
 	var sink *duckv1.Destination
@@ -97,7 +99,9 @@ var _ = Describe("Google Cloud Repositories source", func() {
 			})
 
 			By("creating a source repository", func() {
-				repoName = e2erepo.CreateRepository(repoClient, gcloudProject, f).Name
+				repo := e2erepo.CreateRepository(repoClient, gcloudProject, f)
+				repoName = repo.Name
+				repoURL = repo.Url
 
 				DeferCleanup(func() {
 					By("deleting the source repository "+repoName, func() {
@@ -109,6 +113,7 @@ var _ = Describe("Google Cloud Repositories source", func() {
 			By("creating a GoogleCloudSourceRepositoriesSource object", func() {
 				src, err = createSource(srcClient, ns, "test-", sink,
 					withRepository(repoName),
+					withPublishServiceAccount(emailFromServiceAccountKey(serviceaccountKey)),
 					withServiceAccountKey(serviceaccountKey),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -120,25 +125,10 @@ var _ = Describe("Google Cloud Repositories source", func() {
 		When("an event occurs in the repository", func() {
 
 			BeforeEach(func() {
-				// There are 2 ways to produce a notification to Pub/Sub:
-				//  - perform a Git push to the source repository
-				//  - delete the source repository
-				//
-				// The latter is simpler to execute inside a test suite since it doesn't require a
-				// configured Git client.
-				//
-				// https://cloud.google.com/source-repositories/docs/pubsub-notifications#event_types
-				e2erepo.MustDeleteRepository(repoClient, repoName)
+				e2erepo.InitRepoAndCommit(repoURL)
 			})
 
-			// PENDING SPEC (not executed)
-			// Re-enable after triggermesh/triggermesh#776 is addressed.
-			//
-			// The Compute Engine default service account, used when no service account email is explicitly
-			// specified in the repository's notification configuration, doesn't have the 'pubsub.topics.publish'
-			// IAM permission (anymore?), therefore notifications are currently not sent to Pub/Sub.
-			XSpecify("the source generates an event", func() {
-
+			Specify("the source generates an event", func() {
 				const receiveTimeout = 15 * time.Second
 				const pollInterval = 500 * time.Millisecond
 
@@ -153,6 +143,7 @@ var _ = Describe("Google Cloud Repositories source", func() {
 
 				Expect(e.Type()).To(Equal("com.google.cloud.sourcerepo.notification"))
 				Expect(e.Source()).To(Equal(repoName))
+				Expect(e.Extensions()["pubsubmsgeventtype"]).To(Equal("RefUpdate"))
 			})
 		})
 	})
@@ -182,7 +173,7 @@ var _ = Describe("Google Cloud Repositories source", func() {
 		Specify("the API server rejects the creation of that object", func() {
 
 			By("setting an invalid repository", func() {
-				invalidRepoName := "projects/fake-project/repos//"
+				const invalidRepoName = "projects/fake-project/repos//"
 
 				_, err := createSource(srcClient, ns, "test-invalid-repository-", sink,
 					withRepository(invalidRepoName),
@@ -198,6 +189,19 @@ var _ = Describe("Google Cloud Repositories source", func() {
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("spec.repository: Required value"))
+			})
+
+			By("setting an invalid publish service account", func() {
+				const invalidServiceAccountEmail = "not-an-email"
+
+				_, err := createSource(srcClient, ns, "test-invalid-sa-", sink,
+					withRepository(repoName),
+					withPublishServiceAccount(invalidServiceAccountEmail),
+					withServiceAccountKey(serviceaccountKey),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(
+					"spec.publishServiceAccount in body must be of type email: "))
 			})
 
 			By("setting empty credentials", func() {
@@ -244,6 +248,14 @@ func withRepository(repo string) sourceOption {
 	}
 }
 
+func withPublishServiceAccount(saEmail string) sourceOption {
+	return func(src *unstructured.Unstructured) {
+		if err := unstructured.SetNestedField(src.Object, saEmail, "spec", "publishServiceAccount"); err != nil {
+			framework.FailfWithOffset(3, "Failed to set spec.publishServiceAccount field: %s", err)
+		}
+	}
+}
+
 func withServiceAccountKey(key string) sourceOption {
 	svcAccKeyMap := make(map[string]interface{})
 	if key != "" {
@@ -272,4 +284,19 @@ func readReceivedEvents(c clientset.Interface, namespace, eventDisplayDeplName s
 		*receivedEvents = ev
 		return ev
 	}
+}
+
+// emailFromServiceAccountKey returns the value of the client_email attribute
+// from the given service account key JSON.
+func emailFromServiceAccountKey(saKeyJSON string) string {
+	type serviceAccountKey struct {
+		ClientEmail string `json:"client_email"`
+	}
+
+	saKey := &serviceAccountKey{}
+	if err := json.Unmarshal([]byte(saKeyJSON), saKey); err != nil {
+		framework.FailfWithOffset(2, "Failed to deserialize service account key from JSON: %s", err)
+	}
+
+	return saKey.ClientEmail
 }


### PR DESCRIPTION
Fixes #776 (E2E tests failing on `main`, temporarily disabled in 14e33644139097e8f14ade0ea0d35155c9d97688)

Adds the possibility to specify what service account must be used for publishing to Pub/Sub, as described at https://cloud.google.com/source-repositories/docs/configuring-notifications#add_a_topic.

```yaml
spec:
  repository: projects/my-project/repos/my-repo
  publishServiceAccount: pubsub-publisher@my-project.iam.gserviceaccount.com
 
```

In most cases, specifying this field is highly recommended to be able to use this source, because the Compute Engine default service account is unlikely to have the required `pubsub.topics.publish` permission: https://cloud.google.com/source-repositories/docs/pubsub-notifications#permissions.

Also changes the logic of the e2e test to
1. Use that new attribute.
1. Push to the the repo to generate an event, instead of deleting the repo, which felt clumsy.

Regarding the Git push, I ended up calling `git` commands directly from the test code, because [go-git](https://git-scm.com/book/en/v2/Appendix-B%3A-Embedding-Git-in-your-Applications-go-git) doesn't support Git credential helpers (required to authenticate via `gcloud`).
It should be safe to assume that the CI environment has Git installed, otherwise it wouldn't be able to clone the code in the first place.