### PR TITLE
Add default `config-observability` ConfigMap

### DIFF
--- a/config/configmaps/config-observability.yaml
+++ b/config/configmaps/config-observability.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: triggermesh
+data:
+  # Enables the Prometheus metrics exporter in all TriggerMesh components.
+  # Exposes telemetry metrics in a text-based format on the HTTP endpoint :9092/metrics.
+  metrics.backend-destination: prometheus


### PR DESCRIPTION
By default, the Prometheus metrics exporter isn't enabled, so we should have at least an example of ConfigMap which enables it.

Similar to triggermesh/triggermesh#928 (and triggermesh/triggermesh#935).