### PR TITLE
Output all logs instead of last 10 in case of failed E2E run

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -163,14 +163,14 @@ jobs:
       run: |
         tmp_logs="$(mktemp -d)"
 
-        kubectl -n triggermesh logs -l app=triggermesh-controller > "${tmp_logs}/triggermesh-controller.log"
-        kubectl -n triggermesh logs -l app=triggermesh-webhook    > "${tmp_logs}/triggermesh-webhook.log"
+        kubectl -n triggermesh logs --tail=-1 -l app=triggermesh-controller > "${tmp_logs}/triggermesh-controller.log"
+        kubectl -n triggermesh logs --tail=-1 -l app=triggermesh-webhook    > "${tmp_logs}/triggermesh-webhook.log"
 
-        kubectl -n knative-serving logs -l app=controller > "${tmp_logs}/serving-controller.log"
-        kubectl -n knative-serving logs -l app=webhook    > "${tmp_logs}/serving-webhook.log"
+        kubectl -n knative-serving logs --tail=-1 -l app=controller > "${tmp_logs}/serving-controller.log"
+        kubectl -n knative-serving logs --tail=-1 -l app=webhook    > "${tmp_logs}/serving-webhook.log"
 
-        kubectl -n knative-eventing logs -l app=eventing-controller > "${tmp_logs}/eventing-controller.log"
-        kubectl -n knative-eventing logs -l app=eventing-webhook    > "${tmp_logs}/eventing-webhook.log"
+        kubectl -n knative-eventing logs --tail=-1 -l app=eventing-controller > "${tmp_logs}/eventing-controller.log"
+        kubectl -n knative-eventing logs --tail=-1 -l app=eventing-webhook    > "${tmp_logs}/eventing-webhook.log"
 
         echo "::set-output name=logs_dir::${tmp_logs}"
 


### PR DESCRIPTION
Fixes #857

From `kubectl help logs`:

```
--tail=-1: Lines of recent log file to display. Defaults to -1 with no selector, showing all log
           lines otherwise 10, if a selector is provided.
```