### PR TITLE
Do not use reference to loop iterator variable

### DIFF
--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -365,16 +365,17 @@ func adapterOverrideOptions(overrides *v1alpha1.AdapterOverrides) []resource.Obj
 }
 
 // toQuantity converts corev1.ResourceList to separate CPU and Memory quantities.
-func toQuantity(resources corev1.ResourceList) (*kres.Quantity, *kres.Quantity) {
-	var cpu, memory *kres.Quantity
-
+func toQuantity(resources corev1.ResourceList) (cpu *kres.Quantity, mem *kres.Quantity) {
 	for k, v := range resources {
 		switch k {
 		case corev1.ResourceCPU:
+			v := v
 			cpu = &v
 		case corev1.ResourceMemory:
-			memory = &v
+			v := v
+			mem = &v
 		}
 	}
-	return cpu, memory
+
+	return
 }


### PR DESCRIPTION
Fixes #912

https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable