### PR TITLE
Reduce build parallelism in `publish-image` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             go install .
             popd
 
-            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
+            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} KOFLAGS=--jobs=$(($(nproc)/2)) make release
 
             declare -a release_files=(
               triggermesh-crds.yaml


### PR DESCRIPTION
Builds get killed after merging triggermesh/triggermesh#885

In general, 16 concurrent builds is too much anyway (end-to-end tests also invoke `ko` and do just fine on 4 cores). Memory usage compounds so we reach the limit quickly with such high concurrency.

![image](https://user-images.githubusercontent.com/3299086/170018277-58cf89d3-af79-414d-a3d1-2714a676d56b.png)