### PR TITLE
Enable passing tracing config via env vars

### DIFF
--- a/pkg/extensions/reconciler/function/controller.go
+++ b/pkg/extensions/reconciler/function/controller.go
@@ -46,7 +46,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/dataweavetransformation/controller.go
+++ b/pkg/flow/reconciler/dataweavetransformation/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/jqtransformation/controller.go
+++ b/pkg/flow/reconciler/jqtransformation/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/synchronizer/controller.go
+++ b/pkg/flow/reconciler/synchronizer/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/transformation/controller.go
+++ b/pkg/flow/reconciler/transformation/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/xmltojsontransformation/controller.go
+++ b/pkg/flow/reconciler/xmltojsontransformation/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/flow/reconciler/xslttransformation/controller.go
+++ b/pkg/flow/reconciler/xslttransformation/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/reconciler/testing/controller.go
+++ b/pkg/reconciler/testing/controller.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	rt "knative.dev/pkg/reconciler/testing"
+	tracing "knative.dev/pkg/tracing/config"
 
 	"github.com/triggermesh/triggermesh/pkg/testing/structs"
 )
@@ -67,6 +68,7 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 	cmw := configmap.NewStaticWatcher(
 		NewConfigMap(metrics.ConfigMapName(), nil),
 		NewConfigMap(logging.ConfigMapName(), nil),
+		NewConfigMap(tracing.ConfigName, nil),
 	)
 
 	ctrler := ctor(ctx, cmw)

--- a/pkg/routing/reconciler/filter/controller.go
+++ b/pkg/routing/reconciler/filter/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/routing/reconciler/splitter/controller.go
+++ b/pkg/routing/reconciler/splitter/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awscloudwatchsource/controller.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awscodecommitsource/controller.go
+++ b/pkg/sources/reconciler/awscodecommitsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awscognitoidentitysource/controller.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awsdynamodbsource/controller.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awseventbridgesource/controller.go
+++ b/pkg/sources/reconciler/awseventbridgesource/controller.go
@@ -48,7 +48,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awskinesissource/controller.go
+++ b/pkg/sources/reconciler/awskinesissource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awss3source/controller.go
+++ b/pkg/sources/reconciler/awss3source/controller.go
@@ -48,7 +48,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awssnssource/controller.go
+++ b/pkg/sources/reconciler/awssnssource/controller.go
@@ -50,7 +50,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/awssqssource/controller.go
+++ b/pkg/sources/reconciler/awssqssource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureactivitylogssource/controller.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureblobstoragesource/controller.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureeventgridsource/controller.go
+++ b/pkg/sources/reconciler/azureeventgridsource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureeventhubsource/controller.go
+++ b/pkg/sources/reconciler/azureeventhubsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureiothubsource/controller.go
+++ b/pkg/sources/reconciler/azureiothubsource/controller.go
@@ -42,7 +42,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azurequeuestoragesource/controller.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/controller.go
@@ -42,7 +42,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureservicebusqueuesource/controller.go
+++ b/pkg/sources/reconciler/azureservicebusqueuesource/controller.go
@@ -42,7 +42,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/azureservicebustopicsource/controller.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/cloudeventssource/controller.go
+++ b/pkg/sources/reconciler/cloudeventssource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudauditlogssource/controller.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudbillingsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudiotsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudpubsubsource/controller.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/googlecloudstoragesource/controller.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/controller.go
@@ -49,7 +49,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/httppollersource/controller.go
+++ b/pkg/sources/reconciler/httppollersource/controller.go
@@ -41,7 +41,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/ibmmqsource/controller.go
+++ b/pkg/sources/reconciler/ibmmqsource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/ocimetricssource/controller.go
+++ b/pkg/sources/reconciler/ocimetricssource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/salesforcesource/controller.go
+++ b/pkg/sources/reconciler/salesforcesource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/slacksource/controller.go
+++ b/pkg/sources/reconciler/slacksource/controller.go
@@ -43,7 +43,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/twiliosource/controller.go
+++ b/pkg/sources/reconciler/twiliosource/controller.go
@@ -42,7 +42,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/webhooksource/controller.go
+++ b/pkg/sources/reconciler/webhooksource/controller.go
@@ -42,7 +42,7 @@ func NewController(
 	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/sources/reconciler/zendesksource/controller.go
+++ b/pkg/sources/reconciler/zendesksource/controller.go
@@ -50,7 +50,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/alibabaosstarget/controller.go
+++ b/pkg/targets/reconciler/alibabaosstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awscomprehendtarget/controller.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awsdynamodbtarget/controller.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awseventbridgetarget/controller.go
+++ b/pkg/targets/reconciler/awseventbridgetarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awskinesistarget/controller.go
+++ b/pkg/targets/reconciler/awskinesistarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awslambdatarget/controller.go
+++ b/pkg/targets/reconciler/awslambdatarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awss3target/controller.go
+++ b/pkg/targets/reconciler/awss3target/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awssnstarget/controller.go
+++ b/pkg/targets/reconciler/awssnstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/awssqstarget/controller.go
+++ b/pkg/targets/reconciler/awssqstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/azureeventhubstarget/controller.go
+++ b/pkg/targets/reconciler/azureeventhubstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/cloudeventstarget/controller.go
+++ b/pkg/targets/reconciler/cloudeventstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/confluenttarget/controller.go
+++ b/pkg/targets/reconciler/confluenttarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/datadogtarget/controller.go
+++ b/pkg/targets/reconciler/datadogtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/elasticsearchtarget/controller.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/googlesheettarget/controller.go
+++ b/pkg/targets/reconciler/googlesheettarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/hasuratarget/controller.go
+++ b/pkg/targets/reconciler/hasuratarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/httptarget/controller.go
+++ b/pkg/targets/reconciler/httptarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/ibmmqtarget/controller.go
+++ b/pkg/targets/reconciler/ibmmqtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/infratarget/controller.go
+++ b/pkg/targets/reconciler/infratarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/jiratarget/controller.go
+++ b/pkg/targets/reconciler/jiratarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/logzmetricstarget/controller.go
+++ b/pkg/targets/reconciler/logzmetricstarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/logztarget/controller.go
+++ b/pkg/targets/reconciler/logztarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/oracletarget/controller.go
+++ b/pkg/targets/reconciler/oracletarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/salesforcetarget/controller.go
+++ b/pkg/targets/reconciler/salesforcetarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/sendgridtarget/controller.go
+++ b/pkg/targets/reconciler/sendgridtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/slacktarget/controller.go
+++ b/pkg/targets/reconciler/slacktarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/splunktarget/controller.go
+++ b/pkg/targets/reconciler/splunktarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/tektontarget/controller.go
+++ b/pkg/targets/reconciler/tektontarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/twiliotarget/controller.go
+++ b/pkg/targets/reconciler/twiliotarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/uipathtarget/controller.go
+++ b/pkg/targets/reconciler/uipathtarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 

--- a/pkg/targets/reconciler/zendesktarget/controller.go
+++ b/pkg/targets/reconciler/zendesktarget/controller.go
@@ -44,7 +44,7 @@ func NewController(
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYTARGET_IMAGE.
 	adapterCfg := &adapterConfig{
-		obsConfig: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
+		obsConfig: source.WatchConfigurations(ctx, app, cmw),
 	}
 	envconfig.MustProcess(app, adapterCfg)
 


### PR DESCRIPTION
Suppresses the warning seen in triggermesh/triggermesh#939.

```json
{"level":"warn","ts":"2022-05-25T16:26:56.651Z","logger":"awssqssource","caller":"v2/config.go:185","msg":"Tracing configuration is invalid, using the no-op default{error 26 0  empty json tracing config}","commit":"14d5989"}
```

I can't think about any good reason for not passing `K_TRACING_CONFIG` to adapters. In the worse case, they will simply ignore it.
When `config-tracing` doesn't exist in the `triggermesh` namespace, a default config with no backend is passed:

```yaml
- name: K_TRACING_CONFIG
  value: '{"backend":"","debug":"false","sample-rate":"0"}'
```
