### PR TITLE
Smoke test Eventing before running E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -50,6 +50,9 @@ jobs:
         # use for a container registry.
         registry: 'false'
 
+    - name: Smoke test Eventing webhook
+      run: .github/workflows/scripts/smoke-test-eventing.sh
+
     - name: Read KinD network subnet
       id: kind-subnet
       run: |
@@ -68,7 +71,7 @@ jobs:
         kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
         kubectl -n metallb-system wait --timeout=1m --for=condition=Available deployments.apps/controller
 
-        cat <<'EOM' | kubectl create -f-
+        kubectl create -f - <<'EOM'
         apiVersion: v1
         kind: ConfigMap
         metadata:

--- a/.github/workflows/scripts/smoke-test-eventing.sh
+++ b/.github/workflows/scripts/smoke-test-eventing.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# The Knative Eventing webhook occasionally responds with "connection refused"
+# although its Pod(s) reports "Ready", making Knative Eventing unusable.
+# This script performs a smoke test of the Eventing installation by attempting
+# a create/delete cycle of a basic Channel object. In case of failure, it
+# deletes the Eventing webhook Pod(s) and retries.
+
+set -eu
+set -o pipefail
+
+function create_channel {
+	local err
+
+	err="$(kubectl create -f - 2>&1 >/dev/null <<-EOM
+	apiVersion: messaging.knative.dev/v1
+	kind: Channel
+	metadata:
+	  name: smoke-test
+	EOM
+	)"
+
+	echo "$err"
+}
+
+function delete_channel {
+	kubectl delete channels.messaging.knative.dev/smoke-test >/dev/null
+}
+
+declare -i succeeded=0
+declare last_err
+
+declare -i max_attempts=3
+declare -i was_retried
+
+# outer loop:
+#  - try to create Channel multiple times
+#  - delete webhook and retry on failure (3 attempts)
+for attempt in $(seq 1 "$max_attempts"); do
+	was_retried=0
+
+	# inner loop: create Channel with retries (6 attempts)
+	for _ in $(seq 1 6); do
+		last_err="$(create_channel)"
+		if [ -z "${last_err:-}" ]; then
+			succeeded=1
+			break
+		fi
+
+		was_retried=1
+		echo -n '.' >&2
+		sleep 5
+	done
+
+	if ((was_retried)); then
+		# flush stderr, important in non-interactive environments (CI)
+		echo >&2
+	fi
+
+	if ((succeeded)); then
+		delete_channel
+		break
+	fi
+
+	if ((attempt < max_attempts)); then
+		kubectl -n knative-eventing delete pods -l 'app.kubernetes.io/component=eventing-webhook'
+	fi
+done
+
+if [ -n "$last_err" ]; then
+	echo "Smoke test Channel creation failed: ${last_err}" >&2
+fi


### PR DESCRIPTION
Fixes #801 (hopefully)

The Knative Eventing webhook occasionally responds with "connection refused" although its Pod(s) reports "Ready", making Knative Eventing unusable in the E2E test suite.

This workflow step performs a smoke test of the Eventing installation by attempting a create/delete cycle of a basic `Channel` object. In case of failure, it deletes the Eventing webhook Pod(s) and retries.

Here is a sample run where I deliberately caused the smoke test to fail consistently:

```
......
pod "eventing-webhook-76b66cd56c-zv997" deleted
......
pod "eventing-webhook-76b66cd56c-ht8z2" deleted
......
Smoke test Channel creation failed: Error from server (AlreadyExists): error when creating "STDIN": channels.messaging.knative.dev "smoke-test" already exists
```

It is also possible that the first attempts fail, then the situation resolves itself, in which case the script returns without error.