### PR TITLE
Enable selection of message processor in SQS source

### DIFF
--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -125,6 +125,11 @@ spec:
                       For more details, please refer to the Amazon SQS Developer Guide at
                       https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html.
                     type: string
+              messageProcessor:
+                description: Name of the message processor to use for converting SQS messages to CloudEvents. Supported
+                  values are "default" and "s3".
+                type: string
+                enum: [default, s3]
               auth:
                 description: Authentication method to interact with the Amazon SQS API.
                 type: object

--- a/pkg/apis/sources/v1alpha1/awssqs_types.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_types.go
@@ -58,6 +58,11 @@ type AWSSQSSourceSpec struct {
 	// +optional
 	ReceiveOptions *AWSSQSSourceReceiveOptions `json:"receiveOptions,omitempty"`
 
+	// Name of the message processor to use for converting SQS messages to CloudEvents.
+	// Supported values are "default" and "s3".
+	// +optional
+	MessageProcessor *string `json:"messageProcessor,omitempty"`
+
 	// Authentication method to interact with the Amazon SQS API.
 	Auth AWSAuth `json:"auth"`
 

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -1230,6 +1230,11 @@ func (in *AWSSQSSourceSpec) DeepCopyInto(out *AWSSQSSourceSpec) {
 		*out = new(AWSSQSSourceReceiveOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MessageProcessor != nil {
+		in, out := &in.MessageProcessor, &out.MessageProcessor
+		*out = new(string)
+		**out = **in
+	}
 	in.Auth.DeepCopyInto(&out.Auth)
 	if in.Endpoint != nil {
 		in, out := &in.Endpoint, &out.Endpoint


### PR DESCRIPTION
Allows manually selecting the event processor to use inside the SQS receive adapter.

How to use:

```yaml
apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSSQSSource
metadata:
  name: sample1
spec:
  arn: arn:aws:sqs:eu-central-1:123456789012:foo

  messageProcessor: s3

  sink:
    ref:
      apiVersion: v1
      kind: Service
      name: event-display
```

### Context

Both the event sources for Amazon S3 and Amazon SQS use the same underlying receive adapter.

One of the main differences between the two — besides the fact that the S3 source can reconcile its own SQS queue — is that the S3 source sets the value of the `SQS_MESSAGE_PROCESSOR` environment variable to `"s3"`, thus enabling [S3-aware CloudEvents attributes](https://github.com/triggermesh/aws-event-sources/pull/267).

### Rationale

A user on Slack brought a use-case to my attention where they have a lot of S3 buckets, but each bucket should send notifications to the _same SQS queue_. The destination of events may differ based on the source S3 bucket.

This is a valid use-case — since all messages adhere to the same S3 schema — and one that is already _partially_ achievable with our S3 source by configuring each instance to send to the same SQS queue using the `spec.destination.sqs.queueARN` attribute.

However, this setup isn't optimal cost-wise because we spawn one SQS consumer _per source_ (per bucket), but only one would be enough in this specific case. The cost of reading messages from that single queue would be unnecessarily multiplied by the number of consumers.
Also, I insisted on _partially_ because adding consumers to a SQS queue doesn't result in messages being fanned-out to each consumer, unlike the topic/subscription model of Amazon SNS, for example (#32). So if the `spec.sink` attribute is different for each bucket, SQS falls short to start with.

By allowing users to set `spec.messageProcessor: s3`, we allow them to implement the use-case above with a single `AWSSQSSource` instance, providing that S3 buckets are configured outside of TriggerMesh.