### PR TITLE
Grant adapters read access to configMaps

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -509,6 +509,26 @@ rules:
 
 ---
 
+# This role is used to grant receive adapters read-only access to per-component
+# configurations such as logging, observability and tracing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-config-watcher
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/sources/reconciler/awssnssource/reconciler_test.go
+++ b/pkg/sources/reconciler/awssnssource/reconciler_test.go
@@ -144,7 +144,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -167,7 +168,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(subscribed),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			PostConditions: []func(*testing.T, *rt.TableRow){
@@ -187,7 +189,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(subscribed, deleted),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -211,7 +214,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(subscribed, deleted),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -235,7 +239,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(deleted),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -259,7 +264,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(deleted),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -286,7 +292,8 @@ func TestReconcileSubscription(t *testing.T) {
 			Objects: []runtime.Object{
 				newReconciledSource(),
 				newReconciledServiceAccount(),
-				newReconciledRoleBinding(),
+				newReconciledConfigWatchRoleBinding(),
+				newReconciledMTAdapterRoleBinding(),
 				newReconciledAdapter(),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -399,10 +406,16 @@ func newReconciledServiceAccount() *corev1.ServiceAccount {
 	return NewServiceAccount(newEventSource())()
 }
 
-// newReconciledRoleBinding returns a test RoleBinding object that is
-// identical to what ReconcileKind generates.
-func newReconciledRoleBinding() *rbacv1.RoleBinding {
-	return NewRoleBinding(newReconciledServiceAccount())()
+// newReconciledConfigWatchRoleBinding returns a test config watcher
+// RoleBinding object that is identical to what ReconcileKind generates.
+func newReconciledConfigWatchRoleBinding() *rbacv1.RoleBinding {
+	return NewConfigWatchRoleBinding(newReconciledServiceAccount())()
+}
+
+// newReconciledMTAdapterRoleBinding returns a test (mt-)adapter RoleBinding
+// object that is identical to what ReconcileKind generates.
+func newReconciledMTAdapterRoleBinding() *rbacv1.RoleBinding {
+	return NewMTAdapterRoleBinding(newReconciledServiceAccount())()
 }
 
 // newReconciledAdapter returns a test receive adapter object that is identical

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
@@ -364,7 +364,7 @@ func newReconciledServiceAccount() *corev1.ServiceAccount {
 // newReconciledRoleBinding returns a test RoleBinding object that is
 // identical to what ReconcileKind generates.
 func newReconciledRoleBinding() *rbacv1.RoleBinding {
-	return NewRoleBinding(newReconciledServiceAccount())()
+	return NewConfigWatchRoleBinding(newReconciledServiceAccount())()
 }
 
 // newReconciledAdapter returns a test receive adapter object that is identical

--- a/pkg/sources/reconciler/azureeventgridsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureeventgridsource/reconciler_test.go
@@ -552,7 +552,7 @@ func newReconciledServiceAccount() *corev1.ServiceAccount {
 // newReconciledRoleBinding returns a test RoleBinding object that is
 // identical to what ReconcileKind generates.
 func newReconciledRoleBinding() *rbacv1.RoleBinding {
-	return NewRoleBinding(newReconciledServiceAccount())()
+	return NewConfigWatchRoleBinding(newReconciledServiceAccount())()
 }
 
 // newReconciledAdapter returns a test receive adapter object that is identical

--- a/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/reconciler_test.go
@@ -330,7 +330,7 @@ func newReconciledServiceAccount() *corev1.ServiceAccount {
 // newReconciledRoleBinding returns a test RoleBinding object that is
 // identical to what ReconcileKind generates.
 func newReconciledRoleBinding() *rbacv1.RoleBinding {
-	return NewRoleBinding(newReconciledServiceAccount())()
+	return NewConfigWatchRoleBinding(newReconciledServiceAccount())()
 }
 
 // newReconciledAdapter returns a test receive adapter object that is identical


### PR DESCRIPTION
One pre-requisite of enabling config watchers in receive adapters is that sufficient permissions are granted to serviceAccounts.

This PR automatically binds adapters' serviceAccounts to the (new) `triggermesh-config-watcher` clusterRole.

## Demo

### Creation of a component instance

Notice the `awssqssource-adapter-config-watcher` roleBinding that automatically binds the SQS source's serviceAccount to the `triggermesh-config-watcher` clusterRole.
Both the serviceAccount and the roleBinding are shared between all instances of a given component type. (This was already true prior to this PR)

```console
$ kubectl create -f /tmp/awssqssource.yaml
awssqssource.sources.triggermesh.io/sample1 created
awssqssource.sources.triggermesh.io/sample2 created
```

```console
$ kubectl get awssqssources,serviceaccounts,rolebindings
NAME                                          READY   REASON              SINK                                             AGE
awssqssource.sources.triggermesh.io/sample1   False   ContainerCreating   http://event-display.default.svc.cluster.local   4s
awssqssource.sources.triggermesh.io/sample2   False   ContainerCreating   http://event-display.default.svc.cluster.local   4s

NAME                                  SECRETS   AGE
serviceaccount/awssqssource-adapter   0         4s
serviceaccount/default                0         7d16h

NAME                                                                        ROLE                                     AGE
rolebinding.rbac.authorization.k8s.io/awssqssource-adapter-config-watcher   ClusterRole/triggermesh-config-watcher   4s
```

### Deleting of the component instance

Due to the chain of ownership `tm-component(s)` -> `serviceAccount` -> `roleBinding`, all objects are automatically cleaned up once the last instance of the TriggerMesh component disappears. (This was already true prior to this PR)

```console
$ kubectl delete -f /tmp/awssqssource.yaml
awssqssource.sources.triggermesh.io "sample1" deleted
awssqssource.sources.triggermesh.io "sample2" deleted
```

```console
$ kubectl get awssqssources,serviceaccounts,rolebindings
NAME                     SECRETS   AGE
serviceaccount/default   0         7d16h
```