### PR TITLE
Set a fixed number of concurrent builds in release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           name: Publishing container images and creating release manifests
           environment:
             KO_DOCKER_REPO: gcr.io/triggermesh
-            KOFLAGS: --jobs=8  # adjust based on resource_class
+            KOFLAGS: --jobs=4  # adjust based on resource_class
             DIST_DIR: /tmp/dist/
           command: |
             pushd hack/manifest-cleaner


### PR DESCRIPTION
Build threads are still being killed.

I don't know what is suddenly causing this in CircleCI because builds go through smoothly in GitHub Actions, for the time being I suggest reducing the concurrency further.

![image](https://user-images.githubusercontent.com/3299086/170087900-569f1ed7-9cb2-4862-b288-d132be8c6be6.png)