### PR TITLE
Fix wrong env var name for Transformation adapter

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -173,7 +173,7 @@ spec:
           value: ko://github.com/triggermesh/triggermesh/cmd/jqtransformation-adapter
         - name: SYNCHRONIZER_IMAGE
           value: ko://github.com/triggermesh/triggermesh/cmd/synchronizer-adapter
-        - name: TRANSFORMER_IMAGE
+        - name: TRANSFORMATION_IMAGE
           value: ko://github.com/triggermesh/triggermesh/cmd/transformation-adapter
         - name: XMLTOJSONTRANSFORMATION_IMAGE
           value: ko://github.com/triggermesh/triggermesh/cmd/xmltojsontransformation-adapter


### PR DESCRIPTION
The name of the environment variable containing the adapter's container image is `<KIND>_ADAPTER`.