### PR TITLE
Support IAM role auth in S3 source

### DIFF
--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -220,6 +220,16 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                  iamRole:
+                    description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS
+                      permissions. For more information about IAM roles for service accounts, please refer to the Amazon
+                      EKS User Guide at
+                      https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+                    type: string
+                    pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                oneOf:
+                - required: [credentials]
+                - required: [iamRole]
               sink:
                 description: The destination of events sourced from Amazon S3.
                 type: object

--- a/pkg/apis/sources/v1alpha1/aws_common_types.go
+++ b/pkg/apis/sources/v1alpha1/aws_common_types.go
@@ -29,12 +29,14 @@ type AWSAuth struct {
 	// requests based on a signature composed of an access key ID and a
 	// corresponding secret access key.
 	// See https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+	// +optional
 	Credentials *AWSSecurityCredentials `json:"credentials,omitempty"`
 
 	// (Amazon EKS only) The ARN of an IAM role which can be impersonated
 	// to obtain AWS permissions.
 	// See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
-	EksIAMRole *apis.ARN `json:"iamRole"`
+	// +optional
+	EksIAMRole *apis.ARN `json:"iamRole,omitempty"`
 }
 
 // AWSSecurityCredentials represents a set of AWS security credentials.

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -39,10 +39,11 @@ type AWSS3Source struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ v1alpha1.Reconcilable        = (*AWSS3Source)(nil)
-	_ v1alpha1.AdapterConfigurable = (*AWSS3Source)(nil)
-	_ v1alpha1.EventSource         = (*AWSS3Source)(nil)
-	_ v1alpha1.EventSender         = (*AWSS3Source)(nil)
+	_ v1alpha1.Reconcilable           = (*AWSS3Source)(nil)
+	_ v1alpha1.AdapterConfigurable    = (*AWSS3Source)(nil)
+	_ v1alpha1.ServiceAccountProvider = (*AWSS3Source)(nil)
+	_ v1alpha1.EventSource            = (*AWSS3Source)(nil)
+	_ v1alpha1.EventSender            = (*AWSS3Source)(nil)
 )
 
 // AWSS3SourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -73,12 +73,12 @@ func (s *AWSSQSSource) AsEventSource() string {
 	return s.Spec.ARN.String()
 }
 
-// WantsOwnServiceAccount implements serviceAccountProvider.
+// WantsOwnServiceAccount implements ServiceAccountProvider.
 func (s *AWSSQSSource) WantsOwnServiceAccount() bool {
 	return s.Spec.Auth.EksIAMRole != nil
 }
 
-// ServiceAccountOptions implements serviceAccountProvider.
+// ServiceAccountOptions implements ServiceAccountProvider.
 func (s *AWSSQSSource) ServiceAccountOptions() []resource.ServiceAccountOption {
 	var saOpts []resource.ServiceAccountOption
 


### PR DESCRIPTION
Requested by a user in https://github.com/triggermesh/triggermesh/issues/244#issuecomment-1108796311

Same as #248, but for the Amazon S3 source.

How to use:

```yaml
apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSS3Source
metadata:
  name: sample
spec:
  arn: arn:aws:s3:::triggermeshtest

  auth:
    iamRole: arn:aws:iam::123456789012:role/foo

  sink:
    ref:
      apiVersion: v1
      kind: Service
      name: event-display
```