### PR TITLE
Logger grooming

### DIFF
--- a/pkg/flow/adapter/transformation/adapter_test.go
+++ b/pkg/flow/adapter/transformation/adapter_test.go
@@ -25,6 +25,8 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 
+	logtesting "knative.dev/pkg/logging/testing"
+
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
 )
@@ -50,6 +52,7 @@ func TestStart(t *testing.T) {
 		DataPipeline:    pipeline,
 
 		client: ceClient,
+		logger: logtesting.TestLogger(t),
 	}
 
 	errChan := make(chan error)
@@ -295,6 +298,7 @@ func TestReceiveAndTransform(t *testing.T) {
 			a := &adapter{
 				DataPipeline:    pipeline,
 				ContextPipeline: pipeline,
+				logger:          logtesting.TestLogger(t),
 			}
 
 			transformedEvent, err := a.applyTransformations(tc.originalEvent)

--- a/pkg/flow/adapter/transformation/pipeline.go
+++ b/pkg/flow/adapter/transformation/pipeline.go
@@ -18,7 +18,6 @@ package transformation
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
@@ -62,7 +61,6 @@ func newPipeline(transformations []v1alpha1.Transform) (*Pipeline, error) {
 		}
 		for _, kv := range transformation.Paths {
 			pipeline = append(pipeline, operation.New(kv.Key, kv.Value))
-			log.Printf("%s: %s", transformation.Operation, kv.Key)
 		}
 	}
 

--- a/pkg/flow/adapter/transformation/transformer/delete/delete.go
+++ b/pkg/flow/adapter/transformation/transformer/delete/delete.go
@@ -19,7 +19,6 @@ package delete
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
@@ -140,8 +139,6 @@ func (d *Delete) parse(data interface{}, key, path string) (interface{}, error) 
 			}
 			output[k] = o
 		}
-	default:
-		log.Printf("unhandled type %T\n", value)
 	}
 
 	return output, nil

--- a/pkg/sources/adapter/azureiothubsource/adapter.go
+++ b/pkg/sources/adapter/azureiothubsource/adapter.go
@@ -19,7 +19,6 @@ package azureiothubsource
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"go.uber.org/zap"
@@ -78,7 +77,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		env.ConnectionString,
 	)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatal("Failed to obtain IoT client", zap.Error(err))
 	}
 
 	return &adapter{
@@ -96,9 +95,7 @@ func (a *adapter) Start(ctx context.Context) error {
 
 	ctx = pkgadapter.ContextWithMetricTag(ctx, a.mt)
 
-	log.Fatal(a.c.SubscribeEvents(ctx, a.eventHandler(ctx)))
-
-	return nil
+	return a.c.SubscribeEvents(ctx, a.eventHandler(ctx))
 }
 
 func (a *adapter) eventHandler(ctx context.Context) iotservice.EventHandler {

--- a/pkg/sources/adapter/httppollersource/adapter.go
+++ b/pkg/sources/adapter/httppollersource/adapter.go
@@ -82,7 +82,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		httpRequest: httpRequest,
 
 		ceClient: ceClient,
-		logger:   logging.FromContext(ctx),
+		logger:   logger,
 		mt:       mt,
 	}
 }

--- a/pkg/sources/adapter/httppollersource/httppoller.go
+++ b/pkg/sources/adapter/httppollersource/httppoller.go
@@ -19,7 +19,6 @@ package httppollersource
 import (
 	"context"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"time"
 
@@ -62,7 +61,7 @@ func (h *httpPoller) Start(ctx context.Context) error {
 		select {
 
 		case <-ctx.Done():
-			log.Printf("Shutting down HTTP poller")
+			h.logger.Info("Shutting down HTTP poller")
 			return nil
 
 		case <-t.C:


### PR DESCRIPTION
- Switched from Go's log package to injected zap.Logger,
- Removed excessive and useless output,
- Renamed `log` to `logger` to match common style.

Closes #780