### PR TITLE
Make `adapterOverrides` the last spec element in OpenAPI schemas

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Log Group to source data from. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies
                 type: string
@@ -200,6 +148,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -53,58 +53,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               region:
                 description: Code of the AWS region to source metrics from. Available region codes are documented in the AWS
                   General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
@@ -256,6 +204,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - region
             - metricQueries

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -53,58 +53,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the CodeCommit repository to receive events from. The expected format is documented at
                   https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscodecommit.html#awscodecommit-resources-for-iam-policies.
@@ -207,6 +155,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - branch

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Amazon Cognito Identity Pool to receive notifications from. The expected format is
                   documented at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncognitoidentity.html#amazoncognitoidentity-resources-for-iam-policies.
@@ -197,6 +145,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Amazon Cognito User Pool to receive notifications from. The expected format is documented
                   at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncognitouserpools.html#amazoncognitouserpools-resources-for-iam-policies
@@ -197,6 +145,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the DynamoDB table to receive modification events from. The expected format is documented
                   at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazondynamodb.html#amazondynamodb-resources-for-iam-policies.
@@ -197,6 +145,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Kinesis stream to receive data from. The expected format is documented at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonkinesis.html#amazonkinesis-resources-for-iam-policies.
                 type: string
@@ -196,6 +144,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Amazon RDS database instance to receive metrics for. The expected format is documented
                   at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonrds.html#amazonrds-resources-for-iam-policies.
@@ -209,6 +157,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - pollingInterval

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -57,58 +57,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: |-
                   ARN of the Amazon S3 bucket to receive notifications from. The expected format is documented at
@@ -257,6 +205,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - eventTypes

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Amazon SNS topic to consume messages from. The expected format is documented at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsns.html#amazonsns-resources-for-iam-policies
                 type: string
@@ -212,6 +160,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               arn:
                 description: ARN of the Amazon SQS queue to consume messages from. The expected format is documented at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies.
                 type: string
@@ -219,6 +167,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - arn
             - sink

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -53,58 +53,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               subscriptionID:
                 description: The ID of the Azure subscription which activity logs to subscribe to.
                 type: string
@@ -267,6 +215,58 @@ spec:
                       minLength: 1
                 required:
                 - extensions
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - subscriptionID
             - destination

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -60,58 +60,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               storageAccountID:
                 description: |-
                   Resource ID of the Storage Account to receive events for.
@@ -287,6 +235,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - storageAccountID
             - endpoint

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -51,58 +51,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               scope:
                 description: |-
                   The resource ID the event subscription applies to.
@@ -264,6 +212,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - scope
             - endpoint

--- a/config/300-azureeventhubsource.yaml
+++ b/config/300-azureeventhubsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               eventHubID:
                 description: |-
                   Resource ID of the Event Hubs instance.
@@ -298,6 +246,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - eventHubID
             - auth

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               auth:
                 description: Authentication method to interact with the Azure IOT Hub.
                 type: object
@@ -156,6 +104,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - auth
             - sink

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -52,6 +52,57 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
+              accountName:
+                description: Name of the storage account.
+                type: string
+              queueName:
+                description: Name of the queue.
+                type: string
+              accountKey:
+                description: A storage account access key for authenticating against the Azure Storage REST API.
+                type: object
+                properties:
+                  value:
+                    description: Literal value of the account key.
+                    type: string
+                  valueFromSecret:
+                    description: A reference to a Kubernetes Secret object containing the account key.
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      key:
+                        type: string
+                    required:
+                    - name
+                    - key
+              sink:
+                description: The destination of events sourced from Azure Storage.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -104,57 +155,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              accountName:
-                description: Name of the storage account.
-                type: string
-              queueName:
-                description: Name of the queue.
-                type: string
-              accountKey:
-                description: A storage account access key for authenticating against the Azure Storage REST API.
-                type: object
-                properties:
-                  value:
-                    description: Literal value of the account key.
-                    type: string
-                  valueFromSecret:
-                    description: A reference to a Kubernetes Secret object containing the account key.
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      key:
-                        type: string
-                    required:
-                    - name
-                    - key
-              sink:
-                description: The destination of events sourced from Azure Storage.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
             required:
             - accountName
             - accountKey

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               queueID:
                 description: |-
                   The resource ID the Service Bus Queue to subscribe to.
@@ -298,6 +246,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - queueID
             - auth

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               topicID:
                 description: |-
                   The resource ID the Service Bus Topic to subscribe to.
@@ -223,6 +171,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - topicID
             - auth

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -145,6 +145,59 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - sink
           status:

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               serviceName:
                 description: The name of the API service performing the operation. For example, "pubsub.googleapis.com".
                 type: string
@@ -188,6 +136,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - serviceName
             - methodName

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               billingAccountId:
                 description: The identifier for the Cloud Billing account owning the budget. Example, 01D4EE-079462-DFD6EC.
                 type: string
@@ -180,6 +128,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - billingAccountId
             - budgetId

--- a/config/300-googlecloudiotsource.yaml
+++ b/config/300-googlecloudiotsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               registry:
                 description: Full resource name of the Registry.
                 type: string
@@ -168,6 +116,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - registry
             - serviceAccountKey

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               topic:
                 description: Full resource name of the Pub/Sub topic to subscribe to, in the format "projects/{project_name}/topics/{topic_name}".
                 type: string
@@ -163,6 +111,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - topic
             - serviceAccountKey

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               repository:
                 description: Full resource name of the Repository.
                 type: string
@@ -179,6 +127,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - repository
             - serviceAccountKey

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               bucket:
                 description: Name of the Cloud Storage bucket to receive change notifications from. Must meet the naming requirements
                   described at https://cloud.google.com/storage/docs/naming-buckets
@@ -190,6 +138,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - bucket
             - pubsub

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -47,58 +47,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               eventType:
                 description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event\
                   \ related to the originating occurrence. Please refer to the CloudEvents specification for more details:\
@@ -188,6 +136,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - eventType
             - method

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -50,58 +50,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               connectionName:
                 description: IBM MQ server URI, e.g. ibm-mq.default.svc.cluster.local(1414).
                 type: string
@@ -273,6 +221,58 @@ spec:
                 anyOf:
                 - required: [username, password]
                 - required: [tls]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - connectionName
             - channelName

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               oracleApiPrivateKey:
                 description: PEM encoded API private key that has access to the OCI metrics API.
                 type: object
@@ -228,6 +176,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - oracleApiPrivateKey
             - oracleApiPrivateKeyPassphrase

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               auth:
                 description: Authentication method to interact with the Salesforce API.
                 type: object
@@ -183,6 +131,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - auth
             - subscription

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -52,6 +52,60 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
+              signingSecret:
+                description: Signing secret to authenticate Slack callbacks.
+                type: object
+                properties:
+                  value:
+                    description: Literal value of the signing secret.
+                    type: string
+                  valueFromSecret:
+                    description: A reference to a Kubernetes Secret containing the signing secret.
+                    type: object
+                    properties:
+                      name:
+                        description: Name of the Secret object.
+                        type: string
+                      key:
+                        description: Key from the Secret object.
+                        type: string
+                    required:
+                    - name
+                    - key
+                oneOf:
+                - required: [value]
+                - required: [valueFromSecret]
+              appID:
+                description: ID which identifies the Slack application generating this event. It helps identifying the App
+                  that sources events when multiple Slack applications share the same endpoint.
+                type: string
+              sink:
+                description: The destination of events generated from Slack callbacks.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -107,60 +161,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              signingSecret:
-                description: Signing secret to authenticate Slack callbacks.
-                type: object
-                properties:
-                  value:
-                    description: Literal value of the signing secret.
-                    type: string
-                  valueFromSecret:
-                    description: A reference to a Kubernetes Secret containing the signing secret.
-                    type: object
-                    properties:
-                      name:
-                        description: Name of the Secret object.
-                        type: string
-                      key:
-                        description: Key from the Secret object.
-                        type: string
-                    required:
-                    - name
-                    - key
-                oneOf:
-                - required: [value]
-                - required: [valueFromSecret]
-              appID:
-                description: ID which identifies the Slack application generating this event. It helps identifying the App
-                  that sources events when multiple Slack applications share the same endpoint.
-                type: string
-              sink:
-                description: The destination of events generated from Slack callbacks.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
             required:
             - sink
           status:

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -52,6 +52,33 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
+              sink:
+                description: The destination of events received by the webhook.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -107,33 +134,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              sink:
-                description: The destination of events received by the webhook.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
             required:
             - sink
           status:

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -47,61 +47,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               eventType:
                 description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event\
                   \ related to the originating occurrence. Please refer to the CloudEvents specification for more details:\
@@ -168,6 +113,61 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - eventType
             - sink

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -52,58 +52,6 @@ spec:
             description: Desired state of the event source.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               subdomain:
                 description: Name of the Zendesk subdomain.
                 type: string
@@ -187,6 +135,58 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - subdomain
             - email

--- a/config/301-alibabaosstarget.yaml
+++ b/config/301-alibabaosstarget.yaml
@@ -55,6 +55,45 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              endpoint:
+                type: string
+                description: The domain name used to access the OSS. For more information, please refer to the region and
+                  endpoint guide at https://www.alibabacloud.com/help/doc-detail/31837.htm?spm=a2c63.p38356.879954.8.23bc7d91ARN6Hy#concept-zt4-cvy-5db.
+                pattern: ^oss-([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{1,3}$
+              bucket:
+                type: string
+                description: The unique container to store objects in OSS.
+              accessKeySecret:
+                type: object
+                description: Alibaba SDK access key secret as registered. For more information on how to create an access
+                  key pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              accessKeyID:
+                type: object
+                description: Alibaba SDK access key id as registered. For more information on how to create an access key
+                  pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,45 +149,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              endpoint:
-                type: string
-                description: The domain name used to access the OSS. For more information, please refer to the region and
-                  endpoint guide at https://www.alibabacloud.com/help/doc-detail/31837.htm?spm=a2c63.p38356.879954.8.23bc7d91ARN6Hy#concept-zt4-cvy-5db.
-                pattern: ^oss-([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{1,3}$
-              bucket:
-                type: string
-                description: The unique container to store objects in OSS.
-              accessKeySecret:
-                type: object
-                description: Alibaba SDK access key secret as registered. For more information on how to create an access
-                  key pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              accessKeyID:
-                type: object
-                description: Alibaba SDK access key id as registered. For more information on how to create an access key
-                  pair, please refer to https://www.alibabacloud.com/help/doc-detail/53045.htm?spm=a2c63.p38356.879954.9.23bc7d91ARN6Hy#task968.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - accessKeyID
             - accessKeySecret

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -56,6 +56,39 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              awsApiKey:
+                description: API Key to interact with the Comprehend API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                description: API Secret to interact with the Comprehend API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              region:
+                description: Code of the AWS region to use for the Comprehend API. Available region codes are documented in
+                  the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
+                type: string
+              language:
+                description: Language code to use for Comprehend. Available languages can be found at https://docs.aws.amazon.com/comprehend/latest/dg/supported-languages.html.
+                type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,39 +144,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                description: API Key to interact with the Comprehend API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                description: API Secret to interact with the Comprehend API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              region:
-                description: Code of the AWS region to use for the Comprehend API. Available region codes are documented in
-                  the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints.
-                type: string
-              language:
-                description: Language code to use for Comprehend. Available languages can be found at https://docs.aws.amazon.com/comprehend/latest/dg/supported-languages.html.
-                type: string
             required:
             - region
             - language

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -55,6 +55,36 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              awsApiKey:
+                type: object
+                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the DynamoDB table to post events to. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazondynamodb.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:dynamodb:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:table\/[a-zA-Z0-9-_.]{3,255}$
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,36 +140,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                type: object
-                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                description: API Key to interact with the Amazon DynamoDB API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the DynamoDB table to post events to. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazondynamodb.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:dynamodb:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:table\/[a-zA-Z0-9-_.]{3,255}$
             required:
             - arn
             - awsApiSecret

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -55,6 +55,41 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              awsApiKey:
+                description: API Key to interact with the Amazon EventBridge API. For more information about AWS security
+                  credentials, please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                description: API Secret to interact with the Amazon EventBridge API. For more information about AWS security
+                  credentials, please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the Event Bus that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoneventbridge.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:events:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:event-bus\/.+$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in messages sent to EventBridge. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,41 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                description: API Key to interact with the Amazon EventBridge API. For more information about AWS security
-                  credentials, please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                description: API Secret to interact with the Amazon EventBridge API. For more information about AWS security
-                  credentials, please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the Event Bus that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoneventbridge.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:events:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:event-bus\/.+$
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in messages sent to EventBridge. When this property
-                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -54,6 +54,44 @@ spec:
           spec:
             type: object
             properties:
+              awsApiKey:
+                type: object
+                description: API Key to interact with the Amazon Kinesis API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                type: object
+                description: API Secret to interact with the Amazon Kinesis API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the Kinesis stream that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkinesis.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:kinesis:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:stream/.+$
+              partition:
+                description: A Kinesis partition name is required for the target to know where to stream the events to.
+                type: string
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in records created in Kinesis. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -109,44 +147,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                type: object
-                description: API Key to interact with the Amazon Kinesis API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                type: object
-                description: API Secret to interact with the Amazon Kinesis API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the Kinesis stream that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonkinesis.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:kinesis:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:stream/.+$
-              partition:
-                description: A Kinesis partition name is required for the target to know where to stream the events to.
-                type: string
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in records created in Kinesis. When this property
-                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -55,6 +55,41 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              awsApiKey:
+                type: object
+                description: API Key to interact with the Amazon Lambda API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                type: object
+                description: API Secret to interact with the Amazon Lambda API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the Lambda function that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:lambda:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:(function|layer|event-source-mapping):.+$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in Lambda function calls. When this property is
+                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,41 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                type: object
-                description: API Key to interact with the Amazon Lambda API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                type: object
-                description: API Secret to interact with the Amazon Lambda API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the Lambda function that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:lambda:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:(function|layer|event-source-mapping):.+$
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in Lambda function calls. When this property is
-                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -56,6 +56,41 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              awsApiKey:
+                type: object
+                description: API Key to interact with the Amazon S3 API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                type: object
+                description: API Secret to interact with the Amazon S3 API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                type: string
+                description: ARN of the S3 bucket that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
+                pattern: ^arn:aws(-cn|-us-gov)?:s3:::[0-9a-z][0-9a-z.-]{2,62}$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in objects created in S3. When this property is
+                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,41 +146,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                type: object
-                description: API Key to interact with the Amazon S3 API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                type: object
-                description: API Secret to interact with the Amazon S3 API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                type: string
-                description: ARN of the S3 bucket that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
-                pattern: ^arn:aws(-cn|-us-gov)?:s3:::[0-9a-z][0-9a-z.-]{2,62}$
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in objects created in S3. When this property is
-                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -55,6 +55,41 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              awsApiKey:
+                type: object
+                description: API Key to interact with the SNS API. For more information about AWS security credentials, please
+                  refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                type: object
+                description: API Secret to interact with the SNS API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the SNS queue that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsns.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in notifications sent to SNS. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,41 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                type: object
-                description: API Key to interact with the SNS API. For more information about AWS security credentials, please
-                  refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                type: object
-                description: API Secret to interact with the SNS API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the SNS queue that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsns.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:sns:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in notifications sent to SNS. When this property
-                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -55,6 +55,41 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              awsApiKey:
+                description: API Key to interact with the Amazon SQS API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the access key ID.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              awsApiSecret:
+                description: API Secret to interact with the Amazon SQS API. For more information about AWS security credentials,
+                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object containing the secret access key.
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              arn:
+                description: ARN of the SQS queue that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
+                type: string
+                pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in messages sent to SQS. When this property is
+                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,41 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              awsApiKey:
-                description: API Key to interact with the Amazon SQS API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the access key ID.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              awsApiSecret:
-                description: API Secret to interact with the Amazon SQS API. For more information about AWS security credentials,
-                  please refer to the AWS General Reference at https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-                type: object
-                properties:
-                  secretKeyRef:
-                    description: A reference to a Kubernetes Secret object containing the secret access key.
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              arn:
-                description: ARN of the SQS queue that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
-                type: string
-                pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in messages sent to SQS. When this property is
-                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - arn
             - awsApiSecret

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -57,61 +57,6 @@ spec:
             description: Desired state of the event target.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               eventHubID:
                 description: |-
                   Resource ID of the Event Hubs instance.
@@ -284,6 +229,61 @@ spec:
                 oneOf:
                 - required: [sasToken]
                 - required: [servicePrincipal]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - eventHubID
             - auth

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -51,6 +51,50 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              username:
+                description: Confluent account username when using SASL.
+                type: string
+                minLength: 1
+              password:
+                description: Confluent account password when using SASL.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              topic:
+                description: Topic name to stream the target events to.
+                type: string
+                minLength: 1
+              topicReplicationFactor:
+                description: The number of replicas required to stream to the topic.
+                type: integer
+              topicPartitions:
+                description: The number of partitions used by the topic to stream an event to.
+                type: integer
+              bootstrapServers:
+                description: Array of Confluent Kafka servers used to bootstrap the connection.
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+              securityProtocol:
+                description: Encryption protocol to use for connecting to Confluent Kafka. This can be "Plaintext", "SslPlaintext",
+                  "SaslSsl", or "Ssl". Additional information can be found at https://docs.confluent.io/platform/current/connect/security.html.
+                type: string
+              saslMechanism:
+                description: When using the "saslSsl" securityProtocol attribute, indicate which mechanism to use. This can
+                  be "Gssapi", "OAuthBearer", "Plain", "ScramSha256", and "ScramSha512".
+                type: string
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in messages sent to Kafka. When this property is
+                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -106,50 +150,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              username:
-                description: Confluent account username when using SASL.
-                type: string
-                minLength: 1
-              password:
-                description: Confluent account password when using SASL.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              topic:
-                description: Topic name to stream the target events to.
-                type: string
-                minLength: 1
-              topicReplicationFactor:
-                description: The number of replicas required to stream to the topic.
-                type: integer
-              topicPartitions:
-                description: The number of partitions used by the topic to stream an event to.
-                type: integer
-              bootstrapServers:
-                description: Array of Confluent Kafka servers used to bootstrap the connection.
-                type: array
-                items:
-                  type: string
-                  minLength: 1
-              securityProtocol:
-                description: Encryption protocol to use for connecting to Confluent Kafka. This can be "Plaintext", "SslPlaintext",
-                  "SaslSsl", or "Ssl". Additional information can be found at https://docs.confluent.io/platform/current/connect/security.html.
-                type: string
-              saslMechanism:
-                description: When using the "saslSsl" securityProtocol attribute, indicate which mechanism to use. This can
-                  be "Gssapi", "OAuthBearer", "Plain", "ScramSha256", and "ScramSha512".
-                type: string
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in messages sent to Kafka. When this property is
-                  false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - username
             - password

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -57,6 +57,24 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              apiKey:
+                type: object
+                description: Datadog API Key with access to receive metrics.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                type: object
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -112,24 +130,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              apiKey:
-                type: object
-                description: Datadog API Key with access to receive metrics.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                type: object
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - apiKey
           status:

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -54,61 +54,6 @@ spec:
           spec:
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               indexName:
                 description: Elasticsearch index to stream the events to.
                 type: string
@@ -168,6 +113,61 @@ spec:
                   property is false (default), the entire CloudEvent payload is included. When this property is true, only
                   the CloudEvent data is included.
                 type: boolean
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - connection
             - indexName

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -60,6 +60,36 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              defaultCollection:
+                description: Default firestore collection to stream events into.
+                type: string
+              projectID:
+                description: Google Cloud Project ID associated with the firestore database.
+                type: string
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in documents created in Firestore. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included. component only.
+                type: boolean
+              credentialsJson:
+                type: object
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
+                  refer to https://cloud.google.com/docs/authentication/production.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -115,36 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              defaultCollection:
-                description: Default firestore collection to stream events into.
-                type: string
-              projectID:
-                description: Google Cloud Project ID associated with the firestore database.
-                type: string
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in documents created in Firestore. When this property
-                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included. component only.
-                type: boolean
-              credentialsJson:
-                type: object
-                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
-                  refer to https://cloud.google.com/docs/authentication/production.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - credentialsJson
             - projectID

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -56,6 +56,34 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              bucketName:
+                description: GCP Storage bucket to stream events to. Must meet the naming requirements described at https://cloud.google.com/storage/docs/naming-buckets
+                type: string
+                pattern: ^[a-z0-9][a-z0-9_-]{1,61}[a-z0-9](\.[a-z0-9][a-z0-9_-]{1,61}[a-z0-9])*$
+              credentialsJson:
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
+                  refer to https://cloud.google.com/docs/authentication/production.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in objects created in GCP Storage. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,34 +139,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              bucketName:
-                description: GCP Storage bucket to stream events to. Must meet the naming requirements described at https://cloud.google.com/storage/docs/naming-buckets
-                type: string
-                pattern: ^[a-z0-9][a-z0-9_-]{1,61}[a-z0-9](\.[a-z0-9][a-z0-9_-]{1,61}[a-z0-9])*$
-              credentialsJson:
-                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
-                  refer to https://cloud.google.com/docs/authentication/production.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
-              discardCloudEventContext:
-                description: Whether to omit CloudEvent context attributes in objects created in GCP Storage. When this property
-                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
-                  data is included.
-                type: boolean
             required:
             - credentialsJson
             - bucketName

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -55,6 +55,25 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              credentialsJson:
+                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
+                  refer to https://cloud.google.com/docs/authentication/production.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,25 +129,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              credentialsJson:
-                description: GCP credentials used to programmatically interact with Google Cloud Storage. For additional information,
-                  refer to https://cloud.google.com/docs/authentication/production.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - credentialsJson
           status:

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -56,6 +56,27 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              id:
+                type: string
+                description: Googlesheet ID associated with the document being targeted.
+                minLength: 1
+              defaultPrefix:
+                type: string
+                description: A prefix to be used when creating a new sheet inside a document.
+                minLength: 1
+              googleServiceAccount:
+                description: Google service account token used to authenticate access to the Googlesheet document.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,27 +132,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              id:
-                type: string
-                description: Googlesheet ID associated with the document being targeted.
-                minLength: 1
-              defaultPrefix:
-                type: string
-                description: A prefix to be used when creating a new sheet inside a document.
-                minLength: 1
-              googleServiceAccount:
-                description: Google service account token used to authenticate access to the Googlesheet document.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        minLength: 1
-                      name:
-                        type: string
-                        minLength: 1
             required:
             - id
             - googleServiceAccount

--- a/config/301-hasuratarget.yaml
+++ b/config/301-hasuratarget.yaml
@@ -56,6 +56,42 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              endpoint:
+                description: REST endpoint for the GraphQL instance.
+                type: string
+                minLength: 1
+              defaultRole:
+                description: The default role a query from this target should assume when it is not specified in the event
+                  payload.
+                type: string
+              queries:
+                type: object
+                description: Preload GraphQL queries the target can respond to. When used, the queries are given a unique
+                  name that is referenced as a part of the cloudevent type 'io.triggermesh.graphql.query'.
+                additionalProperties:
+                  type: string
+              jwt:
+                type: object
+                description: A JavaScript Web Token (JWT) containing the credentials required to connect to Hasura.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              admin:
+                type: object
+                description: An API token that acts as an alternative to the jwt token used to connect to Hasura.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,42 +147,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              endpoint:
-                description: REST endpoint for the GraphQL instance.
-                type: string
-                minLength: 1
-              defaultRole:
-                description: The default role a query from this target should assume when it is not specified in the event
-                  payload.
-                type: string
-              queries:
-                type: object
-                description: Preload GraphQL queries the target can respond to. When used, the queries are given a unique
-                  name that is referenced as a part of the cloudevent type 'io.triggermesh.graphql.query'.
-                additionalProperties:
-                  type: string
-              jwt:
-                type: object
-                description: A JavaScript Web Token (JWT) containing the credentials required to connect to Hasura.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              admin:
-                type: object
-                description: An API token that acts as an alternative to the jwt token used to connect to Hasura.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
             required:
             - endpoint
           status:

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -55,61 +55,6 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               response:
                 type: object
                 properties:
@@ -180,6 +125,61 @@ spec:
                 type: object
                 additionalProperties:
                   type: string
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - endpoint
             - method

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -55,61 +55,6 @@ spec:
             description: Desired state of the event target.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               connectionName:
                 description: IBM MQ server URI, e.g. ibm-mq.default.svc.cluster.local(1414).
                 type: string
@@ -255,6 +200,61 @@ spec:
                 anyOf:
                 - required: [username, password]
                 - required: [tls]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - connectionName
             - channelName

--- a/config/301-infratarget.yaml
+++ b/config/301-infratarget.yaml
@@ -56,6 +56,29 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              script:
+                description: JavaScript code to invoke when an event comes in.
+                type: object
+                properties:
+                  code:
+                    type: string
+                  timeout:
+                    type: integer
+                required:
+                - code
+              state:
+                type: object
+                description: Indicate whether stateful headers should be created (ensure), propagated (propagate), or dropped
+                  (none).
+                properties:
+                  headersPolicy:
+                    type: string
+                    enum: [ensure, propagate, none]
+                  bridge:
+                    type: string
+              typeLoopProtection:
+                description: Prevent the InfraTarget from consuming events it just produced.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,29 +134,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              script:
-                description: JavaScript code to invoke when an event comes in.
-                type: object
-                properties:
-                  code:
-                    type: string
-                  timeout:
-                    type: integer
-                required:
-                - code
-              state:
-                type: object
-                description: Indicate whether stateful headers should be created (ensure), propagated (propagate), or dropped
-                  (none).
-                properties:
-                  headersPolicy:
-                    type: string
-                    enum: [ensure, propagate, none]
-                  bridge:
-                    type: string
-              typeLoopProtection:
-                description: Prevent the InfraTarget from consuming events it just produced.
-                type: boolean
             anyOf:
             - required: [script]
             - required: [state]

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -58,6 +58,40 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              auth:
+                type: object
+                description: Credentials to authenticate against the Jira instance.
+                properties:
+                  user:
+                    description: Jira username for the target to use.
+                    type: string
+                    minLength: 1
+                  token:
+                    description: Jira API token associated with the Jira user.
+                    type: object
+                    properties:
+                      secretKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                required:
+                - user
+                - token
+              url:
+                description: Jira instance url.
+                type: string
+                format: url
+                pattern: ^https?:\/\/.+$
+              eventOptions:
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                type: object
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -113,40 +147,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              auth:
-                type: object
-                description: Credentials to authenticate against the Jira instance.
-                properties:
-                  user:
-                    description: Jira username for the target to use.
-                    type: string
-                    minLength: 1
-                  token:
-                    description: Jira API token associated with the Jira user.
-                    type: object
-                    properties:
-                      secretKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                required:
-                - user
-                - token
-              url:
-                description: Jira instance url.
-                type: string
-                format: url
-                pattern: ^https?:\/\/.+$
-              eventOptions:
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                type: object
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - auth
             - url

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -51,61 +51,6 @@ spec:
             type: object
             description: The OpenTelemetry target exposes a common interface to a range of metrics backends.
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               connection:
                 type: object
                 description: Connection information for LogzMetrics.
@@ -164,6 +109,61 @@ spec:
 
                     type: string
                     enum: [always, error, never]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             required:
             - connection
             - instruments

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -56,6 +56,31 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              shippingToken:
+                description: API token used to authenticate the event being streamed.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
+              logsListenerURL:
+                type: string
+                description: Logz listener host to stream events to.
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,31 +136,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              shippingToken:
-                description: API token used to authenticate the event being streamed.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
-              logsListenerURL:
-                type: string
-                description: Logz listener host to stream events to.
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - shippingToken
             - logsListenerURL

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -55,6 +55,59 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              oracleApiPrivateKey:
+                type: object
+                description: Oracle API Private Key to sign each request to the Oracle Cloud. For details on how to create
+                  a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              oracleApiPrivateKeyPassphrase:
+                type: object
+                description: Passphrase to unlock the private key used to sign each request to the Oracle Cloud. For details
+                  on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              oracleApiPrivateKeyFingerprint:
+                type: object
+                description: MD5 fingerprint to identify the keypair associated with the key used to sign each request to
+                  the Oracle Cloud. For details on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              oracleTenancy:
+                description: The Oracle Cloud ID (OCID) of the tenant containing the service to be used on the Oracle Cloud.
+                type: string
+              oracleUser:
+                description: The Oracle Cloud ID (OCID) of the user who owns the key used to interact with the Oracle Cloud.
+                type: string
+              oracleRegion:
+                description: The Oracle Cloud region containing the service being executed. A full list of supported regions
+                  can be found at https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm.
+                type: string
+              function:
+                type: object
+                description: Invoke a serverless function on the Oracle Cloud.
+                properties:
+                  function:
+                    description: The Oracle Cloud ID (OCID) of the function being invoked.
+                    type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,59 +163,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              oracleApiPrivateKey:
-                type: object
-                description: Oracle API Private Key to sign each request to the Oracle Cloud. For details on how to create
-                  a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              oracleApiPrivateKeyPassphrase:
-                type: object
-                description: Passphrase to unlock the private key used to sign each request to the Oracle Cloud. For details
-                  on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              oracleApiPrivateKeyFingerprint:
-                type: object
-                description: MD5 fingerprint to identify the keypair associated with the key used to sign each request to
-                  the Oracle Cloud. For details on how to create a private keypair for Oracle Cloud, refer to https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              oracleTenancy:
-                description: The Oracle Cloud ID (OCID) of the tenant containing the service to be used on the Oracle Cloud.
-                type: string
-              oracleUser:
-                description: The Oracle Cloud ID (OCID) of the user who owns the key used to interact with the Oracle Cloud.
-                type: string
-              oracleRegion:
-                description: The Oracle Cloud region containing the service being executed. A full list of supported regions
-                  can be found at https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm.
-                type: string
-              function:
-                type: object
-                description: Invoke a serverless function on the Oracle Cloud.
-                properties:
-                  function:
-                    description: The Oracle Cloud ID (OCID) of the function being invoked.
-                    type: string
             oneOf:
             - required: [function]
           status:

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -55,6 +55,51 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              auth:
+                type: object
+                description: Attributes required to setup OAuth authentication with Salesforce. To create the credentials,
+                  refer to https://help.salesforce.com/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm.
+                properties:
+                  clientID:
+                    description: OAuth Client ID used to identify the target.
+                    type: string
+                    minLength: 1
+                  server:
+                    description: The Salesforce authentication URL associated with the instance being used.
+                    type: string
+                    format: uri
+                    pattern: ^https?:\/\/.+$
+                  user:
+                    description: Username associated with the Salesforce account.
+                    type: string
+                    minLength: 1
+                  certKey:
+                    type: object
+                    description: Salesforce requires a certificate to facilitate the authentication flow.
+                    properties:
+                      secretKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                required:
+                - clientID
+                - server
+                - user
+                - certKey
+              apiVersion:
+                type: string
+                description: Salesforce API version to use for the target's integration with Salesforce.
+                pattern: v\d+\.\d+$
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,51 +155,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              auth:
-                type: object
-                description: Attributes required to setup OAuth authentication with Salesforce. To create the credentials,
-                  refer to https://help.salesforce.com/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm.
-                properties:
-                  clientID:
-                    description: OAuth Client ID used to identify the target.
-                    type: string
-                    minLength: 1
-                  server:
-                    description: The Salesforce authentication URL associated with the instance being used.
-                    type: string
-                    format: uri
-                    pattern: ^https?:\/\/.+$
-                  user:
-                    description: Username associated with the Salesforce account.
-                    type: string
-                    minLength: 1
-                  certKey:
-                    type: object
-                    description: Salesforce requires a certificate to facilitate the authentication flow.
-                    properties:
-                      secretKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                required:
-                - clientID
-                - server
-                - user
-                - certKey
-              apiVersion:
-                type: string
-                description: Salesforce API version to use for the target's integration with Salesforce.
-                pattern: v\d+\.\d+$
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - auth
           status:

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -55,6 +55,42 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              defaultFromName:
+                description: Default name to use for the from field when sending email via Sendgrid.
+                type: string
+              defaultToName:
+                description: Default name to use for the to field when sending email via Sendgrid.
+                type: string
+              defaultToEmail:
+                description: Default email address to send mail to via Sendgrid.
+                type: string
+              defaultFromEmail:
+                description: Default sender email address for sending mail via Sendgrid.
+                type: string
+              defaultSubject:
+                description: Default subject to use for email sent via this target
+                type: string
+              defaultMessage:
+                description: Default message to use for all email sent via this target.
+                type: string
+              apiKey:
+                description: The Sendgrid API key used to authenticate access.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,42 +146,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              defaultFromName:
-                description: Default name to use for the from field when sending email via Sendgrid.
-                type: string
-              defaultToName:
-                description: Default name to use for the to field when sending email via Sendgrid.
-                type: string
-              defaultToEmail:
-                description: Default email address to send mail to via Sendgrid.
-                type: string
-              defaultFromEmail:
-                description: Default sender email address for sending mail via Sendgrid.
-                type: string
-              defaultSubject:
-                description: Default subject to use for email sent via this target
-                type: string
-              defaultMessage:
-                description: Default message to use for all email sent via this target.
-                type: string
-              apiKey:
-                description: The Sendgrid API key used to authenticate access.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - apiKey
           status:

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -55,6 +55,18 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              token:
+                type: object
+                description: Slack API token used to interface with Slack. Consult the Slack API documenation for details
+                  on how to setup an app for the target https://api.slack.com/web#authentication.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,18 +122,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              token:
-                type: object
-                description: Slack API token used to interface with Slack. Consult the Slack API documenation for details
-                  on how to setup an app for the target https://api.slack.com/web#authentication.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
             required:
             - token
           status:

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -50,6 +50,38 @@ spec:
           spec:
             type: object
             properties:
+              endpoint:
+                type: string
+                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated,
+                  the URL path is trimmed if present. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
+                format: url
+                pattern: ^https?:\/\/.+$
+              token:
+                type: object
+                description: Token for authenticating requests against the HEC. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#About_Event_Collector_tokens.
+                properties:
+                  value:
+                    type: string
+                    format: guid
+                    pattern: ^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$
+                  valueFromSecret:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      key:
+                        type: string
+                oneOf:
+                - required: [value]
+                - required: [valueFromSecret]
+              index:
+                type: string
+                description: Name of the index to send events to. When undefined, events are sent to the default index defined
+                  in the HEC token's configuration.
+                pattern: ^[\w-]+$
+              skipTLSVerify:
+                description: Control whether the target should verify the SSL/TLS certificate used by the event collector.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -105,38 +137,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              endpoint:
-                type: string
-                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated,
-                  the URL path is trimmed if present. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
-                format: url
-                pattern: ^https?:\/\/.+$
-              token:
-                type: object
-                description: Token for authenticating requests against the HEC. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#About_Event_Collector_tokens.
-                properties:
-                  value:
-                    type: string
-                    format: guid
-                    pattern: ^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$
-                  valueFromSecret:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      key:
-                        type: string
-                oneOf:
-                - required: [value]
-                - required: [valueFromSecret]
-              index:
-                type: string
-                description: Name of the index to send events to. When undefined, events are sent to the default index defined
-                  in the HEC token's configuration.
-                pattern: ^[\w-]+$
-              skipTLSVerify:
-                description: Control whether the target should verify the SSL/TLS certificate used by the event collector.
-                type: boolean
             required:
             - endpoint
             - token

--- a/config/301-tektontarget.yaml
+++ b/config/301-tektontarget.yaml
@@ -55,6 +55,18 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              reapPolicy:
+                type: object
+                description: Specify when successful or failed jobs should remain before being cleand out.
+                properties:
+                  success:
+                    description: Minimum age of a successfully completed run object before automatic purging
+                    type: string
+                    pattern: ^\d+[mhd]$
+                  fail:
+                    description: Minimum age of a failed run object before automatic purging
+                    type: string
+                    pattern: ^\d+[mhd]$
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,18 +122,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              reapPolicy:
-                type: object
-                description: Specify when successful or failed jobs should remain before being cleand out.
-                properties:
-                  success:
-                    description: Minimum age of a successfully completed run object before automatic purging
-                    type: string
-                    pattern: ^\d+[mhd]$
-                  fail:
-                    description: Minimum age of a failed run object before automatic purging
-                    type: string
-                    pattern: ^\d+[mhd]$
           status:
             type: object
             description: Reported status of the event target.

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -55,6 +55,41 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              defaultPhoneFrom:
+                description: Default phone number to send the message from.
+                type: string
+              defaultPhoneTo:
+                description: Default phone number to send the message to.
+                type: string
+              sid:
+                type: object
+                description: Twilio account service ID (SID)
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              token:
+                type: object
+                description: Twilio API Token.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              eventOptions:
+                type: object
+                description: 'When should this target generate a response event for processing: always, on error, or never.'
+                properties:
+                  payloadPolicy:
+                    type: string
+                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -110,41 +145,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              defaultPhoneFrom:
-                description: Default phone number to send the message from.
-                type: string
-              defaultPhoneTo:
-                description: Default phone number to send the message to.
-                type: string
-              sid:
-                type: object
-                description: Twilio account service ID (SID)
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              token:
-                type: object
-                description: Twilio API Token.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              eventOptions:
-                type: object
-                description: 'When should this target generate a response event for processing: always, on error, or never.'
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
             required:
             - sid
             - token

--- a/config/301-uipathtarget.yaml
+++ b/config/301-uipathtarget.yaml
@@ -56,6 +56,37 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
+              userKey:
+                description: UiPath user refresh token to support OAuth based authentication. For additional details, refer
+                  to https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps.
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+              robotName:
+                description: Robot to invoke. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-robots.
+                type: string
+              processName:
+                description: UiProccess encompassing the robot. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-processes
+                type: string
+              tenantName:
+                description: UiPath tenant name. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-tenants.
+                type: string
+              accountLogicalName:
+                description: The unique site URL used to identify the UiPath tenant.
+                type: string
+              clientID:
+                description: OAuth ClientID registered by UiPath to identify the target. For details on registering a new
+                  client, please see https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps.
+                type: string
+              organizationUnitID:
+                description: A grouping of orchestrator components within a tenant. For additional details, please see https://docs.uipath.com/orchestrator/docs/about-organization-units.
+                type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,37 +142,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              userKey:
-                description: UiPath user refresh token to support OAuth based authentication. For additional details, refer
-                  to https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps.
-                type: object
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
-              robotName:
-                description: Robot to invoke. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-robots.
-                type: string
-              processName:
-                description: UiProccess encompassing the robot. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-processes
-                type: string
-              tenantName:
-                description: UiPath tenant name. For additional details, refer to https://docs.uipath.com/orchestrator/docs/about-tenants.
-                type: string
-              accountLogicalName:
-                description: The unique site URL used to identify the UiPath tenant.
-                type: string
-              clientID:
-                description: OAuth ClientID registered by UiPath to identify the target. For details on registering a new
-                  client, please see https://docs.uipath.com/orchestrator/reference/using-oauth-for-external-apps.
-                type: string
-              organizationUnitID:
-                description: A grouping of orchestrator components within a tenant. For additional details, please see https://docs.uipath.com/orchestrator/docs/about-organization-units.
-                type: string
             required:
             - organizationUnitID
             - clientID

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -56,6 +56,26 @@ spec:
             type: object
             description: Desired state of event target.
             properties:
+              subject:
+                description: Default subject line to use for tickets created using this target.
+                type: string
+              subdomain:
+                description: User's subdomain on zendesk being targeted.
+                type: string
+              email:
+                description: Default registered email address for interacting with Zendesk.
+                type: string
+              token:
+                type: object
+                description: Zendesk API token for interacting with Zendesk.
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,26 +131,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              subject:
-                description: Default subject line to use for tickets created using this target.
-                type: string
-              subdomain:
-                description: User's subdomain on zendesk being targeted.
-                type: string
-              email:
-                description: Default registered email address for interacting with Zendesk.
-                type: string
-              token:
-                type: object
-                description: Zendesk API token for interacting with Zendesk.
-                properties:
-                  secretKeyRef:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                      name:
-                        type: string
             required:
             - subdomain
             - email

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -56,6 +56,36 @@ spec:
             - expression
             - sink
             properties:
+              expression:
+                description: Google CEL-like expression string.
+                type: string
+              sink:
+                description: Sink is a reference to an object that will resolve to a uri to use as the sink.
+                type: object
+                oneOf:
+                - required: [ref]
+                - required: [uri]
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,36 +141,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              expression:
-                description: Google CEL-like expression string.
-                type: string
-              sink:
-                description: Sink is a reference to an object that will resolve to a uri to use as the sink.
-                type: object
-                oneOf:
-                - required: [ref]
-                - required: [uri]
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
           status:
             type: object
             properties:

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -56,6 +56,55 @@ spec:
             - ceContext
             - sink
             properties:
+              path:
+                type: string
+                description: JSONPath expression representing the key containing the data array to split. Defaults to the
+                  root.
+              ceContext:
+                type: object
+                required:
+                - type
+                - source
+                description: Context attributes to set on produced CloudEvents.
+                properties:
+                  type:
+                    type: string
+                    description: CloudEvent "type" context attribute.
+                  source:
+                    type: string
+                    description: CloudEvent "source" context attribute. Accepts a JSONPath expressions in brackets (e.g. "user/{.name}").
+                  extensions:
+                    type: object
+                    description: Additional context extensions to set on produced CloudEvents.
+                    additionalProperties:
+                      type: string
+              sink:
+                description: Sink is a reference to an object that will resolve to a uri to use as the sink.
+                type: object
+                oneOf:
+                - required: [ref]
+                - required: [uri]
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,55 +160,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              path:
-                type: string
-                description: JSONPath expression representing the key containing the data array to split. Defaults to the
-                  root.
-              ceContext:
-                type: object
-                required:
-                - type
-                - source
-                description: Context attributes to set on produced CloudEvents.
-                properties:
-                  type:
-                    type: string
-                    description: CloudEvent "type" context attribute.
-                  source:
-                    type: string
-                    description: CloudEvent "source" context attribute. Accepts a JSONPath expressions in brackets (e.g. "user/{.name}").
-                  extensions:
-                    type: object
-                    description: Additional context extensions to set on produced CloudEvents.
-                    additionalProperties:
-                      type: string
-              sink:
-                description: Sink is a reference to an object that will resolve to a uri to use as the sink.
-                type: object
-                oneOf:
-                - required: [ref]
-                - required: [uri]
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
           status:
             type: object
             properties:

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -57,61 +57,6 @@ spec:
             - entrypoint
             - code
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               runtime:
                 description: Function runtime name. Python, Ruby or Node runtimes are currently supported.
                 type: string
@@ -176,6 +121,61 @@ spec:
                     description: URI to use as the destination of events.
                     type: string
                     format: uri
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
           status:
             type: object
             properties:

--- a/config/304-dataweavetransformation.yaml
+++ b/config/304-dataweavetransformation.yaml
@@ -55,61 +55,6 @@ spec:
             description: Desired state of the TriggerMesh component.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               dwSpell:
                 description: DataWeave spell used to transform incoming CloudEvents.
                 type: object
@@ -182,6 +127,61 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             anyOf:
             - required: [dwSpell, inputContentType, outputContentType]
             - required: [allowPerEventDwSpell]

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -56,6 +56,37 @@ spec:
             description: Desired state of the transformer.
             type: object
             properties:
+              query:
+                description: The JSON Query to perform on the incoming event
+                type: string
+              sink:
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,37 +142,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              query:
-                description: The JSON Query to perform on the incoming event
-                type: string
-              sink:
-                description: The destination of events emitted by the component. If left empty, the events will be sent back
-                  to the sender.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
           status:
             description: Reported status of the transformer.
             type: object

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -49,6 +49,60 @@ spec:
             description: Desired state of the event synchronizer.
             type: object
             properties:
+              correlationKey:
+                description: Events correlation parameters.
+                type: object
+                properties:
+                  attribute:
+                    description: The name of the correlation key that will be injected into the CloudEvents context. Events
+                      without this attribute are forwarded to the Sink as the client requests while client connections are
+                      held open. Events, which context already has the correlation key, are sent back to the open client connections.
+                    type: string
+                  length:
+                    description: The length of the correlation key to generate. The default value is 24.
+                    type: integer
+                    minimum: 1
+                    maximum: 64
+                    default: 24
+                required:
+                - attribute
+              response:
+                description: Responses handling configuration.
+                type: object
+                properties:
+                  timeout:
+                    description: The time during which the synchronizer will block the client and wait for the response. Expressed
+                      as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+                    type: string
+                required:
+                - timeout
+              sink:
+                description: The destination where the synchronizer will forward incoming requests from the clients.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -104,60 +158,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              correlationKey:
-                description: Events correlation parameters.
-                type: object
-                properties:
-                  attribute:
-                    description: The name of the correlation key that will be injected into the CloudEvents context. Events
-                      without this attribute are forwarded to the Sink as the client requests while client connections are
-                      held open. Events, which context already has the correlation key, are sent back to the open client connections.
-                    type: string
-                  length:
-                    description: The length of the correlation key to generate. The default value is 24.
-                    type: integer
-                    minimum: 1
-                    maximum: 64
-                    default: 24
-                required:
-                - attribute
-              response:
-                description: Responses handling configuration.
-                type: object
-                properties:
-                  timeout:
-                    description: The time during which the synchronizer will block the client and wait for the response. Expressed
-                      as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
-                    type: string
-                required:
-                - timeout
-              sink:
-                description: The destination where the synchronizer will forward incoming requests from the clients.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
             required:
             - correlationKey
             - response

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -54,61 +54,6 @@ spec:
             description: Desired state of the transformation object.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               context:
                 description: CloudEvents Context attributes transformation spec.
                 type: array
@@ -191,6 +136,61 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
           status:
             description: Reported status of Transformation.
             type: object

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -56,6 +56,34 @@ spec:
             description: Desired state of the transformer.
             type: object
             properties:
+              sink:
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: [ref]
+                - required: [uri]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
@@ -111,34 +139,6 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
-              sink:
-                description: The destination of events emitted by the component. If left empty, the events will be sent back
-                  to the sender.
-                type: object
-                properties:
-                  ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
-                    type: object
-                    properties:
-                      apiVersion:
-                        type: string
-                      kind:
-                        type: string
-                      namespace:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                  uri:
-                    description: URI to use as the destination of events.
-                    type: string
-                    format: uri
-                oneOf:
-                - required: [ref]
-                - required: [uri]
           status:
             description: Reported status of the transformer.
             type: object

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -55,61 +55,6 @@ spec:
             description: Desired state of the TriggerMesh component.
             type: object
             properties:
-              adapterOverrides:
-                description: Kubernetes object parameters to apply on top of default adapter values.
-                type: object
-                properties:
-                  public:
-                    description: Adapter visibility scope.
-                    type: boolean
-                  resources:
-                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
-                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
-                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                  tolerations:
-                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          description: Taint key that the toleration applies to.
-                          type: string
-                        operator:
-                          description: Key's relationship to the value.
-                          type: string
-                          enum: [Exists, Equal]
-                        value:
-                          description: Taint value the toleration matches to.
-                          type: string
-                        effect:
-                          description: Taint effect to match.
-                          type: string
-                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
-                        tolerationSeconds:
-                          description: Period of time a toleration of effect NoExecute tolerates the taint.
-                          type: integer
-                          format: int64
               xslt:
                 description: XSLT used to transform incoming CloudEvents.
                 type: object
@@ -174,6 +119,61 @@ spec:
                 oneOf:
                 - required: [ref]
                 - required: [uri]
+              adapterOverrides:
+                description: Kubernetes object parameters to apply on top of default adapter values.
+                type: object
+                properties:
+                  public:
+                    description: Adapter visibility scope.
+                    type: boolean
+                  resources:
+                    description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Limits describes the maximum amount of compute resources allowed. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute resources required. If Requests is omitted
+                          for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                  tolerations:
+                    description: Pod tolerations, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: Taint key that the toleration applies to.
+                          type: string
+                        operator:
+                          description: Key's relationship to the value.
+                          type: string
+                          enum: [Exists, Equal]
+                        value:
+                          description: Taint value the toleration matches to.
+                          type: string
+                        effect:
+                          description: Taint effect to match.
+                          type: string
+                          enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                        tolerationSeconds:
+                          description: Period of time a toleration of effect NoExecute tolerates the taint.
+                          type: integer
+                          format: int64
             anyOf:
             - required: [xslt]
             - required: [allowPerEventXSLT]

--- a/hack/crd-update/crd-update.py
+++ b/hack/crd-update/crd-update.py
@@ -4,6 +4,10 @@ from ruamel.yaml import YAML, scanner, composer
 import sys
 
 yaml = YAML()
+# NOTE(antoineco) Lines may currently overflow this limit under some
+# circumstances due to a bug, which the author of the library expressed
+# interest in fixing in a future release.
+# Ref. https://sourceforge.net/p/ruamel-yaml/tickets/427/
 yaml.width = 120
 
 try:


### PR DESCRIPTION
I think it makes more sense to have the component-specific attributes at the beginning of the spec schema, and the less specific and more technical ones at the end.

The rationale is that users will want to see the most important spec attributes first when these are listed in order, as they will be if we start generating our docs from OpenAPI schemas.

Relates to https://github.com/triggermesh/docs/issues/259