### PR TITLE
clusterroles: adds `sa/delete` permission to `triggermesh-controller` role

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -429,6 +429,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
When using OpenShift 4 based cluster, it was noticed that the controller
wasn't able to update adapter service accounts. The following error
message observed in the logs:

```
{"severity":"INFO","timestamp":"2022-06-21T04:45:03.360080151Z","logger":"triggermesh-controller.event-broadcaster","caller":"record/event.go:285","message":"Event(v1.ObjectReference{Kind:\"DataWeaveTransformation\", Namespace:\"default\", Name:\"dw-map-objects\", UID:\"01b71192-9aa8-4b6f-8c79-5751c430174b\", APIVersion:\"flow.triggermesh.io/v1alpha1\", ResourceVersion:\"6145143\", FieldPath:\"\"}): type: 'Warning' reason: 'FailedRBACUpdate' Failed to update adapter ServiceAccount \"dataweavetransformation-adapter\": serviceaccounts \"dataweavetransformation-adapter\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>","commit":"04e295f"}
```