### PR TITLE
Prevent segfault when a matching adapter has no owner

### DIFF
--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -240,6 +240,9 @@ func (r *GenericDeploymentReconciler[T, L]) findAdapter(rcl v1alpha1.Reconcilabl
 
 	for _, d := range depls {
 		objOwner := metav1.GetControllerOfNoCopy(d)
+		if objOwner == nil {
+			continue
+		}
 
 		if objOwner.UID == owner.UID {
 			return d, nil
@@ -441,6 +444,9 @@ func (r *GenericServiceReconciler[T, L]) findAdapter(rcl v1alpha1.Reconcilable,
 
 	for _, s := range svcs {
 		objOwner := metav1.GetControllerOfNoCopy(s)
+		if objOwner == nil {
+			continue
+		}
 
 		if objOwner.UID == owner.UID {
 			return s, nil


### PR DESCRIPTION
Fixes #911

A malicious user could create a deployment/service with the same labels as the ones expected by the controller, but no ownerReference, and cause a segmentation violation.

This happened to a (non-malicious 😉) user in Slack who tried to fiddle with the adapter deployment and caused a crash of the controller.