### PR TITLE
Add visibility option to cloudevents and webhook sources

### DIFF
--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -161,7 +161,7 @@ spec:
                         value:
                           type: string
                   public:
-                    description: Endpoint visibility scope.
+                    description: Adapter visibility scope.
                     type: boolean
                   resources:
                     description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -160,6 +160,9 @@ spec:
                           type: string
                         value:
                           type: string
+                  public:
+                    description: Endpoint visibility scope.
+                    type: boolean
                   resources:
                     description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -128,7 +128,7 @@ spec:
                         value:
                           type: string
                   public:
-                    description: Endpoint visibility scope.
+                    description: Adapter visibility scope.
                     type: boolean
                   resources:
                     description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -128,7 +128,7 @@ spec:
                         value:
                           type: string
                   public:
-                    description: Adapter visibility scope.
+                    description: Endpoint visibility scope.
                     type: boolean
                   resources:
                     description: Compute Resources required by the adapter. More info at https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
@@ -57,3 +57,18 @@ func (s *CloudEventsSource) GetStatusManager() *v1alpha1.StatusManager {
 func (s *CloudEventsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
 	return s.Spec.AdapterOverrides
 }
+
+// AsEventSource implements EventSource.
+func (s *CloudEventsSource) AsEventSource() string {
+	sourceName := s.Name
+	if s.Namespace != "" {
+		sourceName = s.Namespace + "." + sourceName
+	}
+
+	return sourceName
+}
+
+// GetEventTypes implements EventSource.
+func (s *CloudEventsSource) GetEventTypes() []string {
+	return []string{"*"}
+}

--- a/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_lifecycle.go
@@ -52,3 +52,8 @@ func (s *CloudEventsSource) GetStatusManager() *v1alpha1.StatusManager {
 		Status:       &s.Status,
 	}
 }
+
+// GetAdapterOverrides implements AdapterConfigurable.
+func (s *CloudEventsSource) GetAdapterOverrides() *v1alpha1.AdapterOverrides {
+	return s.Spec.AdapterOverrides
+}

--- a/pkg/apis/sources/v1alpha1/cloudevents_types.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_types.go
@@ -39,9 +39,9 @@ type CloudEventsSource struct {
 // Check the interfaces the event source should be implementing.
 var (
 	_ v1alpha1.Reconcilable        = (*CloudEventsSource)(nil)
-	_ v1alpha1.AdapterConfigurable = (*WebhookSource)(nil)
-	_ v1alpha1.EventSource         = (*WebhookSource)(nil)
-	_ v1alpha1.EventSender         = (*WebhookSource)(nil)
+	_ v1alpha1.AdapterConfigurable = (*CloudEventsSource)(nil)
+	_ v1alpha1.EventSource         = (*CloudEventsSource)(nil)
+	_ v1alpha1.EventSender         = (*CloudEventsSource)(nil)
 )
 
 // CloudEventsSourceSpec defines the desired state of the event source.

--- a/pkg/apis/sources/v1alpha1/cloudevents_types.go
+++ b/pkg/apis/sources/v1alpha1/cloudevents_types.go
@@ -38,8 +38,10 @@ type CloudEventsSource struct {
 
 // Check the interfaces the event source should be implementing.
 var (
-	_ v1alpha1.Reconcilable = (*CloudEventsSource)(nil)
-	_ v1alpha1.EventSender  = (*CloudEventsSource)(nil)
+	_ v1alpha1.Reconcilable        = (*CloudEventsSource)(nil)
+	_ v1alpha1.AdapterConfigurable = (*WebhookSource)(nil)
+	_ v1alpha1.EventSource         = (*WebhookSource)(nil)
+	_ v1alpha1.EventSender         = (*WebhookSource)(nil)
 )
 
 // CloudEventsSourceSpec defines the desired state of the event source.
@@ -59,6 +61,10 @@ type CloudEventsSourceSpec struct {
 	// the rate limiting configuration being applied to each of them individually.
 	// +optional
 	RateLimiter *RateLimiter `json:"rateLimiter,omitempty"`
+
+	// Adapter spec overrides parameters.
+	// +optional
+	AdapterOverrides *v1alpha1.AdapterOverrides `json:"adapterOverrides,omitempty"`
 }
 
 // HTTPCredentials to be used when receiving requests.

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -2463,6 +2463,11 @@ func (in *CloudEventsSourceSpec) DeepCopyInto(out *CloudEventsSourceSpec) {
 		*out = new(RateLimiter)
 		**out = **in
 	}
+	if in.AdapterOverrides != nil {
+		in, out := &in.AdapterOverrides, &out.AdapterOverrides
+		*out = new(commonv1alpha1.AdapterOverrides)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/sources/reconciler/cloudeventssource/adapter.go
+++ b/pkg/sources/reconciler/cloudeventssource/adapter.go
@@ -111,10 +111,22 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
 
+	// Common reconciler internals set the visibility to non public by default. That does
+	// not play well with sources which should default to being public if no visibility
+	// configuration is provided.
+	switch {
+	case typedSrc.Spec.AdapterOverrides == nil:
+		t := true
+		typedSrc.Spec.AdapterOverrides = &commonv1alpha1.AdapterOverrides{
+			Public: &t,
+		}
+	case typedSrc.Spec.AdapterOverrides.Public == nil:
+		t := true
+		typedSrc.Spec.AdapterOverrides.Public = &t
+	}
+
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-
-		resource.VisibilityPublic,
 
 		resource.Volumes(authVolumes...),
 		resource.VolumeMounts(authVolumeMounts...),


### PR DESCRIPTION
Add visibility options to 
- CloudEventsSource
- WebhookSource

Defaulting both of them to public visibility.

This is how they can be set to in-cluster only:

```yaml
apiVersion: sources.triggermesh.io/v1alpha1
kind: CloudEventsSource
metadata:
  name: sample
spec:
  sink:
    ref:
      apiVersion: eventing.knative.dev/v1
      kind: Broker
      name: default

  adapterOverrides:
    public: false
``
