### PR TITLE
fix panic when creating a topic but svc account does not have permissions

### DIFF
--- a/pkg/sources/reconciler/googlecloudauditlogssource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/pubsub.go
@@ -155,7 +155,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topic, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		_, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
@@ -168,7 +168,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			return nil, fmt.Errorf("%w", failCreateTopicEvent(topicID, err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topic)
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicID)
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}

--- a/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
@@ -155,7 +155,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topic, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		_, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
@@ -168,7 +168,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			return nil, fmt.Errorf("%w", failCreateTopicEvent(topicID, err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topic)
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicID)
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}

--- a/pkg/sources/reconciler/googlecloudiotsource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/pubsub.go
@@ -155,7 +155,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topic, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		_, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
@@ -168,7 +168,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			return nil, fmt.Errorf("%w", failCreateTopicEvent(topicID, err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topic)
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicID)
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/pubsub.go
@@ -155,7 +155,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topic, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		_, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
@@ -168,7 +168,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			return nil, fmt.Errorf("%w", failCreateTopicEvent(topicID, err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topic)
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicID)
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}

--- a/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
@@ -155,7 +155,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topic, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		topicCreated, err := cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
@@ -168,7 +168,7 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			return nil, fmt.Errorf("%w", failCreateTopicEvent(topic.String(), err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topic)
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicCreated.String())
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}

--- a/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go
@@ -155,20 +155,20 @@ func ensurePubSubTopic(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GClou
 			Labels: pubsubResourceLabels(src),
 		}
 
-		topicCreated, err := cli.CreateTopicWithConfig(ctx, topicID, cfg)
+		_, err = cli.CreateTopicWithConfig(ctx, topicID, cfg)
 		switch {
 		case isDenied(err):
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
 				"Access denied to Pub/Sub API: "+toErrMsg(err))
-			return nil, controller.NewPermanentError(failCreateTopicEvent(topic.String(), err))
+			return nil, controller.NewPermanentError(failCreateTopicEvent(topicID, err))
 		case err != nil:
 			status.MarkNotSubscribed(v1alpha1.GCloudReasonAPIError,
 				"Cannot create topic: "+toErrMsg(err))
 			// wrap any other error to fail the reconciliation
-			return nil, fmt.Errorf("%w", failCreateTopicEvent(topic.String(), err))
+			return nil, fmt.Errorf("%w", failCreateTopicEvent(topicID, err))
 		}
 
-		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicCreated.String())
+		event.Normal(ctx, ReasonSubscribed, "Created topic %q", topicID)
 	}
 
 	topicResName := &v1alpha1.GCloudResourceName{}


### PR DESCRIPTION
- fix panic when creating a topic but svc account does not have permissions

the variable `topic` is overwritten with `nil` because the svc account does not have permission to create a topic, and then we get a panic.
this should not panic and instead should return an error.
Using a new variable fix the issue.


```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x205fb1b]

goroutine 2565 [running]:
cloud.google.com/go/pubsub.(*Topic).String(...)
        cloud.google.com/go/pubsub@v1.21.0/topic.go:462
github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource.ensurePubSubTopic({0x2ed8968, 0xc002988b70}, 0x4600440?)
        github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go:163 +0x14fb
github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource.ensurePubSub({0x2ed8968, 0xc002988b70}, 0x251d9e0?)
        github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource/pubsub.go:56 +0x5d
github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource.(*Reconciler).ReconcileKind(0xc0009c1a80, {0x2ed8968?, 0xc002021a10?}, 0xc002bdb200)
        github.com/triggermesh/triggermesh/pkg/sources/reconciler/googlecloudstoragesource/reconciler.go:81 +0x449
github.com/triggermesh/triggermesh/pkg/client/generated/injection/reconciler/sources/v1alpha1/googlecloudstoragesource.(*reconcilerImpl).Reconcile(0xc0000cac80, {0x2ed8968, 0xc0020219e0}, {0xc005290340, 0xc})
        github.com/triggermesh/triggermesh/pkg/client/generated/injection/reconciler/sources/v1alpha1/googlecloudstoragesource/reconciler.go:239 +0x6b7
knative.dev/pkg/controller.(*Impl).processNextWorkItem(0xc00032d0e0)
        knative.dev/pkg@v0.0.0-20220314170718-721abec0a377/controller/controller.go:535 +0x58d
knative.dev/pkg/controller.(*Impl).RunContext.func3()
        knative.dev/pkg@v0.0.0-20220314170718-721abec0a377/controller/controller.go:484 +0x68
created by knative.dev/pkg/controller.(*Impl).RunContext
        knative.dev/pkg@v0.0.0-20220314170718-721abec0a377/controller/controller.go:482 +0x2d4
```