### PR TITLE
Print debug output about env state on E2E test failure

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -183,3 +183,24 @@ jobs:
       with:
         name: logs
         path: ${{ steps.logs.outputs.logs_dir }}
+
+    - name: Print debug information about environment
+      if: failure() && steps.e2e.outcome == 'failure'
+      run: |
+        echo '::group::TriggerMesh'
+        kubectl -n triggermesh get pods -l app=triggermesh-webhook -ojsonpath='{.items[*].status.containerStatuses}{"\n"}'
+        kubectl -n triggermesh get pods
+        kubectl -n triggermesh get events --sort-by='.lastTimestamp'
+        echo '::endgroup::'
+
+        echo '::group::Knative Serving'
+        kubectl -n knative-serving get pods -l app=webhook -ojsonpath='{.items[*].status.containerStatuses}{"\n"}'
+        kubectl -n knative-serving get pods
+        kubectl -n knative-serving get events --sort-by='.lastTimestamp'
+        echo '::endgroup::'
+
+        echo '::group::Knative Eventing'
+        kubectl -n knative-eventing get pods -l app=eventing-webhook -ojsonpath='{.items[*].status.containerStatuses}{"\n"}'
+        kubectl -n knative-eventing get pods
+        kubectl -n knative-eventing get events --sort-by='.lastTimestamp'
+        echo '::endgroup::'


### PR DESCRIPTION
Related to triggermesh/triggermesh#801

Helps understanding whether a failure could be related to a failure of the infrastructure, such as a webhook pod crashing, etc.

Example of output: https://github.com/antoineco/triggermesh/runs/6404566605?check_suite_focus=true#step:18:1

Already from this test run I got some very valuable information:

**TriggerMesh webhook is crashing**

```
NAME                                     READY   STATUS    RESTARTS   AGE
triggermesh-webhook-6f7bc4fd7f-rhnm5     1/1     Running   4          6m
```

```
LAST SEEN   TYPE      REASON          OBJECT                                        MESSAGE
5m56s       Normal    Started         pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Started container webhook
5m53s       Warning   Unhealthy       pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Liveness probe failed: Get "https://10.244.0.23:8443/": remote error: tls: unrecognized name
5m42s       Warning   Unhealthy       pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Liveness probe failed: Get "https://10.244.0.23:8443/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
5m31s       Warning   Unhealthy       pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Liveness probe failed: Get "https://10.244.0.23:8443/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
5m30s       Warning   Unhealthy       pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Liveness probe failed: Get "https://10.244.0.23:8443/": context deadline exceeded
5m30s       Warning   Unhealthy       pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Readiness probe failed: Get "https://10.244.0.23:8443/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
5m29s       Normal    Killing         pod/triggermesh-webhook-6f7bc4fd7f-rhnm5      Container webhook failed liveness probe, will be restarted
```

**Eventing webhook is crashing**

```
NAME                                    READY   STATUS    RESTARTS   AGE
eventing-webhook-5489f465f7-5vplh       1/1     Running   2          22m
```

```
LAST SEEN   TYPE      REASON           OBJECT                                       MESSAGE
6m1s        Warning   Unhealthy        pod/eventing-webhook-5489f465f7-5vplh        Liveness probe failed: Get "https://10.244.0.14:8443/": context deadline exceeded
6m          Warning   Unhealthy        pod/eventing-webhook-5489f465f7-5vplh        Liveness probe failed: Get "https://10.244.0.14:8443/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
6m          Normal    Killing          pod/eventing-webhook-5489f465f7-5vplh        Container eventing-webhook failed liveness probe, will be restarted
```

```json
{"level":"fatal","ts":1652354458.9846327,"logger":"fallback","caller":"injection/injection.go:63","msg":"Failed to start informers","error":"failed to wait for cache at index 3 to sync","stacktrace":"knative.dev/pkg/injection.EnableInjectionOrDie.func1
        knative.dev/pkg@v0.0.0-20211101212339-96c0204a70dc/injection/injection.go:63
knative.dev/pkg/injection/sharedmain.MainWithConfig
        knative.dev/pkg@v0.0.0-20211101212339-96c0204a70dc/injection/sharedmain/main.go:224
knative.dev/pkg/injection/sharedmain.MainWithContext
        knative.dev/pkg@v0.0.0-20211101212339-96c0204a70dc/injection/sharedmain/main.go:131
main.main
        knative.dev/eventing/cmd/webhook/main.go:260
runtime.main
        runtime/proc.go:255"}
```

Maybe we are exhausting the resources used by Pods while building TriggerMesh images.