### PR TITLE
Allow enough time for crashed pods to recover before starting E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -101,8 +101,12 @@ jobs:
         ko apply -f config/namespace/
         ko apply -f config/
 
-        kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-controller
-        kubectl -n triggermesh wait --timeout=1m --for=condition=Available deployments.apps/triggermesh-webhook
+        # Building TriggerMesh may cause existing Pods to crash due to resources
+        # exhaustion, including the TriggerMesh webhook. We need to allow enough
+        # time for Pods in CrashLoopBackoff to recover before moving on.
+        kubectl -n triggermesh      wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/part-of=triggermesh
+        kubectl -n knative-serving  wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-serving
+        kubectl -n knative-eventing wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-eventing
 
     - name: Install Ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
Fixes triggermesh/triggermesh#801

Now that I think about it, a lot of the errors we see in E2E tests (except for Azure Event Grid) occur relatively early in the test suite, never at the end. I don't know why I didn't look into Pods' statuses earlier, it would have saved me a lot of time troubleshooting E2E tests.