### PR TITLE
Only schedule "autofix" GitHub Actions workflow on dependabot branches

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,8 +5,8 @@ on:
     workflows:
       - Generated Files
       - OSS Licenses
-    types:
-      - completed
+    types: [ completed ]
+    branches: [ dependabot/go_modules/** ]
 
 jobs:
 


### PR DESCRIPTION
We already [skip the run](https://github.com/triggermesh/triggermesh/blob/f728cf2ac5ac0159ece1dc0643ef5af32e40f99e/.github/workflows/autofix.yaml#L17) if the user that initiated the workflow isn't Dependabot, but we can go one step further and avoid scheduling the workflow entirely if the head branch isn't a Dependabot branch.