### PR TITLE
Fix inaccurate comments on interfaces implementations

### DIFF
--- a/pkg/apis/extensions/v1alpha1/function_lifecycle.go
+++ b/pkg/apis/extensions/v1alpha1/function_lifecycle.go
@@ -94,7 +94,7 @@ func (f *Function) GetSink() *duckv1.Destination {
 	return &f.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (f *Function) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return f.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/dataweavetransformation_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/dataweavetransformation_lifecycle.go
@@ -56,7 +56,7 @@ func (t *DataWeaveTransformation) GetSink() *duckv1.Destination {
 	return &t.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *DataWeaveTransformation) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/jqtransformation_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/jqtransformation_lifecycle.go
@@ -56,7 +56,7 @@ func (t *JQTransformation) GetSink() *duckv1.Destination {
 	return &t.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *JQTransformation) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/synchronizer_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/synchronizer_lifecycle.go
@@ -56,7 +56,7 @@ func (s *Synchronizer) GetSink() *duckv1.Destination {
 	return &s.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *Synchronizer) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/transformation_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/transformation_lifecycle.go
@@ -55,7 +55,7 @@ func (t *Transformation) GetSink() *duckv1.Destination {
 	return &t.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *Transformation) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/xmltojsontransformation_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/xmltojsontransformation_lifecycle.go
@@ -61,7 +61,7 @@ func (t *XMLToJSONTransformation) GetSink() *duckv1.Destination {
 	return &t.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *XMLToJSONTransformation) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/flow/v1alpha1/xslt_lifecycle.go
+++ b/pkg/apis/flow/v1alpha1/xslt_lifecycle.go
@@ -61,7 +61,7 @@ func (t *XSLTTransformation) GetSink() *duckv1.Destination {
 	return &t.Spec.Sink
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *XSLTTransformation) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/routing/v1alpha1/filter_lifecycle.go
+++ b/pkg/apis/routing/v1alpha1/filter_lifecycle.go
@@ -75,7 +75,7 @@ func (*Filter) IsMultiTenant() bool {
 	return true
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (f *Filter) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return f.Spec.AdapterOverrides
 }

--- a/pkg/apis/routing/v1alpha1/splitter_lifecycle.go
+++ b/pkg/apis/routing/v1alpha1/splitter_lifecycle.go
@@ -75,7 +75,7 @@ func (*Splitter) IsMultiTenant() bool {
 	return true
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *Splitter) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awscloudwatch_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatch_lifecycle.go
@@ -85,7 +85,7 @@ func AWSCloudWatchSourceName(ns, name string) string {
 	return "io.triggermesh." + kind + "." + ns + "." + name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSCloudWatchSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awscloudwatchlogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscloudwatchlogs_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSCloudWatchLogsSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSCloudWatchLogsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscodecommit_lifecycle.go
@@ -69,7 +69,7 @@ func (s *AWSCodeCommitSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSCodeCommitSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awscognitoidentity_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscognitoidentity_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSCognitoIdentitySource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSCognitoIdentitySource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awscognitouserpool_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awscognitouserpool_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSCognitoUserPoolSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSCognitoUserPoolSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsdynamodb_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSDynamoDBSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSDynamoDBSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awskinesis_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSKinesisSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSKinesisSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awsperformanceinsights_lifecycle.go
@@ -70,7 +70,7 @@ func (s *AWSPerformanceInsightsSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSPerformanceInsightsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awss3_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awss3_lifecycle.go
@@ -105,7 +105,7 @@ func (s *AWSS3Source) AsEventSource() string {
 	return s3.RealBucketARN(s.Spec.ARN)
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSS3Source) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssns_lifecycle.go
@@ -75,7 +75,7 @@ func (*AWSSNSSource) IsMultiTenant() bool {
 	return true
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSSNSSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -93,7 +93,7 @@ func (s *AWSSQSSource) ServiceAccountOptions() []resource.ServiceAccountOption {
 	return saOpts
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AWSSQSSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureactivitylogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureactivitylogs_lifecycle.go
@@ -62,7 +62,7 @@ func (s *AzureActivityLogsSource) AsEventSource() string {
 	return subsID.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureActivityLogsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_lifecycle.go
@@ -60,7 +60,7 @@ func (s *AzureBlobStorageSource) AsEventSource() string {
 	return s.Spec.StorageAccountID.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureBlobStorageSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_lifecycle.go
@@ -84,7 +84,7 @@ func (s *AzureEventGridSource) GetEventTypes() []string {
 	return eventTypes
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureEventGridSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureeventhub_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureeventhub_lifecycle.go
@@ -71,7 +71,7 @@ func (s *AzureEventHubSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureEventHubSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureiothubsource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureiothubsource_lifecycle.go
@@ -77,7 +77,7 @@ func AzureIOTHubSourceName(namespace, name string) string {
 	return "io.triggermesh.azureiothubsource/" + namespace + "/" + name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureIOTHubSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azurequeuestorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azurequeuestorage_lifecycle.go
@@ -74,7 +74,7 @@ func (s *AzureQueueStorageSource) GetEventTypes() []string {
 	return []string{AzureQueueStorageEventType}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureQueueStorageSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureservicebusqueue_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebusqueue_lifecycle.go
@@ -71,7 +71,7 @@ func (s *AzureServiceBusQueueSource) AsEventSource() string {
 	return s.Spec.QueueID.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureServiceBusQueueSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/azureservicebustopic_lifecycle.go
@@ -66,7 +66,7 @@ func (*AzureServiceBusTopicSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *AzureServiceBusTopicSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 )
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
@@ -39,12 +40,12 @@ func (s *CloudEventsSource) GetStatus() *duckv1.Status {
 	return &s.Status.Status
 }
 
-// GetSink implements EventSource.
+// GetSink implements EventSender.
 func (s *CloudEventsSource) GetSink() *duckv1.Destination {
 	return &s.Spec.Sink
 }
 
-// GetStatusManager implements EventSource.
+// GetStatusManager implements Reconcilable.
 func (s *CloudEventsSource) GetStatusManager() *v1alpha1.StatusManager {
 	return &v1alpha1.StatusManager{
 		ConditionSet: s.GetConditionSet(),

--- a/pkg/apis/sources/v1alpha1/cloudevents_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_lifecycle_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
+
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 )
 
 func TestCloudEventsSourceGetStatus(t *testing.T) {

--- a/pkg/apis/sources/v1alpha1/cloudevents_types.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_types.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 )
 
 // +genclient

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_lifecycle.go
@@ -70,7 +70,7 @@ func (*GoogleCloudAuditLogsSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudAuditLogsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_lifecycle.go
@@ -58,7 +58,7 @@ func (s *GoogleCloudBillingSource) AsEventSource() string {
 	return s.Spec.BudgetID
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudBillingSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_lifecycle.go
@@ -58,7 +58,7 @@ func (s *GoogleCloudIoTSource) AsEventSource() string {
 	return s.Spec.Registry.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudIoTSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudpubsub_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudpubsub_lifecycle.go
@@ -58,7 +58,7 @@ func (s *GoogleCloudPubSubSource) AsEventSource() string {
 	return s.Spec.Topic.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudPubSubSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_lifecycle.go
@@ -58,7 +58,7 @@ func (s *GoogleCloudSourceRepositoriesSource) AsEventSource() string {
 	return s.Spec.Repository.String()
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudSourceRepositoriesSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_lifecycle.go
@@ -58,7 +58,7 @@ func (s *GoogleCloudStorageSource) AsEventSource() string {
 	return "gs://" + s.Spec.Bucket
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *GoogleCloudStorageSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/httppollersource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/httppollersource_lifecycle.go
@@ -74,7 +74,7 @@ func (s *HTTPPollerSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *HTTPPollerSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/ibmmq_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/ibmmq_lifecycle.go
@@ -72,7 +72,7 @@ func (s *IBMMQSource) AsEventSource() string {
 	return fmt.Sprintf("%s/%s", s.Spec.ConnectionName, strings.ToLower(s.Spec.ChannelName))
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *IBMMQSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/ocimetricssource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/ocimetricssource_lifecycle.go
@@ -75,7 +75,7 @@ func (*OCIMetricsSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *OCIMetricsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/salesforce_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/salesforce_lifecycle.go
@@ -67,7 +67,7 @@ func (s *SalesforceSource) GetEventTypes() []string {
 	return []string{"com.salesforce.stream.message"}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *SalesforceSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/slacksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/slacksource_lifecycle.go
@@ -70,7 +70,7 @@ func (*SlackSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *SlackSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/twiliosource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/twiliosource_lifecycle.go
@@ -76,7 +76,7 @@ func (s *TwilioSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *TwilioSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/webhooksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/webhooksource_lifecycle.go
@@ -74,7 +74,7 @@ func (s *WebhookSource) GetEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *WebhookSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/zendesksource_lifecycle.go
@@ -63,7 +63,7 @@ func (*ZendeskSource) IsMultiTenant() bool {
 	return true
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (s *ZendeskSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/alibabaoss_lifecycle.go
@@ -72,7 +72,7 @@ func (t *AlibabaOSSTarget) AsEventSource() string {
 	return "https://" + t.Spec.Bucket + "." + t.Spec.Endpoint
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AlibabaOSSTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_comprehend_lifecycle.go
@@ -69,7 +69,7 @@ func (t *AWSComprehendTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSComprehendTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_dynamodb_lifecycle.go
@@ -66,7 +66,7 @@ func (t *AWSDynamoDBTarget) AsEventSource() string {
 	return t.Spec.ARN
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSDynamoDBTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_eventbridge_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_eventbridge_lifecycle.go
@@ -73,7 +73,7 @@ func (t *AWSEventBridgeTarget) AsEventSource() string {
 	return "io.triggermesh.awseventbridgetargets/" + t.Namespace + "/" + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSEventBridgeTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_kinesis_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_kinesis_lifecycle.go
@@ -48,7 +48,7 @@ func (t *AWSKinesisTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSKinesisTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_lambda_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_lambda_lifecycle.go
@@ -48,7 +48,7 @@ func (t *AWSLambdaTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSLambdaTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_s3_lifecycle.go
@@ -80,7 +80,7 @@ func (t *AWSS3Target) AsEventSource() string {
 	return t.Spec.ARN
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSS3Target) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_sns_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_sns_lifecycle.go
@@ -48,7 +48,7 @@ func (t *AWSSNSTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSSNSTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/aws_sqs_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_lifecycle.go
@@ -48,7 +48,7 @@ func (t *AWSSQSTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AWSSQSTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/azureeventhubs_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/azureeventhubs_lifecycle.go
@@ -75,7 +75,7 @@ func (t *AzureEventHubsTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *AzureEventHubsTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/confluent_lifecycle.go
@@ -48,7 +48,7 @@ func (t *ConfluentTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *ConfluentTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/datadog_lifecycle.go
@@ -81,7 +81,7 @@ func (t *DatadogTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *DatadogTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/elasticsearch_lifecycle.go
@@ -76,7 +76,7 @@ func (t *ElasticsearchTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *ElasticsearchTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudfirestore_lifecycle.go
@@ -89,7 +89,7 @@ func (t *GoogleCloudFirestoreTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *GoogleCloudFirestoreTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudstorage_lifecycle.go
@@ -78,7 +78,7 @@ func (t *GoogleCloudStorageTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *GoogleCloudStorageTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlecloudworkflows_lifecycle.go
@@ -77,7 +77,7 @@ func (t *GoogleCloudWorkflowsTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *GoogleCloudWorkflowsTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/googlesheet_lifecycle.go
@@ -76,7 +76,7 @@ func (t *GoogleSheetTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *GoogleSheetTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/hasura_lifecycle.go
@@ -85,7 +85,7 @@ func (t *HasuraTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *HasuraTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -48,7 +48,7 @@ func (t *HTTPTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *HTTPTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/ibmmq_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/ibmmq_lifecycle.go
@@ -76,7 +76,7 @@ func (t *IBMMQTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *IBMMQTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/infra_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/infra_lifecycle.go
@@ -48,7 +48,7 @@ func (t *InfraTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *InfraTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/jira_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/jira_lifecycle.go
@@ -83,7 +83,7 @@ func (t *JiraTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *JiraTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/logz_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/logz_lifecycle.go
@@ -68,7 +68,7 @@ func (t *LogzTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *LogzTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/logzmetrics_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/logzmetrics_lifecycle.go
@@ -60,7 +60,7 @@ func (*LogzMetricsTarget) AcceptedEventTypes() []string {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *LogzMetricsTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/oracle_lifecycle.go
@@ -48,7 +48,7 @@ func (t *OracleTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *OracleTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/salesforce_lifecycle.go
@@ -76,7 +76,7 @@ func (t *SalesforceTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *SalesforceTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/sendgrid_lifecycle.go
@@ -79,7 +79,7 @@ func (t *SendGridTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *SendGridTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/slack_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/slack_lifecycle.go
@@ -77,7 +77,7 @@ func (t *SlackTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *SlackTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/splunk_lifecycle.go
@@ -48,7 +48,7 @@ func (t *SplunkTarget) GetStatusManager() *v1alpha1.StatusManager {
 	}
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *SplunkTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/tekton_lifecycle.go
@@ -79,7 +79,7 @@ func (t *TektonTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *TektonTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/twilio_lifecycle.go
@@ -79,7 +79,7 @@ func (t *TwilioTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *TwilioTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
@@ -80,7 +80,7 @@ func (t *UiPathTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *UiPathTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }

--- a/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/zendesk_lifecycle.go
@@ -78,7 +78,7 @@ func (t *ZendeskTarget) AsEventSource() string {
 	return "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
 }
 
-// GetAdapterOverrides implements Reconcilable.
+// GetAdapterOverrides implements AdapterConfigurable.
 func (t *ZendeskTarget) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return t.Spec.AdapterOverrides
 }


### PR DESCRIPTION
Fixes a few inaccurate Godocs.

All components:
- GetAdapterOverrides implements `Reconcilable` -> `AdapterConfigurable`

CloudEventsSource only (leftovers from before merging reconciler implementations, most likely):
- GetStatusManager implements `EventSource` -> `Reconcilable`
- GetSink implements `EventSource` -> `EventSender`