### PR TITLE
Add Volumes and VolumeMounts resource helpers

### DIFF
--- a/pkg/reconciler/resource/container.go
+++ b/pkg/reconciler/resource/container.go
@@ -270,6 +270,22 @@ func TerminationErrorToLogs(object interface{}) {
 	*tmp = corev1.TerminationMessageFallbackToLogsOnError
 }
 
+// VolumeMounts attaches VolumeMounts to a Container.
+func VolumeMounts(vms ...corev1.VolumeMount) ObjectOption {
+	return func(object interface{}) {
+		var volMounts *[]corev1.VolumeMount
+
+		switch o := object.(type) {
+		case *corev1.Container:
+			volMounts = &o.VolumeMounts
+		case *appsv1.Deployment, *servingv1.Service:
+			volMounts = &firstContainer(o).VolumeMounts
+		}
+
+		*volMounts = append(*volMounts, vms...)
+	}
+}
+
 // firstContainer returns a PodSpecable's first Container definition.
 // A new empty Container is injected if the PodSpecable does not contain any.
 func firstContainer(object interface{}) *corev1.Container {

--- a/pkg/reconciler/resource/container_test.go
+++ b/pkg/reconciler/resource/container_test.go
@@ -29,6 +29,11 @@ import (
 func TestNewContainer(t *testing.T) {
 	cpuRes, memRes := resource.MustParse("250m"), resource.MustParse("100Mi")
 
+	vm := corev1.VolumeMount{
+		Name:      "some-volume",
+		MountPath: "/myvol",
+	}
+
 	cont := NewContainer(tName,
 		Port("h2c", 8080),
 		Image(tImg),
@@ -43,6 +48,7 @@ func TestNewContainer(t *testing.T) {
 		Requests(&cpuRes, &memRes),
 		Limits(&cpuRes, nil),
 		TerminationErrorToLogs,
+		VolumeMounts(vm),
 	)
 
 	expectCont := &corev1.Container{
@@ -107,6 +113,12 @@ func TestNewContainer(t *testing.T) {
 			},
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "some-volume",
+				MountPath: "/myvol",
+			},
+		},
 	}
 
 	if d := cmp.Diff(expectCont, cont); d != "" {

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -31,6 +31,24 @@ import (
 func TestNewServiceWithDefaultContainer(t *testing.T) {
 	cpuRes, memRes := resource.MustParse("250m"), resource.MustParse("100Mi")
 
+	v := corev1.Volume{
+		Name: "some-volume",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "some-secret",
+				Items: []corev1.KeyToPath{{
+					Key:  "someKey",
+					Path: "someFile",
+				}},
+			},
+		},
+	}
+
+	vm := corev1.VolumeMount{
+		Name:      "some-volume",
+		MountPath: "/myvol",
+	}
+
 	ksvc := NewKnService(tNs, tName,
 		PodLabel("test.podlabel/2", "val2"),
 		Port("health", 8081),
@@ -51,6 +69,8 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		SecretMount("test-vol1", "/path/to/file.ext", "test-secret", "someKey"),
 		ConfigMapMount("test-vol2", "/path/to/file.ext", "test-cmap", "someKey"),
 		VisibilityClusterLocal,
+		Volumes(v),
+		VolumeMounts(vm),
 	)
 
 	expectKsvc := &servingv1.Service{
@@ -136,6 +156,10 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 										SubPath:   "file.ext",
 										ReadOnly:  true,
 									},
+									{
+										Name:      "some-volume",
+										MountPath: "/myvol",
+									},
 								},
 							}},
 							Volumes: []corev1.Volume{
@@ -161,6 +185,18 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 											Items: []corev1.KeyToPath{{
 												Key:  "someKey",
 												Path: "file.ext",
+											}},
+										},
+									},
+								},
+								{
+									Name: "some-volume",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "some-secret",
+											Items: []corev1.KeyToPath{{
+												Key:  "someKey",
+												Path: "someFile",
 											}},
 										},
 									},

--- a/pkg/reconciler/resource/podspecable.go
+++ b/pkg/reconciler/resource/podspecable.go
@@ -88,6 +88,22 @@ func Toleration(t corev1.Toleration) ObjectOption {
 	}
 }
 
+// Volumes attaches Volumes to a PodSpecable.
+func Volumes(vs ...corev1.Volume) ObjectOption {
+	return func(object interface{}) {
+		var vols *[]corev1.Volume
+
+		switch o := object.(type) {
+		case *appsv1.Deployment:
+			vols = &o.Spec.Template.Spec.Volumes
+		case *servingv1.Service:
+			vols = &o.Spec.Template.Spec.Volumes
+		}
+
+		*vols = append(*vols, vs...)
+	}
+}
+
 // SecretMount adds a Secret volume and a corresponding mount to a PodSpecable.
 func SecretMount(name, target, secretName, secretKey string) ObjectOption {
 	return func(object interface{}) {

--- a/pkg/sources/reconciler/cloudeventssource/adapter.go
+++ b/pkg/sources/reconciler/cloudeventssource/adapter.go
@@ -59,38 +59,35 @@ var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedSrc := src.(*v1alpha1.CloudEventsSource)
 
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
-
-	options := []resource.ObjectOption{
-		resource.Image(r.adapterCfg.Image),
-
-		resource.VisibilityPublic,
-
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
-		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
-		resource.EnvVars(makeAppEnv(typedSrc)...),
-	}
+	var authVolumes []corev1.Volume
+	var authVolumeMounts []corev1.VolumeMount
+	var authEnvs []corev1.EnvVar
 
 	if typedSrc.Spec.Credentials != nil {
 		// For each BasicAuth credentials a secret is mounted and a tuple
 		// key/mounted-file pair is added to the environment variable.
 		kvs := []KeyMountedValue{}
 
-		secretArrayNamePrefix := "basicauths"
-		secretBasePath := "/opt"
-		secretFileName := "cesource"
+		const (
+			secretArrayNamePrefix = "basicauths"
+			secretBasePath        = "/opt"
+			secretFileName        = "cesource"
+		)
 
 		for i, ba := range typedSrc.Spec.Credentials.BasicAuths {
 			if ba.Password.ValueFromSecret != nil {
 				secretName := fmt.Sprintf("%s%d", secretArrayNamePrefix, i)
 				secretPath := filepath.Join(secretBasePath, secretName)
 
-				options = append(options, secretMountAtPath(
+				v, vm := secretVolumeAndMountAtPath(
 					secretName,
 					secretPath,
 					secretFileName,
 					ba.Password.ValueFromSecret.Name,
-					ba.Password.ValueFromSecret.Key))
+					ba.Password.ValueFromSecret.Key,
+				)
+				authVolumes = append(authVolumes, v)
+				authVolumeMounts = append(authVolumeMounts, vm)
 
 				kvs = append(kvs, KeyMountedValue{
 					Key:              ba.Username,
@@ -99,16 +96,34 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 			}
 		}
 
-		if len(kvs) != 0 {
+		if len(kvs) > 0 {
 			s, err := json.Marshal(kvs)
 			if err != nil {
 				return nil, fmt.Errorf("serializing keyMountedValues to JSON: %w", err)
 			}
-			options = append(options, resource.EnvVar(envCloudEventsBasicAuthCredentials, string(s)))
+
+			authEnvs = append(authEnvs, corev1.EnvVar{
+				Name:  envCloudEventsBasicAuthCredentials,
+				Value: string(s),
+			})
 		}
 	}
 
-	return common.NewAdapterKnService(src, sinkURI, options...), nil
+	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
+
+	return common.NewAdapterKnService(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.VisibilityPublic,
+
+		resource.Volumes(authVolumes...),
+		resource.VolumeMounts(authVolumeMounts...),
+		resource.EnvVars(authEnvs...),
+
+		resource.EnvVars(makeAppEnv(typedSrc)...),
+		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	), nil
 }
 
 type KeyMountedValue struct {
@@ -149,41 +164,27 @@ func makeAppEnv(o *v1alpha1.CloudEventsSource) []corev1.EnvVar {
 	return envs
 }
 
-// secretMountAtPath returns a build option for a service that adds a
-// secret based volume and mount a key at a path.
-func secretMountAtPath(name, mountPath, mountFile, secretName, secretKey string) resource.ObjectOption {
-	return func(object interface{}) {
-		ksvc, ok := object.(*servingv1.Service)
-		if !ok {
-			return
-		}
-
-		ksvc.Spec.Template.Spec.Volumes = append(
-			ksvc.Spec.Template.Spec.Volumes,
-			corev1.Volume{
-				Name: name,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: secretName,
-						Items: []corev1.KeyToPath{{
-							Key:  secretKey,
-							Path: mountFile,
-						}},
-					},
-				},
-			})
-
-		if len(ksvc.Spec.Template.Spec.Containers) == 0 {
-			ksvc.Spec.Template.Spec.Containers = make([]corev1.Container, 1)
-		}
-
-		ksvc.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-			ksvc.Spec.Template.Spec.Containers[0].VolumeMounts,
-			corev1.VolumeMount{
-				Name:      name,
-				ReadOnly:  true,
-				MountPath: mountPath,
+// secretVolumeAndMountAtPath returns a Secret-based volume and corresponding
+// mount at the given path.
+func secretVolumeAndMountAtPath(name, mountPath, mountFile, secretName, secretKey string) (corev1.Volume, corev1.VolumeMount) {
+	v := corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+				Items: []corev1.KeyToPath{{
+					Key:  secretKey,
+					Path: mountFile,
+				}},
 			},
-		)
+		},
 	}
+
+	vm := corev1.VolumeMount{
+		Name:      name,
+		ReadOnly:  true,
+		MountPath: mountPath,
+	}
+
+	return v, vm
 }


### PR DESCRIPTION
I like how the CloudEvents source has its own helper for applying volumes and mounts.
I think we can decouple that approach even further by separating the creation of the structs from the code that actually applies them.

Next, I would like to apply the same change to the IBM MQ components and remove the overly complex `ConfigMapMount` and `SecretMount` helpers.