### PR TITLE
release-notes.sh: read release highlights from tag annotation

### DIFF
--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -18,6 +18,7 @@ KREPO="triggermesh"
 BASE_URL="https://github.com/triggermesh/${KREPO}/releases/download/${RELEASE}"
 PREV_RELEASE=${PREV_RELEASE:-$(git describe --tags --abbrev=0 ${RELEASE}^ 2>/dev/null)}
 PREV_RELEASE=${PREV_RELEASE:-$(git rev-list --max-parents=0 ${RELEASE}^ 2>/dev/null)}
+NOTABLE_CHANGES=$(git cat-file -p ${RELEASE} | sed '/-----BEGIN PGP SIGNATURE-----/,//d' | tail -n +6)
 CHANGELOG=$(git log --no-merges --pretty=format:'- [%h] %s (%aN)' ${PREV_RELEASE}..${RELEASE})
 if [ $? -ne 0 ]; then
   echo "Error creating changelog"
@@ -37,6 +38,8 @@ RELEASE_ASSETS_TABLE=$(
 )
 
 cat <<EOF
+${NOTABLE_CHANGES}
+
 ## Installation
 
 Install all TriggerMesh custom resources:


### PR DESCRIPTION
Use `git tag --annotate --cleanup=whitespace {TAG}` to create the release tag. Enter the notable changes in the tag annotation. These will be prepended to the autogenerated release notes