### PR TITLE
Remove `spec.public` attribute from Function

### DIFF
--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -126,9 +126,6 @@ spec:
               entrypoint:
                 description: Function name to use as an entrypoint.
                 type: string
-              public:
-                description: Should the function be publicly available.
-                type: boolean
               responseIsEvent:
                 description: Whether function responds with CE payload only or with full event.
                 type: boolean

--- a/config/samples/functions/python.yaml
+++ b/config/samples/functions/python.yaml
@@ -19,6 +19,8 @@ metadata:
 spec:
   runtime: python
   responseIsEvent: true
+  adapterOverrides:
+    public: true
   ceOverrides:
     extensions:
       type: io.triggermesh.python.sample

--- a/config/samples/functions/python.yaml
+++ b/config/samples/functions/python.yaml
@@ -19,7 +19,6 @@ metadata:
 spec:
   runtime: python
   responseIsEvent: true
-  public: true
   ceOverrides:
     extensions:
       type: io.triggermesh.python.sample

--- a/config/samples/functions/ruby.yaml
+++ b/config/samples/functions/ruby.yaml
@@ -18,7 +18,6 @@ metadata:
   name: inline-ruby-function
 spec:
   runtime: ruby
-  public: true
   ceOverrides:
     extensions:
       type: io.triggermesh.ruby.sample

--- a/pkg/apis/extensions/v1alpha1/function_types.go
+++ b/pkg/apis/extensions/v1alpha1/function_types.go
@@ -47,7 +47,6 @@ var (
 type FunctionSpec struct {
 	Runtime         string               `json:"runtime"`
 	Entrypoint      string               `json:"entrypoint"`
-	Public          bool                 `json:"public,omitempty"`
 	Code            string               `json:"code"`
 	ResponseIsEvent bool                 `json:"responseIsEvent,omitempty"`
 	EventStore      EventStoreConnection `json:"eventStore,omitempty"`

--- a/pkg/extensions/reconciler/function/adapter.go
+++ b/pkg/extensions/reconciler/function/adapter.go
@@ -88,15 +88,9 @@ func (r *Reconciler) BuildAdapter(rcl commonv1alpha1.Reconcilable, sinkURI *apis
 		responseMode = "event"
 	}
 
-	ksvcVisibility := resource.VisibilityClusterLocal
-	if f.Spec.Public {
-		ksvcVisibility = resource.VisibilityPublic
-	}
-
 	return common.NewAdapterKnService(rcl, sinkURI,
 		resource.Image(lookupRuntimeImage(f.Spec.Runtime)),
 
-		ksvcVisibility,
 		resource.Annotation(codeVersionAnnotation, cmapRev),
 
 		resource.Label(functionNameLabel, f.Name),


### PR DESCRIPTION
It is now redundant with [`spec.adapterOverrides.public`](https://github.com/triggermesh/triggermesh/blob/8eb93f5ee32c559bce379c1e4d74b6e0d57c8044/config/303-function.yaml#L60-L66).