### PR TITLE
Move Volume and VolumeMount creation out of `pkg/reconciler`

### DIFF
--- a/pkg/reconciler/resource/deployment_test.go
+++ b/pkg/reconciler/resource/deployment_test.go
@@ -69,8 +69,6 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		Limits(&cpuRes, nil),
 		TerminationErrorToLogs,
 		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
-		SecretMount("test-vol1", "/path/to/file.ext", "test-secret", "someKey"),
-		ConfigMapMount("test-vol2", "/path/to/file.ext", "test-cmap", "someKey"),
 		Volumes(v),
 		VolumeMounts(vm),
 	)
@@ -156,65 +154,23 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 							},
 						},
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "test-vol1",
-								MountPath: "/path/to/file.ext",
-								SubPath:   "file.ext",
-								ReadOnly:  true,
-							},
-							{
-								Name:      "test-vol2",
-								MountPath: "/path/to/file.ext",
-								SubPath:   "file.ext",
-								ReadOnly:  true,
-							},
-							{
-								Name:      "some-volume",
-								MountPath: "/myvol",
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "some-volume",
+							MountPath: "/myvol",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "some-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "some-secret",
+								Items: []corev1.KeyToPath{{
+									Key:  "someKey",
+									Path: "someFile",
+								}},
 							},
 						},
 					}},
-					Volumes: []corev1.Volume{
-						{
-							Name: "test-vol1",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test-secret",
-									Items: []corev1.KeyToPath{{
-										Key:  "someKey",
-										Path: "file.ext",
-									}},
-								},
-							},
-						},
-						{
-							Name: "test-vol2",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "test-cmap",
-									},
-									Items: []corev1.KeyToPath{{
-										Key:  "someKey",
-										Path: "file.ext",
-									}},
-								},
-							},
-						},
-						{
-							Name: "some-volume",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "some-secret",
-									Items: []corev1.KeyToPath{{
-										Key:  "someKey",
-										Path: "someFile",
-									}},
-								},
-							},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -66,8 +66,6 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		Requests(&cpuRes, &memRes),
 		Limits(&cpuRes, nil),
 		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
-		SecretMount("test-vol1", "/path/to/file.ext", "test-secret", "someKey"),
-		ConfigMapMount("test-vol2", "/path/to/file.ext", "test-cmap", "someKey"),
 		VisibilityClusterLocal,
 		Volumes(v),
 		VolumeMounts(vm),
@@ -143,64 +141,22 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 										corev1.ResourceCPU: *resource.NewMilliQuantity(250, resource.DecimalSI),
 									},
 								},
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "test-vol1",
-										MountPath: "/path/to/file.ext",
-										SubPath:   "file.ext",
-										ReadOnly:  true,
-									},
-									{
-										Name:      "test-vol2",
-										MountPath: "/path/to/file.ext",
-										SubPath:   "file.ext",
-										ReadOnly:  true,
-									},
-									{
-										Name:      "some-volume",
-										MountPath: "/myvol",
-									},
-								},
+								VolumeMounts: []corev1.VolumeMount{{
+									Name:      "some-volume",
+									MountPath: "/myvol",
+								}},
 							}},
-							Volumes: []corev1.Volume{
-								{
-									Name: "test-vol1",
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-secret",
-											Items: []corev1.KeyToPath{{
-												Key:  "someKey",
-												Path: "file.ext",
-											}},
-										},
+							Volumes: []corev1.Volume{{
+								Name: "some-volume",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "some-secret",
+										Items: []corev1.KeyToPath{{
+											Key:  "someKey",
+											Path: "someFile",
+										}},
 									},
-								},
-								{
-									Name: "test-vol2",
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "test-cmap",
-											},
-											Items: []corev1.KeyToPath{{
-												Key:  "someKey",
-												Path: "file.ext",
-											}},
-										},
-									},
-								},
-								{
-									Name: "some-volume",
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName: "some-secret",
-											Items: []corev1.KeyToPath{{
-												Key:  "someKey",
-												Path: "someFile",
-											}},
-										},
-									},
-								},
+								}},
 							},
 						},
 					},

--- a/pkg/reconciler/resource/podspecable.go
+++ b/pkg/reconciler/resource/podspecable.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resource
 
 import (
-	"path/filepath"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,93 +99,5 @@ func Volumes(vs ...corev1.Volume) ObjectOption {
 		}
 
 		*vols = append(*vols, vs...)
-	}
-}
-
-// SecretMount adds a Secret volume and a corresponding mount to a PodSpecable.
-func SecretMount(name, target, secretName, secretKey string) ObjectOption {
-	return func(object interface{}) {
-		var vols *[]corev1.Volume
-
-		switch o := object.(type) {
-		case *appsv1.Deployment:
-			vols = &o.Spec.Template.Spec.Volumes
-		case *servingv1.Service:
-			vols = &o.Spec.Template.Spec.Volumes
-		}
-
-		*vols = append(*vols, corev1.Volume{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretName,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  secretKey,
-							Path: filepath.Base(target),
-						},
-					},
-				},
-			},
-		})
-
-		var volMounts *[]corev1.VolumeMount
-
-		switch o := object.(type) {
-		case *appsv1.Deployment, *servingv1.Service:
-			volMounts = &firstContainer(o).VolumeMounts
-		}
-
-		*volMounts = append(*volMounts, corev1.VolumeMount{
-			Name:      name,
-			ReadOnly:  true,
-			MountPath: target,
-			SubPath:   filepath.Base(target),
-		})
-	}
-}
-
-// ConfigMapMount adds a ConfigMap volume and a corresponding mount to a PodSpecable.
-func ConfigMapMount(name, target, cmName, cmKey string) ObjectOption {
-	return func(object interface{}) {
-		var vols *[]corev1.Volume
-
-		switch o := object.(type) {
-		case *appsv1.Deployment:
-			vols = &o.Spec.Template.Spec.Volumes
-		case *servingv1.Service:
-			vols = &o.Spec.Template.Spec.Volumes
-		}
-
-		*vols = append(*vols, corev1.Volume{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: cmName,
-					},
-					Items: []corev1.KeyToPath{
-						{
-							Key:  cmKey,
-							Path: filepath.Base(target),
-						},
-					},
-				},
-			},
-		})
-
-		var volMounts *[]corev1.VolumeMount
-
-		switch o := object.(type) {
-		case *appsv1.Deployment, *servingv1.Service:
-			volMounts = &firstContainer(o).VolumeMounts
-		}
-
-		*volMounts = append(*volMounts, corev1.VolumeMount{
-			Name:      name,
-			ReadOnly:  true,
-			MountPath: target,
-			SubPath:   filepath.Base(target),
-		})
 	}
 }

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ibmmqsource
 
 import (
+	"path/filepath"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -66,23 +67,26 @@ var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.IBMMQSource)
 
-	keystoreMount := resource.ObjectOption(func(interface{}) {})
-	passwdStashMount := resource.ObjectOption(func(interface{}) {})
+	var secretVolumes []corev1.Volume
+	var secretVolMounts []corev1.VolumeMount
 
 	if typedSrc.Spec.Auth.TLS != nil {
-		keystoreMount = resource.SecretMount(
+		keyDBVol, keyDBVolMount := secretVolumeAndMountAtPath(
 			"key-database",
 			KeystoreMountPath,
 			typedSrc.Spec.Auth.TLS.KeyRepository.KeyDatabase.ValueFromSecret.Name,
 			typedSrc.Spec.Auth.TLS.KeyRepository.KeyDatabase.ValueFromSecret.Key,
 		)
 
-		passwdStashMount = resource.SecretMount(
+		pwStashVol, pwStashVolMount := secretVolumeAndMountAtPath(
 			"db-password",
 			PasswdStashMountPath,
 			typedSrc.Spec.Auth.TLS.KeyRepository.PasswordStash.ValueFromSecret.Name,
 			typedSrc.Spec.Auth.TLS.KeyRepository.PasswordStash.ValueFromSecret.Key,
 		)
+
+		secretVolumes = append(secretVolumes, keyDBVol, pwStashVol)
+		secretVolMounts = append(secretVolMounts, keyDBVolMount, pwStashVolMount)
 	}
 
 	return common.NewAdapterDeployment(src, sinkURI,
@@ -91,8 +95,8 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.EnvVars(makeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
-		keystoreMount,
-		passwdStashMount,
+		resource.Volumes(secretVolumes...),
+		resource.VolumeMounts(secretVolMounts...),
 	), nil
 }
 
@@ -158,4 +162,32 @@ func makeAppEnv(o *v1alpha1.IBMMQSource) []corev1.EnvVar {
 	}
 
 	return env
+}
+
+// secretVolumeAndMountAtPath returns a Secret-based volume and corresponding
+// mount at the given path.
+func secretVolumeAndMountAtPath(name, mountPath, secretName, secretKey string) (corev1.Volume, corev1.VolumeMount) {
+	v := corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  secretKey,
+						Path: filepath.Base(mountPath),
+					},
+				},
+			},
+		},
+	}
+
+	vm := corev1.VolumeMount{
+		Name:      name,
+		ReadOnly:  true,
+		MountPath: mountPath,
+		SubPath:   filepath.Base(mountPath),
+	}
+
+	return v, vm
 }


### PR DESCRIPTION
Follow-up to #810.

The `ConfigMapMount` and `SecretMount` functional resource helpers we created for the IBM MQ and Function components turned out to be too opinionated to be reusable (cf.. CloudEvents source).

This PR separates the logic that creates the `corev1.Volume` and `corev1.VolumeMount` structs from the logic that applies them, moving the opinionated bits from `pkg/reconciler` to the components' implementations.