### PR TITLE
Let CPU limit dictate number of SQS processors

### DIFF
--- a/cmd/awssqssource-adapter/main.go
+++ b/cmd/awssqssource-adapter/main.go
@@ -17,30 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"runtime"
-
 	"knative.dev/eventing/pkg/adapter/v2"
 
 	"github.com/triggermesh/triggermesh/pkg/sources/adapter/awssqssource"
 )
 
 func main() {
-	setMaxProcs(runtime.NumCPU())
-
 	adapter.Main("awssqssource", awssqssource.NewEnvConfig, awssqssource.NewAdapter)
-}
-
-// setMaxProcs sets the number of threads that can be used by the current
-// process.
-//
-// Knative uses uber-go/automaxprocs to automatically determine the number of
-// threads (GOMAXPROCS) available to the process based on CPU quotas (e.g.
-// 'cpu.request <= 1' translates to 1 thread, regardless of the number of
-// physical cores).
-// This event source has a very predictable CPU profile: it spends most of its
-// time sending network requests without performing any computation on the
-// results, so we assume the defined CPU limit allows all CPU cores to be used
-// without starving on CPU time.
-func setMaxProcs(procs int) int {
-	return runtime.GOMAXPROCS(procs)
 }

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -18,7 +18,6 @@ package awss3source
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	kr "k8s.io/apimachinery/pkg/api/resource"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -66,15 +65,5 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.Port(healthPortName, 8080),
 
 		resource.StartupProbe("/health", healthPortName),
-
-		// See awssqssource/adapter.go for an justification for these values.
-		resource.Requests(
-			kr.NewMilliQuantity(90, kr.DecimalSI),     // 90m
-			kr.NewQuantity(1024*1024*30, kr.BinarySI), // 30Mi
-		),
-		resource.Limits(
-			kr.NewMilliQuantity(1000, kr.DecimalSI),   // 1
-			kr.NewQuantity(1024*1024*45, kr.BinarySI), // 45Mi
-		),
 	), nil
 }

--- a/pkg/sources/reconciler/awssqssource/adapter.go
+++ b/pkg/sources/reconciler/awssqssource/adapter.go
@@ -19,7 +19,6 @@ package awssqssource
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kr "k8s.io/apimachinery/pkg/api/resource"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -66,17 +65,6 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.Port(healthPortName, 8080),
 
 		resource.StartupProbe("/health", healthPortName),
-
-		// CPU throttling can be observed below a limit of 1,
-		// although the CPU usage under load remains below 400m.
-		resource.Requests(
-			kr.NewMilliQuantity(90, kr.DecimalSI),     // 90m
-			kr.NewQuantity(1024*1024*30, kr.BinarySI), // 30Mi
-		),
-		resource.Limits(
-			kr.NewMilliQuantity(1000, kr.DecimalSI),   // 1
-			kr.NewQuantity(1024*1024*45, kr.BinarySI), // 45Mi
-		),
 	), nil
 }
 


### PR DESCRIPTION
Revert to letting `uber-go/automaxprocs` determine the ideal `GOMAXPROCS` value, which can be influenced by setting a CPU limit manually.

Until now, the SQS source was deliberately ignoring cgroups and used all the available physical CPUs on the host to ensure that we were reaching a maximum performance, at the risk to unnecessarily causing higher AWS bills (more parallel processes = more requests to AWS).
Now that we have `adapterOverrides`, we can simply let users decide for themselves.

Please note that this is not a silver bullet. In absence of an explicit limit, the number of processors will still be based on the physical number of CPUs, so this source _will_ remain expensive to run by default until #37 is addressed as well.

Remotely related to #909
Remotely related to #37