### PR TITLE
Watch Pod changes in Deployment reconciler to propagate their status quickly

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -499,13 +499,21 @@ rules:
   - create
   - update
 
-# Determine the exact reason why Deployments fail
+# Observe status of Pods and their ancestors
 - apiGroups:
   - ''
   resources:
   - pods
   verbs:
   - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
+  - watch
 
 ---
 

--- a/pkg/apis/common/v1alpha1/status_conditions.go
+++ b/pkg/apis/common/v1alpha1/status_conditions.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"
-	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
 
 	"knative.dev/eventing/pkg/apis/duck"
 	"knative.dev/pkg/apis"
@@ -151,11 +151,11 @@ func (m *StatusManager) MarkRBACNotBound() {
 // PropagateDeploymentAvailability uses the readiness of the provided
 // Deployment to determine whether the Deployed condition should be marked as
 // True or False.
-// Given an optional PodInterface, the status of dependant Pods is inspected to
-// generate a more meaningful failure reason in case of non-ready status of the
-// Deployment.
+// Given an optional PodLister interface, the status of dependant Pods is
+// inspected to generate a more meaningful failure reason in case of non-ready
+// status of the Deployment.
 func (m *StatusManager) PropagateDeploymentAvailability(ctx context.Context,
-	d *appsv1.Deployment, pi coreclientv1.PodInterface) {
+	d *appsv1.Deployment, pl corelistersv1.PodNamespaceLister) {
 
 	// Deployments are not addressable
 	m.Address = nil
@@ -180,8 +180,8 @@ func (m *StatusManager) PropagateDeploymentAvailability(ctx context.Context,
 		}
 	}
 
-	if pi != nil {
-		ws, err := status.DeploymentPodsWaitingState(d, pi)
+	if pl != nil {
+		ws, err := status.DeploymentPodsWaitingState(d, pl)
 		if err != nil {
 			logging.FromContext(ctx).Warn("Unable to look up statuses of dependant Pods", zap.Error(err))
 		} else if ws != nil {

--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -122,7 +122,7 @@ func (r *GenericDeploymentReconciler[T, L]) reconcileAdapter(ctx context.Context
 
 	currentAdapter, err := getOrCreateAdapter(ctx, r.Lister, r.Client, desiredAdapter, gvk)
 	if err != nil {
-		rcl.GetStatusManager().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodClient(rcl.GetNamespace()))
+		rcl.GetStatusManager().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodLister(rcl.GetNamespace()))
 		return err
 	}
 
@@ -134,7 +134,7 @@ func (r *GenericDeploymentReconciler[T, L]) reconcileAdapter(ctx context.Context
 		return err
 	}
 
-	rcl.GetStatusManager().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodClient(rcl.GetNamespace()))
+	rcl.GetStatusManager().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodLister(rcl.GetNamespace()))
 
 	return nil
 }

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -121,9 +121,9 @@ func NewTestDeploymentReconciler[T kmeta.OwnerRefable, L common.Lister[T]](ctx c
 
 	return common.GenericDeploymentReconciler[T, L]{
 		SinkResolver:          resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
-		Lister:                ls.GetDeploymentLister().Deployments,
 		Client:                fakek8sinjectionclient.Get(ctx).AppsV1().Deployments,
-		PodClient:             fakek8sinjectionclient.Get(ctx).CoreV1().Pods,
+		Lister:                ls.GetDeploymentLister().Deployments,
+		PodLister:             ls.GetPodLister().Pods,
 		GenericRBACReconciler: newTestRBACReconciler(ctx, ls, ownersLister),
 	}
 }

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -109,6 +109,11 @@ func (l *Listers) GetDeploymentLister() appslistersv1.DeploymentLister {
 	return appslistersv1.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
 }
 
+// GetPodLister returns a lister for Pod objects.
+func (l *Listers) GetPodLister() corelistersv1.PodLister {
+	return corelistersv1.NewPodLister(l.IndexerFor(&corev1.Pod{}))
+}
+
 // GetServiceLister returns a lister for Service objects.
 func (l *Listers) GetServiceLister() servinglistersv1.ServiceLister {
 	return servinglistersv1.NewServiceLister(l.IndexerFor(&servingv1.Service{}))

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awscloudwatchlogssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awscloudwatchsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awscodecommitsource/controller_test.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awscodecommitsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awscognitoidentitysource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awscognitouserpoolsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awsdynamodbsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awskinesissource/controller_test.go
+++ b/pkg/sources/reconciler/awskinesissource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awskinesissource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awsperformanceinsightssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/awss3source/controller_test.go
+++ b/pkg/sources/reconciler/awss3source/controller_test.go
@@ -19,12 +19,13 @@ package awss3source
 import (
 	"testing"
 
-	rt "github.com/triggermesh/triggermesh/pkg/reconciler/testing"
+	. "github.com/triggermesh/triggermesh/pkg/reconciler/testing"
 
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awss3source/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,10 +33,13 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		rt.TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {
-		rt.TestControllerConstructorFailures(t, NewController)
+		TestControllerConstructorFailures(t, NewController)
 	})
 }

--- a/pkg/sources/reconciler/awssqssource/controller_test.go
+++ b/pkg/sources/reconciler/awssqssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/awssqssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureactivitylogssource/controller_test.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureactivitylogssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureblobstoragesource/controller_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureblobstoragesource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureeventgridsource/controller_test.go
+++ b/pkg/sources/reconciler/azureeventgridsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureeventgridsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureeventhubsource/controller_test.go
+++ b/pkg/sources/reconciler/azureeventhubsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureeventhubsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureiothubsource/controller_test.go
+++ b/pkg/sources/reconciler/azureiothubsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureiothubsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/azureservicebustopicsource/controller_test.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/azureservicebustopicsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/cloudeventssource/controller_test.go
+++ b/pkg/sources/reconciler/cloudeventssource/controller_test.go
@@ -24,6 +24,7 @@ import (
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/cloudeventssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudauditlogssource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudauditlogssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudbillingsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudbillingsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudiotsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudiotsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudpubsubsource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudpubsubsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudsourcerepositoriessource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/googlecloudstoragesource/controller_test.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/googlecloudstoragesource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/httppollersource/controller_test.go
+++ b/pkg/sources/reconciler/httppollersource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/httppollersource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/ocimetricssource/controller_test.go
+++ b/pkg/sources/reconciler/ocimetricssource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/ocimetricssource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {

--- a/pkg/sources/reconciler/salesforcesource/controller_test.go
+++ b/pkg/sources/reconciler/salesforcesource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/triggermesh/triggermesh/pkg/client/generated/injection/informers/sources/v1alpha1/salesforcesource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -32,7 +33,10 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("No failure", func(t *testing.T) {
-		TestControllerConstructor(t, NewController)
+		TestControllerConstructor(t, NewController,
+			// we expect "Pod" as an additional informer in this reconciler implementation
+			ExpectExtraInformers(1),
+		)
 	})
 
 	t.Run("Failure cases", func(t *testing.T) {


### PR DESCRIPTION
Closes triggermesh/triggermesh#884

Adds a Pod informer to the generic Deployment reconciler and attaches an event handler which, on status changes, finds the outermost ancestor of the Pod (TriggerMesh custom object) and enqueues it.
This results in a rapid propagation of Pods' state changes to their respective TriggerMesh object status.

This is pretty much what Knative Serving does with Services / Revisions. We do it here with Deployments.

> **Note**
> There may be 34 changed files in this PR, but 27 of them are this change to account for the new informer:
>
> ```patch
> -	TestControllerConstructor(t, NewController)
> +	TestControllerConstructor(t, NewController,
> +		// we expect "Pod" as an additional informer in this reconciler implementation
> +		ExpectExtraInformers(1),
> +	)
> ```

### Demo

I created a source with a reference to a secret that didn't exist, and the status of that source transitioned immediately with the different states of the Pod:

```console
$ kubectl get foosources.sources.triggermesh.io -w
NAME     READY   REASON               SINK
sample
sample   False   AdapterUnavailable   http://event-display.default.svc.cluster.local
sample   False   ContainerCreating    http://event-display.default.svc.cluster.local
sample   False   MissingSecret        http://event-display.default.svc.cluster.local
```

The same mechanism would report errors such as missing images, etc. Basically anything that can prevent a Pod from either starting or being created.

Prior to this change, the status would remain `AdapterUnavailable` for several minutes, until a watch eventually expired and the status got re-checked.
This gives users a much quicker feedback about what's going on with the adapter.