### PR TITLE
Label IBM MQ source metrics with name and namespace

### DIFF
--- a/pkg/apis/sources/register.go
+++ b/pkg/apis/sources/register.go
@@ -176,6 +176,12 @@ var (
 		Resource: "httppollersources",
 	}
 
+	// IBMMQSourceResource respresents an event source for IBM MQ.
+	IBMMQSourceResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "ibmmqsources",
+	}
+
 	// OCIMetricsSourceResource represents an event source for OCI Metrics.
 	OCIMetricsSourceResource = schema.GroupResource{
 		Group:    GroupName,

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -31,6 +31,7 @@ import (
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/triggermesh/triggermesh/pkg/apis/sources"
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/ibmmqsource/mq"
 )
@@ -41,6 +42,8 @@ type ibmmqsourceAdapter struct {
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
 
+	mt *pkgadapter.MetricTag
+
 	mqEnvs *SourceEnvAccessor
 }
 
@@ -49,9 +52,16 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 	env := envAcc.(*SourceEnvAccessor)
 	logger := logging.FromContext(ctx)
 
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: sources.IBMMQSourceResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
 	return &ibmmqsourceAdapter{
 		ceClient: ceClient,
 		logger:   logger,
+		mt:       mt,
 		mqEnvs:   env,
 	}
 }
@@ -72,7 +82,9 @@ func (a *ibmmqsourceAdapter) Start(ctx context.Context) error {
 	}
 	defer queue.Close()
 
-	err = queue.RegisterCallback(a.eventHandler(), a.mqEnvs.Delivery, a.logger)
+	ctx = pkgadapter.ContextWithMetricTag(ctx, a.mt)
+
+	err = queue.RegisterCallback(a.eventHandler(ctx), a.mqEnvs.Delivery, a.logger)
 	if err != nil {
 		return fmt.Errorf("failed to register callback: %w", err)
 	}
@@ -88,7 +100,7 @@ func (a *ibmmqsourceAdapter) Start(ctx context.Context) error {
 	return nil
 }
 
-func (a *ibmmqsourceAdapter) eventHandler() mq.Handler {
+func (a *ibmmqsourceAdapter) eventHandler(ctx context.Context) mq.Handler {
 	return func(data []byte, correlID string) error {
 		event := cloudevents.NewEvent(cloudevents.VersionV1)
 		event.SetType(v1alpha1.IBMMQSourceEventType)
@@ -104,7 +116,7 @@ func (a *ibmmqsourceAdapter) eventHandler() mq.Handler {
 			a.logger.Errorf("Can't set Cloudevent data: %v", err)
 			return err
 		}
-		if res := a.ceClient.Send(context.Background(), event); cloudevents.IsUndelivered(res) {
+		if res := a.ceClient.Send(ctx, event); cloudevents.IsUndelivered(res) {
 			a.logger.Errorf("Cloudevent is not delivered: %v\n", res)
 			return res
 		}

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -89,6 +89,8 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVars(makeAppEnv(typedSrc)...),
+		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
+		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		keystoreMount,


### PR DESCRIPTION
Currently, all `ibmmqsource_event_count` metrics are labeled with `{namespace_name="unknown", name="unknown"}`.
This change ensures that the correct namespace and name are propagated instead.