### PR TITLE
Update `knative/pkg` to silence init logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.18
 require (
 	github.com/cloudevents/sdk-go/v2 v2.10.0
 	knative.dev/eventing v0.31.1-0.20220523181303-c3e13967001f
-	knative.dev/pkg v0.0.0-20220512013937-2d8305b2e59a
+	knative.dev/pkg v0.0.0-20220525153005-18f69958870f
 	knative.dev/serving v0.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2542,8 +2542,9 @@ knative.dev/networking v0.0.0-20220412163509-1145ec58c8be h1:MmwR4SfwlXgt/jnjron
 knative.dev/networking v0.0.0-20220412163509-1145ec58c8be/go.mod h1:6OZIUimxPelIIudzHWRd+Lc7ippC5t+DC8CsZKCOjcI=
 knative.dev/pkg v0.0.0-20220412134708-e325df66cb51/go.mod h1:j2MeD8s+JoCu1vegX80GbRXV/xd20Jm1NznxBYtVXiM=
 knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3/go.mod h1:mRzBIY8eoQurpADZ4+3LzNuucKOBhsSvhX6lXqMVpIc=
-knative.dev/pkg v0.0.0-20220512013937-2d8305b2e59a h1:lVm5ZtTrQZg3yid38zu13QgXN02clVzPkMTEyB9FRUo=
 knative.dev/pkg v0.0.0-20220512013937-2d8305b2e59a/go.mod h1:mRzBIY8eoQurpADZ4+3LzNuucKOBhsSvhX6lXqMVpIc=
+knative.dev/pkg v0.0.0-20220525153005-18f69958870f h1:JZQi/4I68vO8AsCpJmVnBE/UxNLseaBUgrHfIQGsIe8=
+knative.dev/pkg v0.0.0-20220525153005-18f69958870f/go.mod h1:pApypeWDkGrsMkUDkV6StWXS4CXhwGWuJEID9GGZY0Y=
 knative.dev/reconciler-test v0.0.0-20220513144654-fdb392439fb5/go.mod h1:blANTpykbOpFykGxucL/8RkU8hH4WmZRWaxifP8heF4=
 knative.dev/serving v0.31.0 h1:pVrrmG6I8f0MYTG6wxCYrFFpOxQGwl4c3GfP8UGqm/o=
 knative.dev/serving v0.31.0/go.mod h1:ObA3YEL77+M60xu4T3cUSpD+AX5eZN6Ww0pHg8iA6NE=


### PR DESCRIPTION
🎁 for @tzununbekov

Logs related to the initialization of loggers and metrics exporters are now only emitted at the `debug` logging level instead of `info`, so they shouldn't "pollute" the app-specific initialization logs anymore (ref. https://github.com/knative/pkg/pull/2522).

Example from the SQS source adapter:

```json
{"level":"warn","ts":"2022-05-25T16:26:56.651Z","logger":"awssqssource","caller":"v2/config.go:185","msg":"Tracing configuration is invalid, using the no-op default{error 26 0  empty json tracing config}","commit":"14d5989"}
{"level":"warn","ts":"2022-05-25T16:26:56.651Z","logger":"awssqssource","caller":"v2/config.go:178","msg":"Sink timeout configuration is invalid, default to -1 (no timeout)","commit":"14d5989"}
{"level":"info","ts":"2022-05-25T16:26:57.752Z","logger":"awssqssource","caller":"awssqssource/adapter.go:201","msg":"Listening to SQS queue at URL: https://sqs.us-west-1.amazonaws.com/123456789012/io_triggermesh_awseventbridgesources-1695670418","commit":"14d5989"}
{"level":"info","ts":"2022-05-25T16:27:05.932Z","logger":"awssqssource","caller":"awssqssource/adapter.go:240","msg":"Waiting for message handlers to terminate","commit":"14d5989"}
```

You will notice that we're still getting two warnings:
- About a missing tracing config
- About a missing timeout setting

Both can be addressed in TriggerMesh in case we want to silence these too.
The first one: we want to enable tracing in the future anyway. -> #941
The second one: easy enough to set `K_SINK_TIMEOUT` to some default in our adapter builders. -> #940