### PR TITLE
Add `spec.sink` enforcement to `crd-update.py`

### DIFF
--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -122,26 +122,25 @@ spec:
                 - required: [uri]
                 properties:
                   ref:
-                    description: Ref points to an Addressable.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
-                        description: API version of the referent.
                         type: string
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                          This is optional field, it gets defaulted to the object holding it if left out.'
                         type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
                   uri:
-                    description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or
-                      a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                    description: URI to use as the destination of events.
                     type: string
+                    format: uri
           status:
             type: object
             properties:

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -141,26 +141,25 @@ spec:
                 - required: [uri]
                 properties:
                   ref:
-                    description: Ref points to an Addressable.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
-                        description: API version of the referent.
                         type: string
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                          This is optional field, it gets defaulted to the object holding it if left out.'
                         type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
                   uri:
-                    description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or
-                      a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                    description: URI to use as the destination of events.
                     type: string
+                    format: uri
           status:
             type: object
             properties:

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -149,33 +149,33 @@ spec:
                 required:
                 - extensions
               sink:
-                description: Sink is a reference to an object that will resolve to a uri to use as the sink.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 oneOf:
                 - required: [ref]
                 - required: [uri]
                 properties:
                   ref:
-                    description: Ref points to an Addressable.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
-                        description: API version of the referent.
                         type: string
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                          This is optional field, it gets defaulted to the object holding it if left out.'
                         type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
                   uri:
-                    description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or
-                      a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                    description: URI to use as the destination of events.
                     type: string
+                    format: uri
           status:
             type: object
             properties:

--- a/config/304-dataweavetransformation.yaml
+++ b/config/304-dataweavetransformation.yaml
@@ -155,12 +155,12 @@ spec:
                 type: string
                 enum: [application/json, application/xml]
               sink:
-                description: The destination of events transformed by this component.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 properties:
                   ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events. If
-                      left empty, the events will be sent back to the sender/source.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -115,7 +115,8 @@ spec:
                 description: The JSON Query to perform on the incoming event
                 type: string
               sink:
-                description: The destination of events transformed by this component.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 properties:
                   ref:

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -164,7 +164,8 @@ spec:
                   required:
                   - operation
               sink:
-                description: The destination of events sourced from the transformation object.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 properties:
                   ref:

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -112,7 +112,8 @@ spec:
                           type: integer
                           format: int64
               sink:
-                description: The destination of events transformed by this component.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 properties:
                   ref:

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -147,12 +147,12 @@ spec:
                 description: Whether the XSLT informed at the spec can be overriden at each CloudEvent.
                 type: boolean
               sink:
-                description: The destination of events transformed by this component.
+                description: The destination of events emitted by the component. If left empty, the events will be sent back
+                  to the sender.
                 type: object
                 properties:
                   ref:
-                    description: Reference to an addressable Kubernetes object to be used as the destination of events. If
-                      left empty, the events will be sent back to the sender/source.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:


### PR DESCRIPTION
I decided to sync `spec.sink` via the `crd-update.py` script, because a lot of components include this attribute.

The rationale is that users will want to see consistent descriptions for common attributes if we start generating our docs from OpenAPI schemas.

Relates to https://github.com/triggermesh/docs/issues/259

---

The script found 5 CRDs with schemas that slightly differ from the template.

I could also add other common attributes such as `spec.ceOverrides` or `spec.eventOptions`. Let me know what you think.