### PR TITLE
Label Knative metrics with name and namespace

### DIFF
--- a/pkg/apis/flow/register.go
+++ b/pkg/apis/flow/register.go
@@ -24,9 +24,39 @@ const (
 )
 
 var (
+	// DataWeaveTransformationResource respresents a DataWeave transformation.
+	DataWeaveTransformationResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "dataweavetransformations",
+	}
+
+	// JQTransformationResource respresents a JQ transformation.
+	JQTransformationResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "jqtransformations",
+	}
+
+	// SynchronizerResource respresents a Synchronizer.
+	SynchronizerResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "synchronizers",
+	}
+
 	// TransformationResource respresents a Bumblebee transformation.
 	TransformationResource = schema.GroupResource{
 		Group:    GroupName,
 		Resource: "transformations",
+	}
+
+	// XMLToJSONTransformationResource respresents a XML to JSON transformation.
+	XMLToJSONTransformationResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "xmltojsontansformations",
+	}
+
+	// XSLTTransformationResource respresents a XSLT transformation.
+	XSLTTransformationResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "xslttransformations",
 	}
 )

--- a/pkg/apis/sources/register.go
+++ b/pkg/apis/sources/register.go
@@ -115,10 +115,23 @@ var (
 		Resource: "azureeventhubsources",
 	}
 
+	// AzureIOTHubSourceResource respresents an event source for Azure IOT Hub.
+	AzureIOTHubSourceResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "azureiothubsources",
+	}
+
 	// AzureQueueStorageSourceResource respresents an event source for Azure Queue Storage.
 	AzureQueueStorageSourceResource = schema.GroupResource{
 		Group:    GroupName,
 		Resource: "azurequeuestoragesources",
+	}
+
+	// AzureServiceBusQueueSourceResource respresents an event source for
+	// Azure Service Bus Queues.
+	AzureServiceBusQueueSourceResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "azureservicebusqueuesources",
 	}
 
 	// AzureServiceBusTopicSourceResource respresents an event source for
@@ -126,6 +139,12 @@ var (
 	AzureServiceBusTopicSourceResource = schema.GroupResource{
 		Group:    GroupName,
 		Resource: "azureservicebustopicsources",
+	}
+
+	// CloudEventsSourceResource respresents an event source for CloudEvents.
+	CloudEventsSourceResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "cloudeventssources",
 	}
 
 	// GoogleCloudAuditLogsSourceResource respresents an event source for Google

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -92,6 +92,11 @@ func NewAdapterDeployment(rcl v1alpha1.Reconcilable, sinkURI *apis.URL, opts ...
 		append(commonAdapterDeploymentOptions(rcl), append([]resource.ObjectOption{
 			resource.Controller(rcl),
 
+			// Used to label Prometheus metrics with the component
+			// instance's namespace and name
+			resource.EnvVar(EnvNamespace, rclNs),
+			resource.EnvVar(EnvName, rclName),
+
 			resource.Label(appInstanceLabel, rclName),
 			resource.Selector(appInstanceLabel, rclName),
 
@@ -108,8 +113,10 @@ func NewMTAdapterDeployment(rcl v1alpha1.Reconcilable, opts ...resource.ObjectOp
 
 	return resource.NewDeployment(rclNs, MTAdapterObjectName(rcl),
 		append(commonAdapterDeploymentOptions(rcl), append([]resource.ObjectOption{
+			// makes Informers namespace-scoped in TriggerMesh's adapter shared Main
 			resource.EnvVar(EnvNamespace, rclNs),
-			resource.EnvVar(system.NamespaceEnvKey, rclNs), // required to enable HA
+			// required to enable Knative's HA
+			resource.EnvVar(system.NamespaceEnvKey, rclNs),
 		}, opts...)...)...,
 	)
 }
@@ -171,6 +178,8 @@ func NewAdapterKnService(rcl v1alpha1.Reconcilable, sinkURI *apis.URL, opts ...r
 		append(commonAdapterKnServiceOptions(rcl), append([]resource.ObjectOption{
 			resource.Controller(rcl),
 
+			// Used to label Prometheus metrics with the component
+			// instance's namespace and name
 			resource.EnvVar(EnvNamespace, rclNs),
 			resource.EnvVar(EnvName, rclName),
 
@@ -190,8 +199,10 @@ func NewMTAdapterKnService(rcl v1alpha1.Reconcilable, opts ...resource.ObjectOpt
 
 	return resource.NewKnService(rclNs, MTAdapterObjectName(rcl),
 		append(commonAdapterKnServiceOptions(rcl), append([]resource.ObjectOption{
+			// makes Informers namespace-scoped in TriggerMesh's adapter shared Main
 			resource.EnvVar(EnvNamespace, rclNs),
-			resource.EnvVar(system.NamespaceEnvKey, rclNs), // required to enable HA
+			// required to enable Knative's HA
+			resource.EnvVar(system.NamespaceEnvKey, rclNs),
 		}, opts...)...)...,
 	)
 }

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awscloudwatchlogssource
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -95,7 +96,9 @@ func TestAdapterCollectLogsBaseCase(t *testing.T) {
 		pollingInterval: duration,
 	}
 
-	a.CollectLogs(nil, now)
+	ctx := context.Background()
+
+	a.CollectLogs(ctx, nil, now)
 	events := ceClient.Sent()
 	assert.Len(t, events, 0)
 }
@@ -144,7 +147,9 @@ func TestAdapterCollectLogs(t *testing.T) {
 		pollingInterval: duration,
 	}
 
-	a.CollectLogs(nil, now)
+	ctx := context.Background()
+
+	a.CollectLogs(ctx, nil, now)
 	events := ceClient.Sent()
 	assert.Len(t, events, 1)
 

--- a/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
+++ b/pkg/sources/adapter/awscloudwatchsource/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awscloudwatchsource
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -162,7 +163,9 @@ func TestCollectMetrics(t *testing.T) {
 		NextToken: nil,
 	}
 
-	a.CollectMetrics(nil, time.Now())
+	ctx := context.Background()
+
+	a.CollectMetrics(ctx, nil, time.Now())
 
 	events := ceClient.Sent()
 	assert.Len(t, events, 1)
@@ -208,7 +211,9 @@ func TestSendMetricEvent(t *testing.T) {
 		NextToken: nil,
 	}
 
-	err := a.SendMetricEvent(&metricOutput)
+	ctx := context.Background()
+
+	err := a.SendMetricEvent(ctx, &metricOutput)
 	assert.NoError(t, err)
 	events := ceClient.Sent()
 	assert.Len(t, events, 1)
@@ -243,7 +248,9 @@ func TestSendMessageEvent(t *testing.T) {
 		NextToken: nil,
 	}
 
-	err := a.SendMetricEvent(&metricOutput)
+	ctx := context.Background()
+
+	err := a.SendMetricEvent(ctx, &metricOutput)
 	assert.NoError(t, err)
 	events := ceClient.Sent()
 	assert.Len(t, events, 1)

--- a/pkg/sources/adapter/awscodecommitsource/adapter_test.go
+++ b/pkg/sources/adapter/awscodecommitsource/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awscodecommitsource
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -73,7 +74,9 @@ func TestSendPREvent(t *testing.T) {
 	pr := &codecommit.PullRequest{}
 	pr.SetPullRequestId("12345")
 
-	err := a.sendEvent(pr)
+	ctx := context.Background()
+
+	err := a.sendEvent(ctx, pr)
 	assert.NoError(t, err)
 
 	gotEvents := ceClient.Sent()
@@ -96,7 +99,9 @@ func TestSendPushEvent(t *testing.T) {
 	commit := &codecommit.Commit{}
 	commit.SetCommitId("12345")
 
-	err := a.sendEvent(commit)
+	ctx := context.Background()
+
+	err := a.sendEvent(ctx, commit)
 	assert.NoError(t, err)
 
 	gotEvents := ceClient.Sent()
@@ -170,7 +175,9 @@ func TestProcessCommits(t *testing.T) {
 			ceClient: adaptertest.NewTestClient(),
 		}
 
-		err := a.processCommits()
+		ctx := context.Background()
+
+		err := a.processCommits(ctx)
 		if tt.ErrMsg == nil {
 			assert.NoError(t, err)
 		} else {

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awscognitoidentitysource
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -157,7 +158,9 @@ func TestSendCognitoEvent(t *testing.T) {
 	}
 	records := []*cognitosync.Record{}
 
-	err := a.sendCognitoEvent(&dataset, records)
+	ctx := context.Background()
+
+	err := a.sendCognitoEvent(ctx, &dataset, records)
 	assert.NoError(t, err)
 
 	gotEvents := ceClient.Sent()

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter_test.go
@@ -115,7 +115,9 @@ func TestSendCognitoEvent(t *testing.T) {
 		cgnIdentityClient: mockedCognitoUserPoolClient{},
 	}
 
-	err := a.sendCognitoEvent(&user)
+	ctx := context.Background()
+
+	err := a.sendCognitoEvent(ctx, &user)
 	assert.NoError(t, err)
 
 	events := ceClient.Sent()

--- a/pkg/sources/adapter/awskinesissource/adapter_test.go
+++ b/pkg/sources/adapter/awskinesissource/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awskinesissource
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -156,7 +157,9 @@ func TestSendCloudevent(t *testing.T) {
 				PartitionKey:   aws.String("key"),
 			}
 
-			err := a.sendKinesisRecord(&record)
+			ctx := context.Background()
+
+			err := a.sendKinesisRecord(ctx, &record)
 			assert.NoError(t, err)
 
 			gotEvents := ceClient.Sent()

--- a/pkg/sources/adapter/cloudeventssource/cloudevents.go
+++ b/pkg/sources/adapter/cloudeventssource/cloudevents.go
@@ -40,10 +40,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol"
-	"go.uber.org/zap"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 
 	"github.com/triggermesh/triggermesh/pkg/adapter/fs"
 )
@@ -55,6 +58,7 @@ type cloudEventsHandler struct {
 	ceServer cloudevents.Client
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
+	mt       *pkgadapter.MetricTag
 }
 
 // Start implements adapter.Adapter.

--- a/pkg/sources/adapter/httppollersource/adapter.go
+++ b/pkg/sources/adapter/httppollersource/adapter.go
@@ -26,13 +26,23 @@ import (
 	"go.uber.org/zap"
 
 	"knative.dev/eventing/pkg/adapter/v2"
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/sources"
 )
 
 // NewAdapter satisfies pkgadapter.AdapterConstructor.
-func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
-	env := aEnv.(*envAccessor)
+func NewAdapter(ctx context.Context, envAcc adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: sources.HTTPPollerSourceResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	env := envAcc.(*envAccessor)
 
 	t := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: env.SkipVerify},
@@ -74,5 +84,6 @@ func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cl
 
 		ceClient: ceClient,
 		logger:   logging.FromContext(ctx),
+		mt:       mt,
 	}
 }

--- a/pkg/sources/adapter/httppollersource/httppoller_test.go
+++ b/pkg/sources/adapter/httppollersource/httppoller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package httppollersource
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -25,9 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cetest "github.com/cloudevents/sdk-go/v2/client/test"
-	"github.com/stretchr/testify/assert"
+
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
@@ -159,7 +162,9 @@ func TestHTTPPollerRequests(t *testing.T) {
 				logger:      logtesting.TestLogger(t),
 			}
 
-			p.dispatch()
+			ctx := context.Background()
+
+			p.dispatch(ctx)
 
 			select {
 			case event := <-chEvent:

--- a/pkg/sources/adapter/ibmmqsource/adapter.go
+++ b/pkg/sources/adapter/ibmmqsource/adapter.go
@@ -41,15 +41,13 @@ var _ pkgadapter.Adapter = (*ibmmqsourceAdapter)(nil)
 type ibmmqsourceAdapter struct {
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
-
-	mt *pkgadapter.MetricTag
+	mt       *pkgadapter.MetricTag
 
 	mqEnvs *SourceEnvAccessor
 }
 
 // NewAdapter returns adapter implementation
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*SourceEnvAccessor)
 	logger := logging.FromContext(ctx)
 
 	mt := &pkgadapter.MetricTag{
@@ -57,6 +55,8 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		Namespace:     envAcc.GetNamespace(),
 		Name:          envAcc.GetName(),
 	}
+
+	env := envAcc.(*SourceEnvAccessor)
 
 	return &ibmmqsourceAdapter{
 		ceClient: ceClient,

--- a/pkg/sources/adapter/ocimetricssource/ocimetrics.go
+++ b/pkg/sources/adapter/ocimetricssource/ocimetrics.go
@@ -28,7 +28,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
-	"knative.dev/eventing/pkg/adapter/v2"
 )
 
 // OCIMetricsAPIHandler handles OCI Metrics.
@@ -50,9 +49,7 @@ type ociMetricsAPIHandler struct {
 }
 
 // NewOCIMetricsAPIHandler returns a new instance of OCIMetricsAPIHandler.
-func NewOCIMetricsAPIHandler(ceClient cloudevents.Client, aEnv adapter.EnvConfigAccessor, eventsource string, logger *zap.SugaredLogger) OCIMetricsAPIHandler {
-	env := aEnv.(*envAccessor)
-
+func NewOCIMetricsAPIHandler(ceClient cloudevents.Client, env *envAccessor, eventsource string, logger *zap.SugaredLogger) OCIMetricsAPIHandler {
 	interval, err := time.ParseDuration(env.PollingFrequency)
 	if err != nil {
 		logger.Panicw("cannot parse polling frequency", zap.Error(err))
@@ -163,7 +160,7 @@ func (o *ociMetricsAPIHandler) collectMetrics(entry v1alpha1.OCIMetrics, startTi
 		o.logger.Errorw("unable to package metrics", zap.Error(err))
 	}
 
-	if result := o.ceClient.Send(context.Background(), *event); !cloudevents.IsACK(result) {
+	if result := o.ceClient.Send(o.context, *event); !cloudevents.IsACK(result) {
 		o.logger.Errorw("unable to send metrics", zap.Error(err))
 	}
 }

--- a/pkg/sources/adapter/slacksource/slack_test.go
+++ b/pkg/sources/adapter/slacksource/slack_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package slacksource
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,9 +25,11 @@ import (
 	"testing"
 	"time"
 
-	cloudeventst "github.com/cloudevents/sdk-go/v2/client/test"
 	"github.com/stretchr/testify/assert"
+
 	zapt "go.uber.org/zap/zaptest"
+
+	cloudeventst "github.com/cloudevents/sdk-go/v2/client/test"
 )
 
 func TestSlackEvent(t *testing.T) {
@@ -260,8 +263,11 @@ func TestSlackEvent(t *testing.T) {
 				req.Header.Add(k, v)
 			}
 
+			ctx := context.Background()
+
+			th := http.HandlerFunc(handler.handleAll(ctx))
+
 			rr := httptest.NewRecorder()
-			th := http.HandlerFunc(handler.handleAll)
 
 			th.ServeHTTP(rr, req)
 

--- a/pkg/sources/adapter/webhooksource/adapter.go
+++ b/pkg/sources/adapter/webhooksource/adapter.go
@@ -21,13 +21,21 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
-	"knative.dev/eventing/pkg/adapter/v2"
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/sources"
 )
 
 // NewAdapter satisfies pkgadapter.AdapterConstructor.
-func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
-	env := aEnv.(*envAccessor)
+func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: sources.WebhookSourceResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	env := envAcc.(*envAccessor)
 
 	return &webhookHandler{
 		eventType:       env.EventType,
@@ -38,7 +46,8 @@ func NewAdapter(ctx context.Context, aEnv adapter.EnvConfigAccessor, ceClient cl
 
 		ceClient: ceClient,
 		logger:   logging.FromContext(ctx),
+		mt:       mt,
 	}
 }
 
-var _ adapter.Adapter = (*webhookHandler)(nil)
+var _ pkgadapter.Adapter = (*webhookHandler)(nil)

--- a/pkg/sources/adapter/webhooksource/env.go
+++ b/pkg/sources/adapter/webhooksource/env.go
@@ -17,16 +17,16 @@ limitations under the License.
 package webhooksource
 
 import (
-	"knative.dev/eventing/pkg/adapter/v2"
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 )
 
 // NewEnvConfig satisfies pkgadapter.EnvConfigConstructor.
-func NewEnvConfig() adapter.EnvConfigAccessor {
+func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 	return &envAccessor{}
 }
 
 type envAccessor struct {
-	adapter.EnvConfig
+	pkgadapter.EnvConfig
 
 	EventType         string `envconfig:"WEBHOOK_EVENT_TYPE" required:"true"`
 	EventSource       string `envconfig:"WEBHOOK_EVENT_SOURCE" required:"true"`

--- a/pkg/sources/adapter/webhooksource/webhook_test.go
+++ b/pkg/sources/adapter/webhooksource/webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhooksource
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -25,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	zapt "go.uber.org/zap/zaptest"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cloudeventst "github.com/cloudevents/sdk-go/v2/client/test"
-	"github.com/stretchr/testify/assert"
-	zapt "go.uber.org/zap/zaptest"
 )
 
 const (
@@ -134,8 +137,11 @@ func TestWebhookEvent(t *testing.T) {
 				req.Header.Add(k, v)
 			}
 
+			ctx := context.Background()
+
+			th := http.HandlerFunc(handler.handleAll(ctx))
+
 			rr := httptest.NewRecorder()
-			th := http.HandlerFunc(handler.handleAll)
 
 			th.ServeHTTP(rr, req)
 

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -76,8 +76,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.EnvVar(envQueries, queries),
 		resource.EnvVar(envPollingInterval, pollingInterval.String()),
 		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -60,8 +60,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 		resource.EnvVar(common.EnvARN, queueARN.String()),
 		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVar(envMessageProcessor, "s3"),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -61,8 +61,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
 		resource.EnvVars(reconciler.MakeAWSEndpointEnvVars(typedSrc.Spec.Endpoint)...),
 		resource.EnvVars(optEnvs...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),

--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -51,8 +51,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 		resource.EnvVars(iotHubEnvs...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -54,8 +54,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.EnvVar("AZURE_ACCOUNT_NAME", typedSrc.Spec.AccountName),
 		resource.EnvVar("AZURE_QUEUE_NAME", typedSrc.Spec.QueueName),
 		resource.EnvVars(storageQueueEnvs...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }

--- a/pkg/sources/reconciler/cloudeventssource/adapter.go
+++ b/pkg/sources/reconciler/cloudeventssource/adapter.go
@@ -65,8 +65,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.Image(r.adapterCfg.Image),
 
 		resource.VisibilityPublic,
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
+
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 		resource.EnvVars(makeAppEnv(typedSrc)...),

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -89,8 +89,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.Image(r.adapterCfg.Image),
 
 		resource.EnvVars(makeAppEnv(typedSrc)...),
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		keystoreMount,

--- a/pkg/sources/reconciler/ocimetricssource/adapter.go
+++ b/pkg/sources/reconciler/ocimetricssource/adapter.go
@@ -78,14 +78,6 @@ func makeOCIMetricsEnvs(src *v1alpha1.OCIMetricsSource) []corev1.EnvVar {
 
 	ociEnvs := []corev1.EnvVar{
 		{
-			Name:  common.EnvNamespace,
-			Value: src.GetNamespace(),
-		},
-		{
-			Name:  common.EnvName,
-			Value: src.GetName(),
-		},
-		{
 			Name:  userOCID,
 			Value: src.Spec.User,
 		},

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -45,8 +45,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 		resource.VisibilityPublic,
 
-		resource.EnvVar(common.EnvNamespace, src.GetNamespace()),
-		resource.EnvVar(common.EnvName, src.GetName()),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	)
 }


### PR DESCRIPTION
Closes #803

Currently, all `<component>_event_count` metrics are labeled with `{namespace_name="unknown", name="unknown"}`.
This change ensures that the correct namespace and name are propagated instead.

Before:
![image](https://user-images.githubusercontent.com/3299086/165549487-15d8b249-cfcc-4eae-9ed3-6456d44433f9.png)

After:
![image](https://user-images.githubusercontent.com/3299086/165549640-3f5699c8-cc0b-413d-bb3d-bf6ca9207b9f.png)
