### PR TITLE
Updates confluent target to allow two more authentication methods

### DIFF
--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -52,7 +52,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 	var kc KafkaClient
 	var err error
 
-	if env.SecurityProtocol == "SASL_SSL" && env.SecurityMechanisms == "PLAIN" {
+	switch env.SecurityMechanisms {
+	case "PLAIN":
 		kc, err = NewKafkaClient(&kafka.ConfigMap{
 			"bootstrap.servers":       env.BootstrapServers,
 			"sasl.username":           env.SASLUsername,
@@ -65,9 +66,7 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		if err != nil {
 			logger.Panic(err)
 		}
-	}
-
-	if env.SecurityProtocol == "SASL_SSL" && env.SecurityMechanisms == "SCRAM-SHA-256" {
+	case "SCRAM-SHA-256":
 		kc, err = NewKafkaClient(&kafka.ConfigMap{
 			"bootstrap.servers":        env.BootstrapServers,
 			"sasl.username":            env.SASLUsername,
@@ -83,10 +82,7 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		if err != nil {
 			logger.Panic(err)
 		}
-	}
-
-	if env.SecurityProtocol == "SASL_SSL" && env.SecurityMechanisms == "GSSAPI" {
-		fmt.Println("GSSAPI")
+	case "GSSAPI":
 		kc, err = NewKafkaClient(&kafka.ConfigMap{
 			"bootstrap.servers":          env.BootstrapServers,
 			"group.id":                   env.GroupID,
@@ -104,6 +100,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 		if err != nil {
 			logger.Panic(err)
 		}
+	default:
+		logger.Panicf("Unsupported security mechanism: %s", env.SecurityMechanisms)
 	}
 
 	if kc == nil {

--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -75,9 +75,9 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 			"security.protocol":        env.SecurityProtocol,
 			"broker.version.fallback":  env.BrokerVersionFallback,
 			"api.version.fallback.ms":  env.APIVersionFallbackMs,
-			"ssl.ca.location":          env.SSLCALocation,
-			"ssl.certificate.location": env.SSLClientCert,
-			"ssl.key.location":         env.SSLClientKey,
+			"ssl.ca.location":          env.SSLCAFileLocation,
+			"ssl.certificate.location": env.SSLClientCertFileLocation,
+			"ssl.key.location":         env.SSLClientKeyFileLocation,
 		})
 		if err != nil {
 			logger.Panic(err)
@@ -93,8 +93,8 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 			"sasl.mechanisms":            env.SecurityMechanisms,
 			"sasl.kerberos.service.name": env.KerberosServiceName,
 			"sasl.kerberos.principal":    env.KerberosPrincipal,
-			"sasl.kerberos.keytab":       env.KerberosKeytab,
-			"ssl.ca.location":            env.SSLCALocation,
+			"sasl.kerberos.keytab":       env.KerberosKeytabFileLocation,
+			"ssl.ca.location":            env.SSLCAFileLocation,
 		})
 
 		if err != nil {

--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -107,7 +107,7 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 	}
 
 	if kc == nil {
-		logger.Panic("kafka client is nil")
+		logger.Panic("Kafka client is nil! Please check the configuration.")
 	}
 
 	return &confluentAdapter{

--- a/pkg/targets/adapter/confluenttarget/config.go
+++ b/pkg/targets/adapter/confluenttarget/config.go
@@ -35,7 +35,7 @@ type envAccessor struct {
 	SASLPassword       string `envconfig:"CONFLUENT_SASL_PASSWORD" required:"true"`
 	Topic              string `envconfig:"CONFLUENT_TOPIC" required:"true"`
 	SecurityMechanisms string `envconfig:"CONFLUENT_SECURITY_MECANISMS" required:"true"`
-	SecurityProtocol   string `envconfig:"CONFLUENT_SECURITY_PROTOCOL" required:"true"`
+	SecurityProtocol   string `envconfig:"CONFLUENT_SECURITY_PROTOCOL" required:"false" default:"SASL_SSL"`
 
 	SSLCALocation string `envconfig:"SSL_CA_LOCATION" required:"false"`
 	SSLClientCert string `envconfig:"SSL_CLIENT_CERT" required:"false"`

--- a/pkg/targets/adapter/confluenttarget/config.go
+++ b/pkg/targets/adapter/confluenttarget/config.go
@@ -37,14 +37,14 @@ type envAccessor struct {
 	SecurityMechanisms string `envconfig:"CONFLUENT_SECURITY_MECANISMS" required:"true"`
 	SecurityProtocol   string `envconfig:"CONFLUENT_SECURITY_PROTOCOL" required:"false" default:"SASL_SSL"`
 
-	SSLCALocation string `envconfig:"SSL_CA_LOCATION" required:"false"`
-	SSLClientCert string `envconfig:"SSL_CLIENT_CERT" required:"false"`
-	SSLClientKey  string `envconfig:"SSL_CLIENT_KEY" required:"false"`
+	SSLCAFileLocation         string `envconfig:"SSL_CA_LOCATION" required:"false"`
+	SSLClientCertFileLocation string `envconfig:"SSL_CLIENT_CERT" required:"false"`
+	SSLClientKeyFileLocation  string `envconfig:"SSL_CLIENT_KEY" required:"false"`
 
-	KerberosKeytab      string `envconfig:"KERBEROS_KEYTAB" required:"false"`
-	KerberosPrincipal   string `envconfig:"KERBEROS_PRINCIPAL" required:"false" `
-	KerberosServiceName string `envconfig:"KERBEROS_SERVICE_NAME" required:"false" `
-	GroupID             string `envconfig:"CONFLUENT_GROUP_ID" required:"false" `
+	KerberosKeytabFileLocation string `envconfig:"KERBEROS_KEYTAB" required:"false"`
+	KerberosPrincipal          string `envconfig:"KERBEROS_PRINCIPAL" required:"false" `
+	KerberosServiceName        string `envconfig:"KERBEROS_SERVICE_NAME" required:"false" `
+	GroupID                    string `envconfig:"CONFLUENT_GROUP_ID" required:"false" `
 
 	// This set of variables are experimental and not graduated to the CRD.
 	BrokerVersionFallback       string `envconfig:"CONFLUENT_BROKER_VERSION_FALLBACK" required:"false" default:"0.10.0.0"`

--- a/pkg/targets/adapter/confluenttarget/config.go
+++ b/pkg/targets/adapter/confluenttarget/config.go
@@ -30,12 +30,21 @@ type envAccessor struct {
 
 	// This block of environment variables are expected to be informed
 	// by the the Confluent object and as such part of the CRD.
-	BootstrapServers string `envconfig:"CONFLUENT_BOOTSTRAP_SERVERS" required:"true"`
-	SASLUsername     string `envconfig:"CONFLUENT_SASL_USERNAME" required:"true"`
-	SASLPassword     string `envconfig:"CONFLUENT_SASL_PASSWORD" required:"true"`
-	Topic            string `envconfig:"CONFLUENT_TOPIC" required:"true"`
-	SASLMechanisms   string `envconfig:"CONFLUENT_SASL_MECHANISMS" required:"false" default:"PLAIN"`
-	SecurityProtocol string `envconfig:"CONFLUENT_SECURITY_PROTOCOL" required:"false" default:"SASL_SSL"`
+	BootstrapServers   string `envconfig:"CONFLUENT_BOOTSTRAP_SERVERS" required:"true"`
+	SASLUsername       string `envconfig:"CONFLUENT_SASL_USERNAME" required:"true"`
+	SASLPassword       string `envconfig:"CONFLUENT_SASL_PASSWORD" required:"true"`
+	Topic              string `envconfig:"CONFLUENT_TOPIC" required:"true"`
+	SecurityMechanisms string `envconfig:"CONFLUENT_SECURITY_MECANISMS" required:"true"`
+	SecurityProtocol   string `envconfig:"CONFLUENT_SECURITY_PROTOCOL" required:"true"`
+
+	SSLCALocation string `envconfig:"SSL_CA_LOCATION" required:"false"`
+	SSLClientCert string `envconfig:"SSL_CLIENT_CERT" required:"false"`
+	SSLClientKey  string `envconfig:"SSL_CLIENT_KEY" required:"false"`
+
+	KerberosKeytab      string `envconfig:"KERBEROS_KEYTAB" required:"false"`
+	KerberosPrincipal   string `envconfig:"KERBEROS_PRINCIPAL" required:"false" `
+	KerberosServiceName string `envconfig:"KERBEROS_SERVICE_NAME" required:"false" `
+	GroupID             string `envconfig:"CONFLUENT_GROUP_ID" required:"false" `
 
 	// This set of variables are experimental and not graduated to the CRD.
 	BrokerVersionFallback       string `envconfig:"CONFLUENT_BROKER_VERSION_FALLBACK" required:"false" default:"0.10.0.0"`


### PR DESCRIPTION
This update allows users to utilize an additional two security additional security mechanisms: GSSAPI, and SCRAM-SHA-256. 
