### PR TITLE
Clarify description of intermediate destinations in event sources' documentation

### DIFF
--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -152,7 +152,7 @@ spec:
                   - s3:Replication:OperationReplicatedAfterThreshold
               destination:
                 description: The intermediate destination of notifications originating from the Amazon S3 bucket, before
-                  they are retrieved by TriggerMesh. If omitted, an Amazon SQS queue is automatically created and
+                  they are retrieved by this event source. If omitted, an Amazon SQS queue is automatically created and
                   associated with the bucket.
                 type: object
                 properties:

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -115,7 +115,8 @@ spec:
                 format: guid
                 pattern: ^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$
               destination:
-                description: The intermediate destination of activity logs, before they are retrieved by TriggerMesh.
+                description: The intermediate destination of activity logs, before they are retrieved by this event
+                  source.
                 type: object
                 properties:
                   eventHubs:

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -156,7 +156,7 @@ spec:
                   - Microsoft.Storage.BlobInventoryPolicyCompleted
               endpoint:
                 description: The intermediate destination of events subscribed via Event Grid, before they are retrieved
-                  by TriggerMesh.
+                  by this event source.
                 type: object
                 properties:
                   eventHubs:

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -133,7 +133,7 @@ spec:
                   type: string
               endpoint:
                 description: The intermediate destination of events subscribed via Event Grid, before they are retrieved
-                  by TriggerMesh.
+                  by this event source.
                 type: object
                 properties:
                   eventHubs:

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -130,8 +130,9 @@ spec:
                 properties:
                   topic:
                     description: Full resource name of the Pub/Sub topic where change notifications originating from the
-                      configured audit logs sink are sent to. If not supplied, a topic is created on behalf of the user,
-                      in the GCP project referenced by the 'project' attribute. The expected format is described at
+                      configured audit logs sink are sent to, before being retrieved by this event source. If not
+                      supplied, a topic is created on behalf of the user, in the GCP project referenced by the 'project'
+                      attribute. The expected format is described at
                       https://cloud.google.com/pubsub/docs/admin#resource_names
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -125,8 +125,9 @@ spec:
                 properties:
                   topic:
                     description: Full resource name of the Pub/Sub topic where notifications originating from the
-                      configured billing budget are sent to. If not supplied, a topic is created on behalf of the user,
-                      in the GCP project referenced by the 'project' attribute. The expected format is described at
+                      configured billing budget are sent to, before being retrieved by this event source. If not
+                      supplied, a topic is created on behalf of the user, in the GCP project referenced by the 'project'
+                      attribute. The expected format is described at
                       https://cloud.google.com/pubsub/docs/admin#resource_names.
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$

--- a/config/300-googlecloudiotsource.yaml
+++ b/config/300-googlecloudiotsource.yaml
@@ -119,9 +119,9 @@ spec:
                 properties:
                   topic:
                     description: Full resource name of the Pub/Sub topic where messages originating from the configured
-                      IoT Registry are sent to. If not supplied, a topic is created on behalf of the user, in the GCP
-                      project referenced by the 'project' attribute. The expected format is described at
-                      https://cloud.google.com/pubsub/docs/admin#resource_names.
+                      IoT Registry are sent to, before being retrieved by this event source. If not supplied, a topic is
+                      created on behalf of the user, in the GCP project referenced by the 'project' attribute. The
+                      expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names.
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$
               serviceAccountKey:

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -119,9 +119,9 @@ spec:
                 properties:
                   topic:
                     description: Full resource name of the Pub/Sub topic where change notifications originating from the
-                      configured repo are sent to. If not supplied, a topic is created on behalf of the user, in the
-                      GCP project referenced by the 'project' attribute. The expected format is described at
-                      https://cloud.google.com/pubsub/docs/admin#resource_names
+                      configured repo are sent to, before being retrieved by this event source. If not supplied, a topic
+                      is created on behalf of the user, in the GCP project referenced by the 'project' attribute. The
+                      expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$
                 required: [topic]

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -120,9 +120,9 @@ spec:
                 properties:
                   topic:
                     description: Full resource name of the Pub/Sub topic where change notifications originating from the
-                      configured bucket are sent to. If not supplied, a topic is created on behalf of the user, in the
-                      GCP project referenced by the 'project' attribute. The expected format is described at
-                      https://cloud.google.com/pubsub/docs/admin#resource_names
+                      configured bucket are sent to, before being retrieved by this event source. If not supplied, a
+                      topic is created on behalf of the user, in the GCP project referenced by the 'project' attribute.
+                      The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names
                     type: string
                     pattern: ^projects\/[a-z][a-z0-9-]{3,29}\/topics\/[a-zA-Z][\w-.~%+]{2,254}$
                   project:

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -68,7 +68,7 @@ type AWSS3SourceSpec struct {
 	EventTypes []string `json:"eventTypes"`
 
 	// The intermediate destination of notifications originating from the
-	// Amazon S3 bucket, before they are retrieved by TriggerMesh.
+	// Amazon S3 bucket, before they are retrieved by this event source.
 	// If omitted, an Amazon SQS queue is automatically created and
 	// associated with the bucket.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
+++ b/pkg/apis/sources/v1alpha1/azureactivitylogs_types.go
@@ -52,7 +52,7 @@ type AzureActivityLogsSourceSpec struct {
 	SubscriptionID string `json:"subscriptionID"`
 
 	// The intermediate destination of activity logs, before they are
-	// retrieved by TriggerMesh.
+	// retrieved by this event source.
 	Destination AzureActivityLogsSourceDestination `json:"destination"`
 
 	// Categories of Activity Logs to collect.

--- a/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azureblobstorage_types.go
@@ -71,7 +71,7 @@ type AzureBlobStorageSourceSpec struct {
 	EventTypes []string `json:"eventTypes,omitempty"`
 
 	// The intermediate destination of events subscribed via Event Grid,
-	// before they are retrieved by TriggerMesh.
+	// before they are retrieved by this event source.
 	Endpoint AzureEventGridSourceEndpoint `json:"endpoint"`
 
 	// Authentication method to interact with the Azure REST API.

--- a/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
+++ b/pkg/apis/sources/v1alpha1/azureeventgrid_types.go
@@ -71,7 +71,7 @@ type AzureEventGridSourceSpec struct {
 	EventTypes []string `json:"eventTypes,omitempty"`
 
 	// The intermediate destination of events subscribed via Event Grid,
-	// before they are retrieved by TriggerMesh.
+	// before they are retrieved by this event source.
 	Endpoint AzureEventGridSourceEndpoint `json:"endpoint"`
 
 	// Authentication method to interact with the Azure REST API.

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
@@ -85,9 +85,10 @@ type GoogleCloudAuditLogsSourcePubSubSpec struct {
 	// Optional: no more than one of the following may be specified.
 
 	// Full resource name of the Pub/Sub topic where change notifications
-	// originating from the configured sink are sent to. If not supplied,
-	// a topic is created on behalf of the user, in the GCP project
-	// referenced by the Project attribute.
+	// originating from the configured sink are sent to, before being
+	// retrieved by this event source. If not supplied, a topic is created
+	// on behalf of the user, in the GCP project referenced by the Project
+	// attribute.
 	//
 	// The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names:
 	//   "projects/{project_name}/topics/{topic_name}"

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
@@ -74,9 +74,10 @@ type GoogleCloudBillingSourcePubSubSpec struct {
 	// Optional: no more than one of the following may be specified.
 
 	// Full resource name of the Pub/Sub topic where change notifications
-	// originating from the configured sink are sent to. If not supplied,
-	// a topic is created on behalf of the user, in the GCP project
-	// referenced by the Project attribute.
+	// originating from the configured sink are sent to, before being
+	// retrieved by this event source. If not supplied, a topic is created
+	// on behalf of the user, in the GCP project referenced by the Project
+	// attribute.
 	//
 	// The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names:
 	//   "projects/{project_name}/topics/{topic_name}"

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
@@ -75,9 +75,10 @@ type GoogleCloudIoTSourcePubSubSpec struct {
 	// Optional: no more than one of the following may be specified.
 
 	// Full resource name of the Pub/Sub topic where change notifications
-	// originating from the configured IoT Registry are sent to. If not supplied,
-	// a topic is created on behalf of the user, in the GCP project
-	// referenced by the Project attribute.
+	// originating from the configured IoT Registry are sent to, before
+	// being retrieved by this event source. If not supplied, a topic is
+	// created on behalf of the user, in the GCP project referenced by the
+	// Project attribute.
 	//
 	// The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names:
 	//   "projects/{project_name}/topics/{topic_name}"

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
@@ -81,9 +81,10 @@ type GoogleCloudSourceRepositoriesSourcePubSubSpec struct {
 	// Optional: no more than one of the following may be specified.
 
 	// Full resource name of the Pub/Sub topic where change notifications
-	// originating from the configured sink are sent to. If not supplied,
-	// a topic is created on behalf of the user, in the GCP project
-	// referenced by the Project attribute.
+	// originating from the configured sink are sent to, before being
+	// retrieved by this event source. If not supplied, a topic is created
+	// on behalf of the user, in the GCP project referenced by the Project
+	// attribute.
 	//
 	// The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names:
 	//   "projects/{project_name}/topics/{topic_name}"

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
@@ -79,9 +79,10 @@ type GoogleCloudStorageSourcePubSubSpec struct {
 	// Optional: no more than one of the following may be specified.
 
 	// Full resource name of the Pub/Sub topic where change notifications
-	// originating from the configured bucket are sent to. If not supplied,
-	// a topic is created on behalf of the user, in the GCP project
-	// referenced by the Project attribute.
+	// originating from the configured bucket are sent to, before being
+	// retrieved by this event source. If not supplied, a topic is created
+	// on behalf of the user, in the GCP project referenced by the Project
+	// attribute.
 	//
 	// The expected format is described at https://cloud.google.com/pubsub/docs/admin#resource_names:
 	//   "projects/{project_name}/topics/{topic_name}"


### PR DESCRIPTION
Broadly addresses @odacremolbap's [review comment](https://github.com/triggermesh/triggermesh/pull/798#discussion_r865572892) from #798.
