### PR TITLE
Document IAM permissions required by the Amazon EventBridge source

### DIFF
--- a/test/e2e/framework/aws/eventbridge/eventbridge.go
+++ b/test/e2e/framework/aws/eventbridge/eventbridge.go
@@ -56,7 +56,7 @@ func ForceDeleteEventBus(ebClient eventbridgeiface.EventBridgeAPI, eventBusName 
 // any associated rule should also be deleted.
 func deleteEventBus(ebClient eventbridgeiface.EventBridgeAPI, eventBusName string, force bool) {
 	if force {
-		removeAllRules(ebClient, eventBusName)
+		deleteAllRules(ebClient, eventBusName)
 	}
 
 	eventBus := &eventbridge.DeleteEventBusInput{

--- a/test/e2e/framework/aws/eventbridge/rules.go
+++ b/test/e2e/framework/aws/eventbridge/rules.go
@@ -23,8 +23,8 @@ import (
 	"github.com/triggermesh/triggermesh/test/e2e/framework"
 )
 
-// removeAllRules removes all rules from the given event bus.
-func removeAllRules(ebClient eventbridgeiface.EventBridgeAPI, eventBusName string) {
+// deleteAllRules deletes all rules from the given event bus.
+func deleteAllRules(ebClient eventbridgeiface.EventBridgeAPI, eventBusName string) {
 	in := &eventbridge.ListRulesInput{
 		EventBusName: &eventBusName,
 	}

--- a/test/e2e/iam/aws_iam_policy.jsonc
+++ b/test/e2e/iam/aws_iam_policy.jsonc
@@ -7,6 +7,35 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "E2EFrameworkEventBridgeEventBus",
+            "Effect": "Allow",
+            "Action": [
+                "events:CreateEventBus",
+                "events:TagResource",
+                "events:DeleteEventBus",
+                "events:PutEvents"
+            ],
+            "Resource": "arn:aws:events:*:043455440429:event-bus/e2e-*"
+        },
+        {
+            "Sid": "E2EFrameworkEventBridgeEventRule1",
+            "Effect": "Allow",
+            "Action": [
+                "events:ListRules"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "E2EFrameworkEventBridgeEventRule2",
+            "Effect": "Allow",
+            "Action": [
+                "events:DeleteRule",
+                "events:ListTargetsByRule",
+                "events:RemoveTargets"
+            ],
+            "Resource": "arn:aws:events:*:043455440429:rule/e2e-*"
+        },
+        {
             "Sid": "E2EFrameworkSNS",
             "Effect": "Allow",
             "Action": [
@@ -16,9 +45,7 @@
                 "sns:GetTopicAttributes",
                 "sns:SetTopicAttributes"
             ],
-            "Resource": [
-                "arn:aws:sns:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:sns:*:043455440429:e2e-*"
         },
         {
             "Sid": "E2EFrameworkSQS",
@@ -32,9 +59,7 @@
                 "sqs:SetQueueAttributes",
                 "sqs:TagQueue"
             ],
-            "Resource": [
-                "arn:aws:sqs:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:sqs:*:043455440429:e2e-*"
         },
         {
             "Sid": "E2EFrameworkCodeCommit",
@@ -46,9 +71,7 @@
                 "codecommit:CreateCommit",
                 "codecommit:TagResource"
             ],
-            "Resource": [
-                "arn:aws:codecommit:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:codecommit:*:043455440429:e2e-*"
         },
         {
             "Sid": "E2EFrameworkKinesis",
@@ -62,9 +85,7 @@
                 "kinesis:GetShardIterator",
                 "kinesis:GetRecords"
             ],
-            "Resource": [
-                "arn:aws:kinesis:*:043455440429:stream/e2e-*"
-            ]
+            "Resource": "arn:aws:kinesis:*:043455440429:stream/e2e-*"
         },
         {
             "Sid": "E2EFrameworkCognitoUserPools",
@@ -74,9 +95,7 @@
                 "cognito-idp:AdminCreateUser",
                 "cognito-idp:DeleteUserPool"
             ],
-            "Resource": [
-                "*"
-            ]
+            "Resource": "*"
         },
         {
             "Sid": "E2EFrameworkDynamoDB",
@@ -87,9 +106,7 @@
                 "dynamodb:DeleteTable",
                 "dynamodb:PutItem"
             ],
-            "Resource": [
-                "arn:aws:dynamodb:*:043455440429:table/e2e-*"
-            ]
+            "Resource": "arn:aws:dynamodb:*:043455440429:table/e2e-*"
         },
         {
             "Sid": "E2EFrameworkS3",
@@ -101,9 +118,44 @@
                 "s3:DeleteBucket",
                 "s3:DeleteObject"
             ],
-            "Resource": [
-                "arn:aws:s3:::e2e-*"
-            ]
+            "Resource": "arn:aws:s3:::e2e-*"
+        },
+        {
+            "Sid": "AWSEventBridgeSourceReconcilerEventRule1",
+            "Effect": "Allow",
+            "Action": [
+                "events:ListRuleNamesByTarget"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AWSEventBridgeSourceReconcilerEventRule2",
+            "Effect": "Allow",
+            "Action": [
+                "events:DescribeRule",
+                "events:ListTargetsByRule",
+                "events:PutRule",
+                "events:PutTargets",
+                "events:DeleteRule",
+                "events:RemoveTargets",
+                "events:ListTagsForResource",
+                "events:TagResource"
+            ],
+            "Resource": "arn:aws:events:*:043455440429:rule/e2e-*"
+        },
+        {
+            "Sid": "AWSEventBridgeSourceReconcilerQueue",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:GetQueueAttributes",
+                "sqs:ListQueueTags",
+                "sqs:CreateQueue",
+                "sqs:SetQueueAttributes",
+                "sqs:TagQueue",
+                "sqs:DeleteQueue"
+            ],
+            "Resource": "arn:aws:sqs:*:043455440429:io_triggermesh_awseventbridgesources-*"
         },
         {
             "Sid": "AWSCodeCommitSourceReceiveAdapter",
@@ -115,9 +167,7 @@
                 "codecommit:ListPullRequests",
                 "codecommit:GetPullRequest"
             ],
-            "Resource": [
-                "arn:aws:codecommit:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:codecommit:*:043455440429:e2e-*"
         },
         {
             "Sid": "AWSSNSSourceReceiveAdapter",
@@ -125,9 +175,7 @@
             "Action": [
                 "sns:ConfirmSubscription"
             ],
-            "Resource": [
-                "arn:aws:sns:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:sns:*:043455440429:e2e-*"
         },
         {
             "Sid": "AWSSNSSourceReconciler",
@@ -137,9 +185,7 @@
                 "sns:Subscribe",
                 "sns:Unsubscribe"
             ],
-            "Resource": [
-                "arn:aws:sns:*:043455440429:e2e-*"
-            ]
+            "Resource": "arn:aws:sns:*:043455440429:e2e-*"
         },
         {
             "Sid": "AWSSQSSourceReceiveAdapter",
@@ -150,8 +196,9 @@
                 "sqs:DeleteMessage"
             ],
             "Resource": [
-                "arn:aws:sqs:*:043455440429:e2e-*"
-            ]
+                "arn:aws:sqs:*:043455440429:e2e-*",
+                "arn:aws:sqs:*:043455440429:io_triggermesh_awseventbridgesources-*"
+	    ]
         },
         {
             "Sid": "AWSKinesisSourceReceiveAdapter",
@@ -161,9 +208,7 @@
                 "kinesis:GetShardIterator",
                 "kinesis:GetRecords"
             ],
-            "Resource": [
-                "arn:aws:kinesis:*:043455440429:stream/e2e-*"
-            ]
+            "Resource": "arn:aws:kinesis:*:043455440429:stream/e2e-*"
         },
         {
             "Sid": "AWSCognitoUserPoolSourceReceiveAdapter",


### PR DESCRIPTION
End-to-end [failed due to missing permissions](https://github.com/triggermesh/triggermesh/runs/6591619517?check_suite_focus=true) ❌, so here is an updated version of our IAM policy that covers the permissions required to run the source.

Here is a [successful run after updating the policy](https://github.com/triggermesh/triggermesh/actions/runs/2384254587) ✅.

![image](https://user-images.githubusercontent.com/3299086/170295477-dd549fe9-9c5e-4020-8342-c86c52532aa8.png)