### PR TITLE
Merge adapter builders into generic `AdapterBuilder` interface

### DIFF
--- a/pkg/extensions/reconciler/function/adapter.go
+++ b/pkg/extensions/reconciler/function/adapter.go
@@ -52,10 +52,10 @@ type adapterConfig struct {
 	obsConfig source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(rcl commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	f := rcl.(*v1alpha1.Function)
 

--- a/pkg/extensions/reconciler/function/reconciler_test.go
+++ b/pkg/extensions/reconciler/function/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/extensions/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -78,7 +79,7 @@ func newFunction() *v1alpha1.Function {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/dataweavetransformation/adapter.go
+++ b/pkg/flow/reconciler/dataweavetransformation/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/dataweavetransformation-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.DataWeaveTransformation)
 

--- a/pkg/flow/reconciler/dataweavetransformation/reconciler_test.go
+++ b/pkg/flow/reconciler/dataweavetransformation/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -96,7 +97,7 @@ func newTarget() *v1alpha1.DataWeaveTransformation {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/jqtransformation/adapter.go
+++ b/pkg/flow/reconciler/jqtransformation/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/jqtransformation-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.JQTransformation)
 

--- a/pkg/flow/reconciler/jqtransformation/reconciler_test.go
+++ b/pkg/flow/reconciler/jqtransformation/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.JQTransformation {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/synchronizer/adapter.go
+++ b/pkg/flow/reconciler/synchronizer/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/synchronizer-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.Synchronizer)
 

--- a/pkg/flow/reconciler/synchronizer/reconciler_test.go
+++ b/pkg/flow/reconciler/synchronizer/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis"
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
@@ -85,7 +86,7 @@ func newTarget() *v1alpha1.Synchronizer {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/transformation/adapter.go
+++ b/pkg/flow/reconciler/transformation/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/transformation-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.Transformation)
 

--- a/pkg/flow/reconciler/transformation/reconciler_test.go
+++ b/pkg/flow/reconciler/transformation/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -98,7 +99,7 @@ func newTarget() *v1alpha1.Transformation {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/xmltojsontransformation/adapter.go
+++ b/pkg/flow/reconciler/xmltojsontransformation/adapter.go
@@ -42,10 +42,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/xmltojsontransformation-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.XMLToJSONTransformation)
 

--- a/pkg/flow/reconciler/xmltojsontransformation/reconciler_test.go
+++ b/pkg/flow/reconciler/xmltojsontransformation/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.XMLToJSONTransformation {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/flow/reconciler/xslttransformation/adapter.go
+++ b/pkg/flow/reconciler/xslttransformation/adapter.go
@@ -45,10 +45,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/xslttransformation-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.XSLTTransformation)
 

--- a/pkg/flow/reconciler/xslttransformation/reconciler_test.go
+++ b/pkg/flow/reconciler/xslttransformation/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -99,7 +100,7 @@ func newTarget() *v1alpha1.XSLTTransformation {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -53,20 +53,16 @@ var knativeServingAnnotations = []string{
 	serving.UpdaterAnnotation,
 }
 
-// AdapterDeploymentBuilder provides all the necessary information for building
-// a component's adapter backed by a Deployment.
-type AdapterDeploymentBuilder interface {
-	BuildAdapter(rcl v1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error)
-}
-
-// AdapterServiceBuilder provides all the necessary information for building a
-// component's adapter backed by a Knative Service.
-type AdapterServiceBuilder interface {
-	BuildAdapter(rcl v1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error)
+// AdapterBuilder provides all the necessary information for building a
+// component's adapter object.
+type AdapterBuilder[T metav1.Object] interface {
+	BuildAdapter(rcl v1alpha1.Reconcilable, sinkURI *apis.URL) (T, error)
 }
 
 // ReconcileAdapter reconciles a receive adapter for a component instance.
-func (r *GenericDeploymentReconciler[T, L]) ReconcileAdapter(ctx context.Context, ab AdapterDeploymentBuilder) reconciler.Event {
+func (r *GenericDeploymentReconciler[T, L]) ReconcileAdapter(ctx context.Context,
+	ab AdapterBuilder[*appsv1.Deployment]) reconciler.Event {
+
 	rcl := v1alpha1.ReconcilableFromContext(ctx)
 
 	initStatus(rcl)
@@ -165,7 +161,9 @@ func (r *GenericDeploymentReconciler[T, L]) syncAdapterDeployment(ctx context.Co
 }
 
 // ReconcileAdapter reconciles a receive adapter for a component instance.
-func (r *GenericServiceReconciler[T, L]) ReconcileAdapter(ctx context.Context, ab AdapterServiceBuilder) reconciler.Event {
+func (r *GenericServiceReconciler[T, L]) ReconcileAdapter(ctx context.Context,
+	ab AdapterBuilder[*servingv1.Service]) reconciler.Event {
+
 	rcl := v1alpha1.ReconcilableFromContext(ctx)
 
 	initStatus(rcl)

--- a/pkg/routing/reconciler/filter/adapter.go
+++ b/pkg/routing/reconciler/filter/adapter.go
@@ -36,10 +36,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(rtr commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	return common.NewMTAdapterKnService(rtr,
 		resource.Image(r.adapterCfg.Image),

--- a/pkg/routing/reconciler/splitter/adapter.go
+++ b/pkg/routing/reconciler/splitter/adapter.go
@@ -36,10 +36,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(rtr commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	return common.NewMTAdapterKnService(rtr,
 		resource.Image(r.adapterCfg.Image),

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -46,10 +46,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCloudWatchLogsSource)
 

--- a/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/reconciler_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -84,7 +86,7 @@ func newEventSource() *v1alpha1.AWSCloudWatchLogsSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -52,10 +52,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCloudWatchSource)
 

--- a/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/reconciler_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -99,7 +101,7 @@ func newEventSource() *v1alpha1.AWSCloudWatchSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awscodecommitsource/adapter.go
+++ b/pkg/sources/reconciler/awscodecommitsource/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCodeCommitSource)
 

--- a/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/reconciler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/codecommit"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -81,7 +83,7 @@ func newEventSource() *v1alpha1.AWSCodeCommitSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCognitoIdentitySource)
 

--- a/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/reconciler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -79,7 +81,7 @@ func newEventSource() *v1alpha1.AWSCognitoIdentitySource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCognitoUserPoolSource)
 

--- a/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/reconciler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -79,7 +81,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSCognitoUserPoo
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSDynamoDBSource)
 

--- a/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/reconciler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -79,7 +81,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSDynamoDBSource
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSKinesisSource)
 

--- a/pkg/sources/reconciler/awskinesissource/reconciler_test.go
+++ b/pkg/sources/reconciler/awskinesissource/reconciler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/kinesis"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -79,7 +81,7 @@ func newEventSource(skipCEAtrributes ...interface{}) *v1alpha1.AWSKinesisSource 
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSPerformanceInsightsSource)
 

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSS3Source)
 

--- a/pkg/sources/reconciler/awssnssource/adapter.go
+++ b/pkg/sources/reconciler/awssnssource/adapter.go
@@ -35,10 +35,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),

--- a/pkg/sources/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler_test.go
@@ -120,7 +120,7 @@ func newEventSource() *v1alpha1.AWSSNSSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSSQSSource)
 

--- a/pkg/sources/reconciler/awssqssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssqssource/reconciler_test.go
@@ -94,7 +94,7 @@ func newEventSource() *v1alpha1.AWSSQSSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureactivitylogssource/adapter.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/adapter.go
@@ -46,10 +46,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureActivityLogsSource)
 

--- a/pkg/sources/reconciler/azureactivitylogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -102,7 +104,7 @@ func newEventSource() *v1alpha1.AzureActivityLogsSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureblobstoragesource/adapter.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureBlobStorageSource)
 

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
@@ -138,7 +138,7 @@ func newEventSource() *v1alpha1.AzureBlobStorageSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureeventgridsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventgridsource/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureEventGridSource)
 

--- a/pkg/sources/reconciler/azureeventgridsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureeventgridsource/reconciler_test.go
@@ -155,7 +155,7 @@ func newEventSource() *v1alpha1.AzureEventGridSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureeventhubsource/adapter.go
+++ b/pkg/sources/reconciler/azureeventhubsource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureEventHubSource)
 

--- a/pkg/sources/reconciler/azureeventhubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureeventhubsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -92,7 +94,7 @@ func newEventSource() *v1alpha1.AzureEventHubSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureIOTHubSource)
 	iotHubEnvs := []corev1.EnvVar{}

--- a/pkg/sources/reconciler/azureiothubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureiothubsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -82,7 +84,7 @@ func newEventSource() *v1alpha1.AzureIOTHubSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureQueueStorageSource)
 

--- a/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/adapter.go
@@ -39,10 +39,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureServiceBusQueueSource)
 

--- a/pkg/sources/reconciler/azureservicebusqueuesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -92,7 +94,7 @@ func newEventSource() *v1alpha1.AzureServiceBusQueueSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/adapter.go
@@ -39,10 +39,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureServiceBusTopicSource)
 

--- a/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
@@ -128,7 +128,7 @@ func newEventSource() *v1alpha1.AzureServiceBusTopicSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/cloudeventssource/adapter.go
+++ b/pkg/sources/reconciler/cloudeventssource/adapter.go
@@ -52,10 +52,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedSrc := src.(*v1alpha1.CloudEventsSource)
 

--- a/pkg/sources/reconciler/cloudeventssource/reconciler_test.go
+++ b/pkg/sources/reconciler/cloudeventssource/reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	commonv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
@@ -97,7 +98,7 @@ func newEventSource() *v1alpha1.CloudEventsSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudAuditLogsSource)
 

--- a/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -96,7 +98,7 @@ func newEventSource() *v1alpha1.GoogleCloudAuditLogsSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudBillingSource)
 

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -96,7 +98,7 @@ func newEventSource() *v1alpha1.GoogleCloudBillingSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudIoTSource)
 

--- a/pkg/sources/reconciler/googlecloudiotsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -100,7 +102,7 @@ func newEventSource() *v1alpha1.GoogleCloudIoTSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudPubSubSource)
 

--- a/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -94,7 +96,7 @@ func newEventSource() *v1alpha1.GoogleCloudPubSubSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudSourceRepositoriesSource)
 

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -99,7 +101,7 @@ func newEventSource() *v1alpha1.GoogleCloudSourceRepositoriesSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudStorageSource)
 

--- a/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -95,7 +97,7 @@ func newEventSource() *v1alpha1.GoogleCloudStorageSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/httppollersource/adapter.go
+++ b/pkg/sources/reconciler/httppollersource/adapter.go
@@ -56,7 +56,7 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.HTTPPollerSource)
 

--- a/pkg/sources/reconciler/httppollersource/reconciler_test.go
+++ b/pkg/sources/reconciler/httppollersource/reconciler_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
@@ -90,7 +92,7 @@ func newEventSource() *v1alpha1.HTTPPollerSource {
 			},
 			BasicAuthUsername: &username,
 			BasicAuthPassword: &commonv1alpha1.ValueFromField{
-				ValueFromSecret: &v1.SecretKeySelector{
+				ValueFromSecret: &corev1.SecretKeySelector{
 					Key: "key",
 				},
 			},
@@ -105,7 +107,7 @@ func newEventSource() *v1alpha1.HTTPPollerSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -60,10 +60,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/ibmmqsource-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.IBMMQSource)
 

--- a/pkg/sources/reconciler/ocimetricssource/adapter.go
+++ b/pkg/sources/reconciler/ocimetricssource/adapter.go
@@ -54,10 +54,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.OCIMetricsSource)
 

--- a/pkg/sources/reconciler/ocimetricssource/reconciler_test.go
+++ b/pkg/sources/reconciler/ocimetricssource/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -113,7 +114,7 @@ func newEventSource() *v1alpha1.OCIMetricsSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/salesforcesource/adapter.go
+++ b/pkg/sources/reconciler/salesforcesource/adapter.go
@@ -50,10 +50,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterDeploymentBuilder.
-var _ common.AdapterDeploymentBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterDeploymentBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.SalesforceSource)
 

--- a/pkg/sources/reconciler/salesforcesource/reconciler_test.go
+++ b/pkg/sources/reconciler/salesforcesource/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -98,7 +99,7 @@ func newEventSource() *v1alpha1.SalesforceSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterDeploymentBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*appsv1.Deployment] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -44,10 +44,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedSrc := src.(*v1alpha1.SlackSource)
 

--- a/pkg/sources/reconciler/slacksource/reconciler_test.go
+++ b/pkg/sources/reconciler/slacksource/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newEventSource() *v1alpha1.SlackSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/twiliosource/adapter.go
+++ b/pkg/sources/reconciler/twiliosource/adapter.go
@@ -35,10 +35,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),

--- a/pkg/sources/reconciler/twiliosource/reconciler_test.go
+++ b/pkg/sources/reconciler/twiliosource/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -73,7 +74,7 @@ func newEventSource() *v1alpha1.TwilioSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*servingv1.Service, error) {
 	typedSrc := src.(*v1alpha1.WebhookSource)
 

--- a/pkg/sources/reconciler/webhooksource/reconciler_test.go
+++ b/pkg/sources/reconciler/webhooksource/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newEventSource() *v1alpha1.WebhookSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/sources/reconciler/zendesksource/adapter.go
+++ b/pkg/sources/reconciler/zendesksource/adapter.go
@@ -36,10 +36,10 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	return common.NewMTAdapterKnService(src,
 		resource.Image(r.adapterCfg.Image),

--- a/pkg/sources/reconciler/zendesksource/reconciler_test.go
+++ b/pkg/sources/reconciler/zendesksource/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	commonv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/apis/sources"
@@ -105,7 +106,7 @@ func newEventSource() *v1alpha1.ZendeskSource {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/alibabaosstarget/adapter.go
+++ b/pkg/targets/reconciler/alibabaosstarget/adapter.go
@@ -46,10 +46,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/alibabaosstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AlibabaOSSTarget)
 

--- a/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/alibabaosstarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -78,7 +79,7 @@ func newTarget() *v1alpha1.AlibabaOSSTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awscomprehendtarget/adapter.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/adapter.go
@@ -44,10 +44,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awscomprehendtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSComprehendTarget)
 

--- a/pkg/targets/reconciler/awscomprehendtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -78,7 +79,7 @@ func newTarget() *v1alpha1.AWSComprehendTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awsdynamodbtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSDynamoDBTarget)
 

--- a/pkg/targets/reconciler/awsdynamodbtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSDynamoDBTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awseventbridgetarget/adapter.go
+++ b/pkg/targets/reconciler/awseventbridgetarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awseventbridgetarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSEventBridgeTarget)
 

--- a/pkg/targets/reconciler/awseventbridgetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awseventbridgetarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSEventBridgeTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awskinesistarget/adapter.go
+++ b/pkg/targets/reconciler/awskinesistarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awskinesistarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSKinesisTarget)
 

--- a/pkg/targets/reconciler/awskinesistarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awskinesistarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/kinesis"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSKinesisTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awslambdatarget/adapter.go
+++ b/pkg/targets/reconciler/awslambdatarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awslambdatarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSLambdaTarget)
 

--- a/pkg/targets/reconciler/awslambdatarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awslambdatarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSLambdaTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awss3target/adapter.go
+++ b/pkg/targets/reconciler/awss3target/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awss3target-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSS3Target)
 

--- a/pkg/targets/reconciler/awss3target/reconciler_test.go
+++ b/pkg/targets/reconciler/awss3target/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.AWSS3Target {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awssnstarget/adapter.go
+++ b/pkg/targets/reconciler/awssnstarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awssnstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSSNSTarget)
 

--- a/pkg/targets/reconciler/awssnstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awssnstarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/sns"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSSNSTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/awssqstarget/adapter.go
+++ b/pkg/targets/reconciler/awssqstarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/awssqstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AWSSQSTarget)
 

--- a/pkg/targets/reconciler/awssqstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/awssqstarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/aws/aws-sdk-go/service/sqs"
 
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.AWSSQSTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/azureeventhubstarget/adapter.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/adapter.go
@@ -45,10 +45,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/azureeventhubstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.AzureEventHubsTarget)
 

--- a/pkg/targets/reconciler/azureeventhubstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	commonv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
@@ -90,7 +91,7 @@ func newTarget() *v1alpha1.AzureEventHubsTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/cloudeventstarget/adapter.go
+++ b/pkg/targets/reconciler/cloudeventstarget/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/cloudeventstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.CloudEventsTarget)
 

--- a/pkg/targets/reconciler/cloudeventstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/cloudeventstarget/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	commonv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
@@ -97,7 +98,7 @@ func newTarget() *v1alpha1.CloudEventsTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/confluenttarget/adapter.go
+++ b/pkg/targets/reconciler/confluenttarget/adapter.go
@@ -41,10 +41,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/confluenttarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.ConfluentTarget)
 

--- a/pkg/targets/reconciler/confluenttarget/reconciler_test.go
+++ b/pkg/targets/reconciler/confluenttarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.ConfluentTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/datadogtarget/adapter.go
+++ b/pkg/targets/reconciler/datadogtarget/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/datadogtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.DatadogTarget)
 

--- a/pkg/targets/reconciler/datadogtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/datadogtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.DatadogTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/elasticsearchtarget/adapter.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/elasticsearchtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.ElasticsearchTarget)
 

--- a/pkg/targets/reconciler/elasticsearchtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.ElasticsearchTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/googlecloudfirestoretarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.GoogleCloudFirestoreTarget)
 

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.GoogleCloudFirestoreTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
@@ -42,10 +42,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/googlecloudstoragetarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.GoogleCloudStorageTarget)
 

--- a/pkg/targets/reconciler/googlecloudstoragetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.GoogleCloudStorageTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
@@ -42,10 +42,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/googlecloudworkflowstarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.GoogleCloudWorkflowsTarget)
 

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.GoogleCloudWorkflowsTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/googlesheettarget/adapter.go
+++ b/pkg/targets/reconciler/googlesheettarget/adapter.go
@@ -43,10 +43,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/googlesheettarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.GoogleSheetTarget)
 

--- a/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
+++ b/pkg/targets/reconciler/googlesheettarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.GoogleSheetTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/hasuratarget/adapter.go
+++ b/pkg/targets/reconciler/hasuratarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/hasuratarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.HasuraTarget)
 

--- a/pkg/targets/reconciler/hasuratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/hasuratarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.HasuraTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/httptarget/adapter.go
+++ b/pkg/targets/reconciler/httptarget/adapter.go
@@ -58,10 +58,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/httptarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.HTTPTarget)
 

--- a/pkg/targets/reconciler/httptarget/reconciler_test.go
+++ b/pkg/targets/reconciler/httptarget/reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -86,7 +87,7 @@ func newTarget() *v1alpha1.HTTPTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/ibmmqtarget/adapter.go
+++ b/pkg/targets/reconciler/ibmmqtarget/adapter.go
@@ -61,10 +61,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/ibmmqtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.IBMMQTarget)
 

--- a/pkg/targets/reconciler/ibmmqtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/ibmmqtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -80,7 +81,7 @@ func newTarget() *v1alpha1.IBMMQTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/infratarget/adapter.go
+++ b/pkg/targets/reconciler/infratarget/adapter.go
@@ -48,10 +48,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/infratarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.InfraTarget)
 

--- a/pkg/targets/reconciler/infratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/infratarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.InfraTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/jiratarget/adapter.go
+++ b/pkg/targets/reconciler/jiratarget/adapter.go
@@ -44,10 +44,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/jiratarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.JiraTarget)
 

--- a/pkg/targets/reconciler/jiratarget/reconciler_test.go
+++ b/pkg/targets/reconciler/jiratarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.JiraTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/logzmetricstarget/adapter.go
+++ b/pkg/targets/reconciler/logzmetricstarget/adapter.go
@@ -49,10 +49,10 @@ type adapterConfig struct {
 	Image string `envconfig:"OPENTELEMETRYTARGET_IMAGE" default:"gcr.io/triggermesh/opentelemetrytarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.LogzMetricsTarget)
 

--- a/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logzmetricstarget/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -86,7 +87,7 @@ func newTarget() *v1alpha1.LogzMetricsTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/logztarget/adapter.go
+++ b/pkg/targets/reconciler/logztarget/adapter.go
@@ -44,10 +44,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/logztarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.LogzTarget)
 

--- a/pkg/targets/reconciler/logztarget/reconciler_test.go
+++ b/pkg/targets/reconciler/logztarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -77,7 +78,7 @@ func newTarget() *v1alpha1.LogzTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/oracletarget/adapter.go
+++ b/pkg/targets/reconciler/oracletarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/oracletarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.OracleTarget)
 

--- a/pkg/targets/reconciler/oracletarget/reconciler_test.go
+++ b/pkg/targets/reconciler/oracletarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -82,7 +83,7 @@ func newTarget() *v1alpha1.OracleTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/salesforcetarget/adapter.go
+++ b/pkg/targets/reconciler/salesforcetarget/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/salesforcetarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.SalesforceTarget)
 

--- a/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
+++ b/pkg/targets/reconciler/salesforcetarget/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -83,7 +84,7 @@ func newTarget() *v1alpha1.SalesforceTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/sendgridtarget/adapter.go
+++ b/pkg/targets/reconciler/sendgridtarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/sendgridtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.SendGridTarget)
 

--- a/pkg/targets/reconciler/sendgridtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/sendgridtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.SendGridTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/slacktarget/adapter.go
+++ b/pkg/targets/reconciler/slacktarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/slacktarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.SlackTarget)
 

--- a/pkg/targets/reconciler/slacktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/slacktarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.SlackTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -47,10 +47,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/splunktarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.SplunkTarget)
 

--- a/pkg/targets/reconciler/splunktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/splunktarget/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -78,7 +79,7 @@ func newTarget() *v1alpha1.SplunkTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/tektontarget/adapter.go
+++ b/pkg/targets/reconciler/tektontarget/adapter.go
@@ -40,10 +40,10 @@ type adapterConfig struct {
 	ReapingInterval string `split_words:"true" default:"5m"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.TektonTarget)
 

--- a/pkg/targets/reconciler/tektontarget/reconciler_test.go
+++ b/pkg/targets/reconciler/tektontarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.TektonTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/twiliotarget/adapter.go
+++ b/pkg/targets/reconciler/twiliotarget/adapter.go
@@ -46,10 +46,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/twiliotarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.TwilioTarget)
 

--- a/pkg/targets/reconciler/twiliotarget/reconciler_test.go
+++ b/pkg/targets/reconciler/twiliotarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -75,7 +76,7 @@ func newTarget() *v1alpha1.TwilioTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/uipathtarget/adapter.go
+++ b/pkg/targets/reconciler/uipathtarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/uipathtarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.UiPathTarget)
 

--- a/pkg/targets/reconciler/uipathtarget/reconciler_test.go
+++ b/pkg/targets/reconciler/uipathtarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -82,7 +83,7 @@ func newTarget() *v1alpha1.UiPathTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}

--- a/pkg/targets/reconciler/zendesktarget/adapter.go
+++ b/pkg/targets/reconciler/zendesktarget/adapter.go
@@ -38,10 +38,10 @@ type adapterConfig struct {
 	Image string `default:"gcr.io/triggermesh/zendesktarget-adapter"`
 }
 
-// Verify that Reconciler implements common.AdapterServiceBuilder.
-var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
+// Verify that Reconciler implements common.AdapterBuilder.
+var _ common.AdapterBuilder[*servingv1.Service] = (*Reconciler)(nil)
 
-// BuildAdapter implements common.AdapterServiceBuilder.
+// BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) (*servingv1.Service, error) {
 	typedTrg := trg.(*v1alpha1.ZendeskTarget)
 

--- a/pkg/targets/reconciler/zendesktarget/reconciler_test.go
+++ b/pkg/targets/reconciler/zendesktarget/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rt "knative.dev/pkg/reconciler/testing"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/triggermesh/pkg/client/generated/injection/client/fake"
@@ -79,7 +80,7 @@ func newTarget() *v1alpha1.ZendeskTarget {
 
 // adapterBuilder returns a slim Reconciler containing only the fields accessed
 // by r.BuildAdapter().
-func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+func adapterBuilder(cfg *adapterConfig) common.AdapterBuilder[*servingv1.Service] {
 	return &Reconciler{
 		adapterCfg: cfg,
 	}


### PR DESCRIPTION
Merges `AdapterDeploymentBuilder` and `AdapterServiceBuilder`.
These two interfaces had the same signatures, just with a different concrete type, which makes them a perfect candidate for a generic interface.

The reason why I didn't include this change in triggermesh/triggermesh#882 is because it induces a lot of boilerplate changes to all `adapter.go` and `reconciler_test.go` files, which can make things harder to review.