### PR TITLE
Add Event Processing stat reporter to all components

### DIFF
--- a/pkg/apis/targets/register.go
+++ b/pkg/apis/targets/register.go
@@ -147,6 +147,11 @@ var (
 		Group:    GroupName,
 		Resource: "logzmetricstargets",
 	}
+	// OpenTelemetryTargetResource respresents an event target for OpenTelemetry.
+	OpenTelemetryTargetResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "opentelemetrytargets",
+	}
 	// OracleTargetResource respresents an event target for Oracle.
 	OracleTargetResource = schema.GroupResource{
 		Group:    GroupName,

--- a/pkg/flow/adapter/dataweavetransformation/adapter.go
+++ b/pkg/flow/adapter/dataweavetransformation/adapter.go
@@ -72,6 +72,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		Name:          envAcc.GetName(),
 	}
 
+	metrics.MustRegisterEventProcessingStatsView()
+
 	env := envAcc.(*envAccessor)
 
 	if err := env.validate(); err != nil {

--- a/pkg/flow/adapter/jqtransformation/adapter.go
+++ b/pkg/flow/adapter/jqtransformation/adapter.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
@@ -40,6 +41,8 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		Namespace:     envAcc.GetNamespace(),
 		Name:          envAcc.GetName(),
 	}
+
+	metrics.MustRegisterEventProcessingStatsView()
 
 	env := envAcc.(*envAccessor)
 
@@ -63,7 +66,9 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		replier:  replier,
 		ceClient: ceClient,
 		logger:   logger,
-		mt:       mt,
+
+		mt: mt,
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -76,7 +81,9 @@ type jqadapter struct {
 	replier  *targetce.Replier
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
-	mt       *pkgadapter.MetricTag
+
+	mt *pkgadapter.MetricTag
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Start is a blocking function and will return if an error occurs

--- a/pkg/flow/adapter/transformation/adapter.go
+++ b/pkg/flow/adapter/transformation/adapter.go
@@ -76,9 +76,9 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		Name:          envAcc.GetName(),
 	}
 
-	env := envAcc.(*envConfig)
-
 	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envConfig)
 
 	trnContext, trnData := []v1alpha1.Transform{}, []v1alpha1.Transform{}
 	err := json.Unmarshal([]byte(env.TransformationContext), &trnContext)
@@ -108,8 +108,9 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		ContextPipeline: contextPl,
 		DataPipeline:    dataPl,
 
-		mt:     mt,
-		sr:     metrics.MustNewEventProcessingStatsReporter(mt),
+		mt: mt,
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
+
 		sink:   env.Sink,
 		client: ceClient,
 	}

--- a/pkg/flow/adapter/xmltojsontransformation/adapter.go
+++ b/pkg/flow/adapter/xmltojsontransformation/adapter.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow"
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
@@ -64,6 +65,8 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		Name:          envAcc.GetName(),
 	}
 
+	metrics.MustRegisterEventProcessingStatsView()
+
 	env := envAcc.(*envAccessor)
 
 	replier, err := targetce.New(env.Component, logger.Named("replier"),
@@ -79,7 +82,9 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		replier:  replier,
 		ceClient: ceClient,
 		logger:   logger,
-		mt:       mt,
+
+		mt: mt,
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -90,7 +95,9 @@ type Adapter struct {
 	replier  *targetce.Replier
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
-	mt       *pkgadapter.MetricTag
+
+	mt *pkgadapter.MetricTag
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Start is a blocking function and will return if an error occurs

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -23,8 +23,7 @@ import (
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/metrics/metricstest"
 
-	// Essential. Initializes a Prometheus metrics exporter for tests.
-	_ "knative.dev/pkg/metrics/testing"
+	metricstesting "github.com/triggermesh/triggermesh/pkg/metrics/testing"
 
 	. "github.com/triggermesh/triggermesh/pkg/metrics"
 )
@@ -51,7 +50,7 @@ func TestEventProcessingStatsReporter(t *testing.T) {
 	}
 
 	t.Run("record without tags", func(t *testing.T) {
-		resetMetrics(t)
+		metricstesting.ResetMetrics(t)
 
 		st.ReportProcessingSuccess()
 		st.ReportProcessingError(true)
@@ -79,7 +78,7 @@ func TestEventProcessingStatsReporter(t *testing.T) {
 	})
 
 	t.Run("record with tags", func(t *testing.T) {
-		resetMetrics(t)
+		metricstesting.ResetMetrics(t)
 
 		const tEventType = "test.type.v0"
 		tagEventType := TagEventType(tEventType)
@@ -114,7 +113,7 @@ func TestEventProcessingStatsReporter(t *testing.T) {
 	})
 
 	t.Run("latency distribution", func(t *testing.T) {
-		resetMetrics(t)
+		metricstesting.ResetMetrics(t)
 
 		st.ReportProcessingLatency(12 * time.Millisecond)
 		st.ReportProcessingLatency(374 * time.Millisecond)
@@ -128,25 +127,6 @@ func TestEventProcessingStatsReporter(t *testing.T) {
 			2250.0,
 		)
 	})
-}
-
-// OpenCensus metrics carry global state that need to be reset between unit tests.
-func resetMetrics(t *testing.T) {
-	t.Helper()
-
-	metricstest.Unregister(
-		"event_processing_success_count",
-		"event_processing_error_count",
-		"event_processing_latencies",
-	)
-
-	MustRegisterEventProcessingStatsView()
-
-	metricstest.AssertNoMetric(t,
-		"event_processing_success_count",
-		"event_processing_error_count",
-		"event_processing_latencies",
-	)
 }
 
 // appendTags returns a copy of the given metrics tags with extra key/values inserted.

--- a/pkg/metrics/testing/metrics.go
+++ b/pkg/metrics/testing/metrics.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"knative.dev/pkg/metrics/metricstest"
+
+	// Essential. Initializes a Prometheus metrics exporter for tests.
+	_ "knative.dev/pkg/metrics/testing"
+
+	"github.com/triggermesh/triggermesh/pkg/metrics"
+)
+
+// ResetMetrics resets the global state of OpenCensus metrics.
+// Must be called between unit tests.
+func ResetMetrics(t *testing.T) {
+	t.Helper()
+
+	UnregisterMetrics()
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	metricstest.AssertNoMetric(t,
+		"event_processing_success_count",
+		"event_processing_error_count",
+		"event_processing_latencies",
+	)
+}
+
+// UnregisterMetrics unregisters the metrics that were registered in the global
+// state of OpenCensus.
+// Can be used instead of ResetMetrics to avoid panics in tests that already
+// call metrics.MustRegisterEventProcessingStatsView.
+func UnregisterMetrics() {
+	metricstest.Unregister(
+		"event_processing_success_count",
+		"event_processing_error_count",
+		"event_processing_latencies",
+	)
+}

--- a/pkg/targets/adapter/alibabaosstarget/adapter.go
+++ b/pkg/targets/adapter/alibabaosstarget/adapter.go
@@ -21,21 +21,34 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"go.uber.org/zap"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
 // NewTarget adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AlibabaOSSTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	replier, err := targetce.New(env.Component, logger.Named("replier"),
 		targetce.ReplierWithStatefulHeaders(env.BridgeIdentifier),
@@ -57,6 +70,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		replier:  replier,
 		ceClient: ceClient,
 		logger:   logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -69,6 +84,8 @@ type ossAdapter struct {
 	replier  *targetce.Replier
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Returns if stopCh is closed or Send() returns an error.

--- a/pkg/targets/adapter/awsdynamodbtarget/adapter.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/adapter.go
@@ -23,22 +23,34 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/logging"
+
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/logging"
-
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
 // NewTarget Adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AWSDynamoDBTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	a := MustParseARN(env.AwsTargetArn)
 
@@ -61,6 +73,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		discardCEContext: env.DiscardCEContext,
 		ceClient:         ceClient,
 		logger:           logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -75,6 +89,8 @@ type adapter struct {
 	discardCEContext bool
 	ceClient         cloudevents.Client
 	logger           *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 func (a *adapter) Start(ctx context.Context) error {

--- a/pkg/targets/adapter/awslambdatarget/adapter.go
+++ b/pkg/targets/adapter/awslambdatarget/adapter.go
@@ -23,19 +23,32 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/logging"
+
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/logging"
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
 // NewTarget Adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AWSLambdaTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	a := MustParseARN(env.AwsTargetArn)
 
@@ -52,6 +65,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		ceClient:         ceClient,
 
 		logger: logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -66,6 +81,8 @@ type adapter struct {
 
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 func (a *adapter) Start(ctx context.Context) error {

--- a/pkg/targets/adapter/awss3target/adapter.go
+++ b/pkg/targets/adapter/awss3target/adapter.go
@@ -25,21 +25,33 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/logging"
+
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/logging"
-
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
 // NewTarget Adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AWSS3TargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	a := MustParseARN(env.AwsTargetArn)
 
@@ -61,6 +73,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		discardCEContext: env.DiscardCEContext,
 		ceClient:         ceClient,
 		logger:           logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -74,6 +88,8 @@ type adapter struct {
 	discardCEContext bool
 	ceClient         cloudevents.Client
 	logger           *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 func (a *adapter) Start(ctx context.Context) error {

--- a/pkg/targets/adapter/awssnstarget/adapter.go
+++ b/pkg/targets/adapter/awssnstarget/adapter.go
@@ -23,20 +23,33 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/logging"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/logging"
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
 // NewTarget Adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AWSSNSTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	a := MustParseARN(env.AwsTargetArn)
 
@@ -53,6 +66,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		discardCEContext: env.DiscardCEContext,
 		ceClient:         ceClient,
 		logger:           logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -66,6 +81,8 @@ type adapter struct {
 	discardCEContext bool
 	ceClient         cloudevents.Client
 	logger           *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 func (a *adapter) Start(ctx context.Context) error {

--- a/pkg/targets/adapter/awssqstarget/adapter.go
+++ b/pkg/targets/adapter/awssqstarget/adapter.go
@@ -23,20 +23,34 @@ import (
 
 	"go.uber.org/zap"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/logging"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/logging"
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
 // NewTarget Adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.AWSSQSTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
+
 	a := MustParseARN(env.AwsTargetArn)
 
 	sqsSession := session.Must(session.NewSession(
@@ -52,6 +66,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 
 		ceClient: ceClient,
 		logger:   logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -65,6 +81,8 @@ type adapter struct {
 	discardCEContext bool
 	ceClient         cloudevents.Client
 	logger           *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 func (a *adapter) Start(ctx context.Context) error {

--- a/pkg/targets/adapter/cloudeventstarget/adapter_test.go
+++ b/pkg/targets/adapter/cloudeventstarget/adapter_test.go
@@ -23,12 +23,11 @@ import (
 	"testing"
 	"time"
 
-	// Essential. Initializes a Prometheus metrics exporter for tests.
-	_ "knative.dev/pkg/metrics/testing"
-
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	adaptertest "knative.dev/eventing/pkg/adapter/v2/test"
 	loggingtesting "knative.dev/pkg/logging/testing"
@@ -37,6 +36,7 @@ import (
 	fakefs "github.com/triggermesh/triggermesh/pkg/adapter/fs/fake"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/metrics"
+	metricstesting "github.com/triggermesh/triggermesh/pkg/metrics/testing"
 )
 
 const (
@@ -88,7 +88,7 @@ func TestCloudEventsDispatch(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			resetMetrics(t)
+			metricstesting.ResetMetrics(t)
 
 			metricTags := map[string]string{
 				"resource_group": targets.CloudEventsTargetResource.String(),
@@ -166,23 +166,4 @@ func TestCloudEventsDispatch(t *testing.T) {
 			}
 		})
 	}
-}
-
-// OpenCensus metrics carry global state that need to be reset between unit tests.
-func resetMetrics(t *testing.T) {
-	t.Helper()
-
-	metricstest.Unregister(
-		"event_processing_success_count",
-		"event_processing_error_count",
-		"event_processing_latencies",
-	)
-
-	metrics.MustRegisterEventProcessingStatsView()
-
-	metricstest.AssertNoMetric(t,
-		"event_processing_success_count",
-		"event_processing_error_count",
-		"event_processing_latencies",
-	)
 }

--- a/pkg/targets/adapter/elasticsearchtarget/adapter.go
+++ b/pkg/targets/adapter/elasticsearchtarget/adapter.go
@@ -23,23 +23,35 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/elastic/go-elasticsearch/v7"
-	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"go.uber.org/zap"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"go.uber.org/zap"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
 // NewTarget adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.ElasticsearchTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	replier, err := targetce.New(env.Component, logger.Named("replier"),
 		targetce.ReplierWithStatefulHeaders(env.BridgeIdentifier),
@@ -56,6 +68,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		discardCEContext: env.DiscardCEContext,
 		ceClient:         ceClient,
 		logger:           logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -72,6 +86,8 @@ type esAdapter struct {
 	replier  *targetce.Replier
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Returns if stopCh is closed or Send() returns an error.

--- a/pkg/targets/adapter/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/adapter/googlecloudstoragetarget/adapter.go
@@ -20,23 +20,35 @@ import (
 	"context"
 	"encoding/json"
 
+	"go.uber.org/zap"
+
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"go.uber.org/zap"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
 // NewTarget adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.GoogleCloudFirestoreTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	// Creates a client.
 	client, err := storage.NewClient(ctx, option.WithCredentialsJSON([]byte(env.Credentials)))
@@ -60,6 +72,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		replier:          replier,
 		ceClient:         ceClient,
 		logger:           logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -73,6 +87,8 @@ type googlecloudstorageAdapter struct {
 	replier          *targetce.Replier
 	ceClient         cloudevents.Client
 	logger           *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Returns if stopCh is closed or Send() returns an error.

--- a/pkg/targets/adapter/logztarget/adapter.go
+++ b/pkg/targets/adapter/logztarget/adapter.go
@@ -19,21 +19,34 @@ package logztarget
 import (
 	"context"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/logzio/logzio-go"
 	"go.uber.org/zap"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/logging"
 
+	"github.com/logzio/logzio-go"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/targets"
 	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/metrics"
 	targetce "github.com/triggermesh/triggermesh/pkg/targets/adapter/cloudevents"
 )
 
 // NewTarget adapter implementation
 func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
-	env := envAcc.(*envAccessor)
 	logger := logging.FromContext(ctx)
+
+	mt := &pkgadapter.MetricTag{
+		ResourceGroup: targets.LogzTargetResource.String(),
+		Namespace:     envAcc.GetNamespace(),
+		Name:          envAcc.GetName(),
+	}
+
+	metrics.MustRegisterEventProcessingStatsView()
+
+	env := envAcc.(*envAccessor)
 
 	replier, err := targetce.New(env.Component, logger.Named("replier"),
 		targetce.ReplierWithStatefulHeaders(env.BridgeIdentifier),
@@ -58,6 +71,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		replier:  replier,
 		ceClient: ceClient,
 		logger:   logger,
+
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
 	}
 }
 
@@ -69,6 +84,8 @@ type logzAdapter struct {
 	replier  *targetce.Replier
 	ceClient cloudevents.Client
 	logger   *zap.SugaredLogger
+
+	sr *metrics.EventProcessingStatsReporter
 }
 
 // Returns if stopCh is closed or Send() returns an error.


### PR DESCRIPTION
Changes:

- Enable the Event Processing stat reporter in all components that are able to process events (flow, targets).
- Adjust adapter tests under `pkg/flow/adapter/` to play nice with metrics:
  - Reset global state between tests
  - Register views only once

> **Note**
> This PR doesn't include the logic for _using_ the reporter, which is component-specific and will be addressed in separate PRs to facilitate the review process and deliver value step by step.