### PR TITLE
Do not run `go mod download` in Dockerfiles

### DIFF
--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -27,10 +27,6 @@ ENV CGO_CFLAGS="-I$MQ_INSTALLATION_PATH/inc"
 
 WORKDIR /go/triggermesh
 
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
 COPY . .
 
 RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -27,10 +27,6 @@ ENV CGO_CFLAGS="-I$MQ_INSTALLATION_PATH/inc"
 
 WORKDIR /go/triggermesh
 
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
 COPY . .
 
 RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqtarget-adapter ./cmd/ibmmqtarget-adapter


### PR DESCRIPTION
Closes #800

### Benchmark

#### Before

```console
$ docker image build --no-cache -t before -f cmd/ibmmqsource-adapter/Dockerfile .
 => [builder 6/8] RUN go mod download                                                                        57.5s
 => [builder 8/8] RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter   81.2s
```

Total: `138.7s`

#### After

```console
$ docker image build --no-cache -t after-f cmd/ibmmqsource-adapter/Dockerfile .
 => [builder 5/5] RUN GOOS=linux GOARCH=amd64 go build -v -o ibmmqsource-adapter ./cmd/ibmmqsource-adapter   94.9s
```

Total: `94.9s`