### PR TITLE
Report YAML linter errors in both the GitHub Actions workflow logs and the Files Changed tab 

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Generate and commit
     runs-on: ubuntu-latest
 
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'failure' }}
+    if: github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'failure'
 
     # We want to avoid concurrent runs of this job, because they would end up committing
     # the same changes to the same branch in parallel, and ultimately fail.

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -60,11 +60,24 @@ jobs:
           ${{ github.job }}-${{ runner.os }}-go-
 
     - name: Lint Kubernetes manifests
+      id: yamllint
       uses: ibiqlik/action-yamllint@v3
       with:
         file_or_dir: config/
         config_file: .github/workflows/config/yamllint-k8s.yaml
         format: github
+
+    # (hack) By default, errors are reported to the GitHub commit view only (or
+    # the "Files changed" tab on PRs).
+    # In case errors were found, run the linter a second time but don't direct
+    # the output to GitHub, so that they are also visible in the execution logs
+    # of the workflow, with line numbers.
+    - name: Lint Kubernetes manifests (debug)
+      if: failure() && steps.yamllint.outcome == 'failure'
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        file_or_dir: config/
+        config_file: .github/workflows/config/yamllint-k8s.yaml
 
     - name: RBAC rules consistency
       run: |


### PR DESCRIPTION
In case the `yamllint` step fails, run it a second time, but this time don't send the errors to GitHub and simply print them in the logs.

With that approach, errors are visible in both places:

---

**In the changes overview** (commit view, or PRs "files changed" tab) 👈 current behaviour

![image](https://user-images.githubusercontent.com/3299086/166646275-e6aa83ec-6bef-4731-988d-8eb00f4be4d1.png)

---

**In the logs of the workflow**

![image](https://user-images.githubusercontent.com/3299086/166646425-7e7242f5-cac2-4ecb-89b6-88f785e1cba2.png)