### PR TITLE
Remove `GCLOUD_PROJECT` secret in E2E CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -128,7 +128,6 @@ jobs:
         AWS_REGION: ${{ secrets.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
         GCLOUD_SERVICEACCOUNT_KEY: ${{ secrets.GCLOUD_SERVICEACCOUNT_KEY }}
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
The `google-github-actions/auth` Action already exports this environment variable, which value is read from the provided service account key (in different flavors, probably for compatibility reasons):

```yaml
env:
    CLOUDSDK_CORE_PROJECT: ***
    CLOUDSDK_PROJECT: ***
    GCLOUD_PROJECT: ***
    GCP_PROJECT: ***
    GOOGLE_CLOUD_PROJECT: ***
```

There is no need to manually set it.

If this gets merged, I will remove the corresponding repository secret as well.