### PR TITLE
Use global `TektonTargets` lister in reaper instead of sending List namespace calls to Kubernetes

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -448,15 +448,6 @@ rules:
   verbs:
   - update
 
-# List namespaces
-# Required by the TektonTarget reaper.
-- apiGroups:
-  - ''
-  resources:
-  - namespaces
-  verbs:
-  - list
-
 # Read credentials
 - apiGroups:
   - ''

--- a/pkg/targets/reconciler/tektontarget/controller.go
+++ b/pkg/targets/reconciler/tektontarget/controller.go
@@ -52,7 +52,7 @@ func NewController(
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
-		trgLister:  informer.Lister().TektonTargets,
+		trgLister:  informer.Lister(),
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 

--- a/pkg/targets/reconciler/tektontarget/reconciler.go
+++ b/pkg/targets/reconciler/tektontarget/reconciler.go
@@ -33,7 +33,7 @@ type Reconciler struct {
 	base       common.GenericServiceReconciler[*v1alpha1.TektonTarget, listersv1alpha1.TektonTargetNamespaceLister]
 	adapterCfg *adapterConfig
 
-	trgLister func(namespace string) listersv1alpha1.TektonTargetNamespaceLister
+	trgLister listersv1alpha1.TektonTargetLister
 }
 
 // Check that our Reconciler implements Interface


### PR DESCRIPTION
Closes triggermesh/triggermesh#886

Instead of listing TektonTargets in two steps:

```golang
namespaces, _ := k8sclient.Get(ctx).CoreV1().Namespaces().List()
for _, ns := range namespaces.Items {
	targets, err := r.trgLister(ns.Name).List(labels.Everything())
	// ...
}
```

just list them all from the cache in a single step:

```golang
targets, _ := r.trgLister.List(labels.Everything())
```