### PR TITLE
Collect logs after failed E2E run

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -116,6 +116,7 @@ jobs:
         credentials_json: ${{ secrets.GCLOUD_SERVICEACCOUNT_KEY }}
 
     - name: Run e2e tests
+      id: e2e
       env:
         AWS_REGION: ${{ secrets.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -155,3 +156,27 @@ jobs:
         # Final retrieval of E2E namespaces, gives us a chance to see whether
         # some of them were still Terminating after the grace period.
         kubectl get ns -l e2e-framework
+
+    - name: Collect logs
+      id: logs
+      if: failure() && steps.e2e.outcome == 'failure'
+      run: |
+        tmp_logs="$(mktemp -d)"
+
+        kubectl -n triggermesh logs -l app=triggermesh-controller > "${tmp_logs}/triggermesh-controller.log"
+        kubectl -n triggermesh logs -l app=triggermesh-webhook    > "${tmp_logs}/triggermesh-webhook.log"
+
+        kubectl -n knative-serving logs -l app=controller > "${tmp_logs}/serving-controller.log"
+        kubectl -n knative-serving logs -l app=webhook    > "${tmp_logs}/serving-webhook.log"
+
+        kubectl -n knative-eventing logs -l app=eventing-controller > "${tmp_logs}/eventing-controller.log"
+        kubectl -n knative-eventing logs -l app=eventing-webhook    > "${tmp_logs}/eventing-webhook.log"
+
+        echo "::set-output name=logs_dir::${tmp_logs}"
+
+    - name: Upload logs
+      if: failure() && steps.logs.outputs.logs_dir
+      uses: actions/upload-artifact@v3
+      with:
+        name: logs
+        path: ${{ steps.logs.outputs.logs_dir }}


### PR DESCRIPTION
Closes #393

Collects, archives, and uploads (to GitHub Actions) the logs of the following components whenever E2E tests fail:
- TriggerMesh controller + webhook
- Serving controller + webhook
- Eventing controller + webhook

We could of course do more on a per-test basis (like in #721), such as isolating the API events of the component instance being tested, or collecting logs of receive adapters, but I think this is a good place to start when troubleshooting tests.

---

Demo:

![e2e_logs_1](https://user-images.githubusercontent.com/3299086/167304792-38b3a299-b128-4b73-9ce9-2386b9d3c5af.png)

![e2e_logs_2](https://user-images.githubusercontent.com/3299086/167304800-3ce3a648-13e3-4e09-a42b-e6896fae3295.png)

![e2e_logs_3](https://user-images.githubusercontent.com/3299086/167304847-fbddb26b-853a-4851-bfc6-463f4b5d6a2b.png)