### PR TITLE
Export MakeAppEnv functions

### DIFF
--- a/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/adapter.go
+++ b/hack/targetgen/scaffolding/pkg/targets/reconciler/newtarget/adapter.go
@@ -49,7 +49,7 @@ func makeTargetAdapterKService(target *v1alpha1.{{.Kind}}, cfg *adapterConfig) *
 	ksvcLabels := libreconciler.MakeAdapterLabels(adapterName, target)
 	podLabels := libreconciler.MakeAdapterLabels(adapterName, target)
 	envSvc := libreconciler.MakeServiceEnv(name, target.Namespace)
-	envApp := makeAppEnv(target)
+	envApp := MakeAppEnv(target)
 	envObs := libreconciler.MakeObsEnv(cfg.obsConfig)
 	envs := append(envSvc, envApp...)
 	envs = append(envs, envObs...)
@@ -63,7 +63,9 @@ func makeTargetAdapterKService(target *v1alpha1.{{.Kind}}, cfg *adapterConfig) *
 	)
 }
 
-func makeAppEnv(o *v1alpha1.{{.Kind}}) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.{{.Kind}}) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  libreconciler.EnvBridgeID,

--- a/pkg/flow/reconciler/dataweavetransformation/adapter.go
+++ b/pkg/flow/reconciler/dataweavetransformation/adapter.go
@@ -56,12 +56,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(trg, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.DataWeaveTransformation) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.DataWeaveTransformation) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		*o.Spec.DwSpell.ToEnvironmentVariable(envDWSPELL),
 		{

--- a/pkg/flow/reconciler/jqtransformation/adapter.go
+++ b/pkg/flow/reconciler/jqtransformation/adapter.go
@@ -52,12 +52,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(trg, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.JQTransformation) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.JQTransformation) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envQuery,

--- a/pkg/flow/reconciler/synchronizer/adapter.go
+++ b/pkg/flow/reconciler/synchronizer/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(trg, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.Synchronizer) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.Synchronizer) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  common.EnvBridgeID,

--- a/pkg/flow/reconciler/xmltojsontransformation/adapter.go
+++ b/pkg/flow/reconciler/xmltojsontransformation/adapter.go
@@ -51,12 +51,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(trg, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.XMLToJSONTransformation) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.XMLToJSONTransformation) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  common.EnvBridgeID,

--- a/pkg/flow/reconciler/xslttransformation/adapter.go
+++ b/pkg/flow/reconciler/xslttransformation/adapter.go
@@ -54,12 +54,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, sinkURI *apis
 
 	return common.NewAdapterKnService(trg, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.XSLTTransformation) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.XSLTTransformation) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		*o.Spec.XSLT.ToEnvironmentVariable(envXSLT),
 		{

--- a/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchlogssource/adapter.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -53,20 +54,34 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCloudWatchLogsSource)
 
-	pollingInterval := defaultPollingInterval
-	if f := typedSrc.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
-		pollingInterval = time.Duration(*f)
-	}
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVar(envPollingInterval, pollingInterval.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSCloudWatchLogsSource) []corev1.EnvVar {
+	pollingInterval := defaultPollingInterval
+	if f := o.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
+		pollingInterval = time.Duration(*f)
+	}
+
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			}, {
+				Name:  envPollingInterval,
+				Value: pollingInterval.String(),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awscloudwatchsource/adapter.go
+++ b/pkg/sources/reconciler/awscloudwatchsource/adapter.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -59,8 +60,27 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSCloudWatchSource)
 
+	env, err := MakeAppEnv(typedSrc)
+	if err != nil {
+		return nil, fmt.Errorf("building adapter environment: %w", err)
+	}
+
+	return common.NewAdapterDeployment(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVars(env...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+
+		resource.Port(healthPortName, 8080),
+		resource.StartupProbe("/health", healthPortName),
+	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSCloudWatchSource) ([]corev1.EnvVar, error) {
 	var queries string
-	if qs := typedSrc.Spec.MetricQueries; len(qs) > 0 {
+	if qs := o.Spec.MetricQueries; len(qs) > 0 {
 		q, err := json.Marshal(qs)
 		if err != nil {
 			return nil, fmt.Errorf("serializing spec.metricQueries to JSON: %w", err)
@@ -69,20 +89,22 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	}
 
 	pollingInterval := defaultPollingInterval
-	if f := typedSrc.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
+	if f := o.Spec.PollingInterval; f != nil && time.Duration(*f).Nanoseconds() > 0 {
 		pollingInterval = time.Duration(*f)
 	}
 
-	return common.NewAdapterDeployment(src, sinkURI,
-		resource.Image(r.adapterCfg.Image),
-
-		resource.EnvVar(envRegion, typedSrc.Spec.Region),
-		resource.EnvVar(envQueries, queries),
-		resource.EnvVar(envPollingInterval, pollingInterval.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
-		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
-
-		resource.Port(healthPortName, 8080),
-		resource.StartupProbe("/health", healthPortName),
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  envRegion,
+				Value: o.Spec.Region,
+			}, {
+				Name:  envQueries,
+				Value: queries,
+			}, {
+				Name:  envPollingInterval,
+				Value: pollingInterval.String(),
+			},
+		}...,
 	), nil
 }

--- a/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/reconciler/awscognitoidentitysource/adapter.go
@@ -18,6 +18,7 @@ package awscognitoidentitysource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -50,11 +51,23 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSCognitoIdentitySource) []corev1.EnvVar {
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/reconciler/awscognitouserpoolsource/adapter.go
@@ -18,6 +18,7 @@ package awscognitouserpoolsource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -50,11 +51,23 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSCognitoUserPoolSource) []corev1.EnvVar {
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awsdynamodbsource/adapter.go
+++ b/pkg/sources/reconciler/awsdynamodbsource/adapter.go
@@ -18,6 +18,7 @@ package awsdynamodbsource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -50,11 +51,23 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSDynamoDBSource) []corev1.EnvVar {
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awskinesissource/adapter.go
+++ b/pkg/sources/reconciler/awskinesissource/adapter.go
@@ -18,6 +18,7 @@ package awskinesissource
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -50,11 +51,23 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSKinesisSource) []corev1.EnvVar {
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/reconciler/awsperformanceinsightssource/adapter.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -57,13 +58,29 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, typedSrc.Spec.ARN.String()),
-		resource.EnvVar(envPollingInterval, typedSrc.Spec.PollingInterval.String()),
-		resource.EnvVar(envMetrics, strings.Join(typedSrc.Spec.Metrics, ",")),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSPerformanceInsightsSource) []corev1.EnvVar {
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: o.Spec.ARN.String(),
+			}, {
+				Name:  envPollingInterval,
+				Value: o.Spec.PollingInterval.String(),
+			}, {
+				Name:  envMetrics,
+				Value: strings.Join(o.Spec.Metrics, ","),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -18,6 +18,7 @@ package awss3source
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
@@ -50,20 +51,34 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AWSS3Source)
 
-	// the user may or may not provide a queue ARN in the source's spec, so
-	// the source's status is unfortunately our only source of truth here
-	queueARN := typedSrc.Status.QueueARN
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvARN, queueARN.String()),
-		resource.EnvVars(reconciler.MakeAWSAuthEnvVars(typedSrc.Spec.Auth)...),
-		resource.EnvVar(envMessageProcessor, "s3"),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSS3Source) []corev1.EnvVar {
+	// the user may or may not provide a queue ARN in the source's spec, so
+	// the source's status is unfortunately our only source of truth here
+	queueARN := o.Status.QueueARN
+
+	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvARN,
+				Value: queueARN.String(),
+			}, {
+				Name:  envMessageProcessor,
+				Value: "s3",
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/azureblobstoragesource/adapter.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/adapter.go
@@ -50,34 +50,51 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureBlobStorageSource)
 
-	// the user may or may not provide an Event Hub name in the source's
-	// spec, so the source's status is unfortunately our only source of
-	// truth here
-	var hubResID string
-	var hubName string
-	if ehID := typedSrc.Status.EventHubID; ehID != nil {
-		hubResID = ehID.String()
-		hubName = ehID.ResourceName
-	}
-
-	var hubEnvs []corev1.EnvVar
-	if spAuth := typedSrc.Spec.Auth.ServicePrincipal; spAuth != nil {
-		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADTenantID, spAuth.TenantID)
-		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADClientID, spAuth.ClientID)
-		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADClientSecret, spAuth.ClientSecret)
-	}
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvHubResourceID, hubResID),
-		resource.EnvVar(common.EnvHubNamespace, typedSrc.Spec.Endpoint.EventHubs.NamespaceID.ResourceName),
-		resource.EnvVar(common.EnvHubName, hubName),
-		resource.EnvVars(hubEnvs...),
-		resource.EnvVar(envMessageProcessor, "eventgrid"),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Port(healthPortName, 8080),
 		resource.StartupProbe("/health", healthPortName),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AzureBlobStorageSource) []corev1.EnvVar {
+	// the user may or may not provide an Event Hub name in the source's
+	// spec, so the source's status is unfortunately our only source of
+	// truth here
+	var hubResID string
+	var hubName string
+	if ehID := o.Status.EventHubID; ehID != nil {
+		hubResID = ehID.String()
+		hubName = ehID.ResourceName
+	}
+
+	var hubEnvs []corev1.EnvVar
+	if spAuth := o.Spec.Auth.ServicePrincipal; spAuth != nil {
+		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADTenantID, spAuth.TenantID)
+		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADClientID, spAuth.ClientID)
+		hubEnvs = common.MaybeAppendValueFromEnvVar(hubEnvs, common.EnvAADClientSecret, spAuth.ClientSecret)
+	}
+
+	return append(hubEnvs, []corev1.EnvVar{
+		{
+			Name:  common.EnvHubResourceID,
+			Value: hubResID,
+		}, {
+			Name:  common.EnvHubNamespace,
+			Value: o.Spec.Endpoint.EventHubs.NamespaceID.ResourceName,
+		}, {
+			Name:  common.EnvHubName,
+			Value: hubName,
+		}, {
+			Name:  envMessageProcessor,
+			Value: "eventgrid",
+		},
+	}...,
+	)
 }

--- a/pkg/sources/reconciler/azureiothubsource/adapter.go
+++ b/pkg/sources/reconciler/azureiothubsource/adapter.go
@@ -46,11 +46,16 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 // BuildAdapter implements common.AdapterBuilder.
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.AzureIOTHubSource)
-	iotHubEnvs := []corev1.EnvVar{}
-	iotHubEnvs = common.MaybeAppendValueFromEnvVar(iotHubEnvs, envAzureIOTHubConnString, typedSrc.Spec.Auth.SASToken.ConnectionString)
+
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(iotHubEnvs...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AzureIOTHubSource) []corev1.EnvVar {
+	return common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, envAzureIOTHubConnString, o.Spec.Auth.SASToken.ConnectionString)
 }

--- a/pkg/sources/reconciler/cloudeventssource/adapter.go
+++ b/pkg/sources/reconciler/cloudeventssource/adapter.go
@@ -132,7 +132,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 		resource.VolumeMounts(authVolumeMounts...),
 		resource.EnvVars(authEnvs...),
 
-		resource.EnvVars(makeAppEnv(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
@@ -150,8 +150,9 @@ func (kmv *KeyMountedValue) Decode(value string) error {
 	return nil
 }
 
-// makeAppEnv creates the environment variables specific to this adapter component.
-func makeAppEnv(o *v1alpha1.CloudEventsSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.CloudEventsSource) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  common.EnvBridgeID,

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -48,25 +48,38 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudAuditLogsSource)
 
-	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var subsName string
-	if sn := typedSrc.Status.Subscription; sn != nil {
-		subsName = sn.String()
-	}
-
-	var authEnvs []corev1.EnvVar
-	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
-
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
-		resource.EnvVars(authEnvs...),
-		resource.EnvVar(common.EnvCESource, src.(commonv1alpha1.EventSource).AsEventSource()),
-		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudAuditLogsGenericEventType),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudAuditLogsSource) []corev1.EnvVar {
+	// we rely on the source's status to persist the ID of the Pub/Sub subscription
+	var subsName string
+	if sn := o.Status.Subscription; sn != nil {
+		subsName = sn.String()
+	}
+
+	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvGCloudPubSubSubscription,
+				Value: subsName,
+			}, {
+				Name:  common.EnvCESource,
+				Value: o.AsEventSource(),
+			}, {
+				Name:  common.EnvCEType,
+				Value: v1alpha1.GoogleCloudAuditLogsGenericEventType,
+			}, {
+				Name:  adapter.EnvConfigCEOverrides,
+				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/googlecloudiotsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudiotsource/adapter.go
@@ -48,25 +48,38 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudIoTSource)
 
-	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var subsName string
-	if sn := typedSrc.Status.Subscription; sn != nil {
-		subsName = sn.String()
-	}
-
-	var authEnvs []corev1.EnvVar
-	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
-
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
-		resource.EnvVars(authEnvs...),
-		resource.EnvVar(common.EnvCESource, src.(commonv1alpha1.EventSource).AsEventSource()),
-		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudIoTGenericEventType),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudIoTSource) []corev1.EnvVar {
+	// we rely on the source's status to persist the ID of the Pub/Sub subscription
+	var subsName string
+	if sn := o.Status.Subscription; sn != nil {
+		subsName = sn.String()
+	}
+
+	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvGCloudPubSubSubscription,
+				Value: subsName,
+			}, {
+				Name:  common.EnvCESource,
+				Value: o.AsEventSource(),
+			}, {
+				Name:  common.EnvCEType,
+				Value: v1alpha1.GoogleCloudIoTGenericEventType,
+			}, {
+				Name:  adapter.EnvConfigCEOverrides,
+				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -48,25 +48,38 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudSourceRepositoriesSource)
 
-	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var subsName string
-	if sn := typedSrc.Status.Subscription; sn != nil {
-		subsName = sn.String()
-	}
-
-	var authEnvs []corev1.EnvVar
-	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
-
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
-		resource.EnvVars(authEnvs...),
-		resource.EnvVar(common.EnvCESource, src.(commonv1alpha1.EventSource).AsEventSource()),
-		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudSourceRepoGenericEventType),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudSourceRepositoriesSource) []corev1.EnvVar {
+	// we rely on the source's status to persist the ID of the Pub/Sub subscription
+	var subsName string
+	if sn := o.Status.Subscription; sn != nil {
+		subsName = sn.String()
+	}
+
+	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvGCloudPubSubSubscription,
+				Value: subsName,
+			}, {
+				Name:  common.EnvCESource,
+				Value: o.AsEventSource(),
+			}, {
+				Name:  common.EnvCEType,
+				Value: v1alpha1.GoogleCloudSourceRepoGenericEventType,
+			}, {
+				Name:  adapter.EnvConfigCEOverrides,
+				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -48,25 +48,38 @@ var _ common.AdapterBuilder[*appsv1.Deployment] = (*Reconciler)(nil)
 func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis.URL) (*appsv1.Deployment, error) {
 	typedSrc := src.(*v1alpha1.GoogleCloudStorageSource)
 
-	// we rely on the source's status to persist the ID of the Pub/Sub subscription
-	var subsName string
-	if sn := typedSrc.Status.Subscription; sn != nil {
-		subsName = sn.String()
-	}
-
-	var authEnvs []corev1.EnvVar
-	authEnvs = common.MaybeAppendValueFromEnvVar(authEnvs, common.EnvGCloudSAKey, typedSrc.Spec.ServiceAccountKey)
-
-	ceOverridesStr := cloudevents.OverridesJSON(typedSrc.Spec.CloudEventOverrides)
-
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVar(common.EnvGCloudPubSubSubscription, subsName),
-		resource.EnvVars(authEnvs...),
-		resource.EnvVar(common.EnvCESource, src.(commonv1alpha1.EventSource).AsEventSource()),
-		resource.EnvVar(common.EnvCEType, v1alpha1.GoogleCloudStorageGenericEventType),
-		resource.EnvVar(adapter.EnvConfigCEOverrides, ceOverridesStr),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
+}
+
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudStorageSource) []corev1.EnvVar {
+	// we rely on the source's status to persist the ID of the Pub/Sub subscription
+	var subsName string
+	if sn := o.Status.Subscription; sn != nil {
+		subsName = sn.String()
+	}
+
+	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
+		[]corev1.EnvVar{
+			{
+				Name:  common.EnvGCloudPubSubSubscription,
+				Value: subsName,
+			}, {
+				Name:  common.EnvCESource,
+				Value: o.AsEventSource(),
+			}, {
+				Name:  common.EnvCEType,
+				Value: v1alpha1.GoogleCloudSourceRepoGenericEventType,
+			}, {
+				Name:  adapter.EnvConfigCEOverrides,
+				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+			},
+		}...,
+	)
 }

--- a/pkg/sources/reconciler/httppollersource/adapter.go
+++ b/pkg/sources/reconciler/httppollersource/adapter.go
@@ -63,12 +63,14 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVars(makeHTTPPollerEnvs(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
 }
 
-func makeHTTPPollerEnvs(src *v1alpha1.HTTPPollerSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(src *v1alpha1.HTTPPollerSource) []corev1.EnvVar {
 	skipVerify := false
 	if src.Spec.SkipVerify != nil {
 		skipVerify = *src.Spec.SkipVerify

--- a/pkg/sources/reconciler/ibmmqsource/adapter.go
+++ b/pkg/sources/reconciler/ibmmqsource/adapter.go
@@ -92,7 +92,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVars(makeAppEnv(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Volumes(secretVolumes...),
@@ -100,7 +100,9 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.IBMMQSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.IBMMQSource) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envConnectionName,

--- a/pkg/sources/reconciler/kafkasource/adapter.go
+++ b/pkg/sources/reconciler/kafkasource/adapter.go
@@ -105,7 +105,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterDeployment(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVars(makeAppEnv(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 
 		resource.Volumes(secretVolumes...),
@@ -113,7 +113,9 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.KafkaSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.KafkaSource) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  envBootstrapServers,

--- a/pkg/sources/reconciler/slacksource/adapter.go
+++ b/pkg/sources/reconciler/slacksource/adapter.go
@@ -56,12 +56,14 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 
 		resource.VisibilityPublic,
 
-		resource.EnvVars(makeSlackEnvs(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
 }
 
-func makeSlackEnvs(src *v1alpha1.SlackSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(src *v1alpha1.SlackSource) []corev1.EnvVar {
 	var slackEnvs []corev1.EnvVar
 
 	if appID := src.Spec.AppID; appID != nil {

--- a/pkg/sources/reconciler/webhooksource/adapter.go
+++ b/pkg/sources/reconciler/webhooksource/adapter.go
@@ -74,12 +74,14 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 	return common.NewAdapterKnService(src, sinkURI,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVars(makeWebhookEnvs(typedSrc)...),
+		resource.EnvVars(MakeAppEnv(typedSrc)...),
 		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
 	), nil
 }
 
-func makeWebhookEnvs(src *v1alpha1.WebhookSource) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(src *v1alpha1.WebhookSource) []corev1.EnvVar {
 	envs := []corev1.EnvVar{{
 		Name:  envWebhookEventType,
 		Value: src.Spec.EventType,

--- a/pkg/targets/reconciler/alibabaosstarget/adapter.go
+++ b/pkg/targets/reconciler/alibabaosstarget/adapter.go
@@ -55,12 +55,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AlibabaOSSTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AlibabaOSSTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envEndpoint,

--- a/pkg/targets/reconciler/awscomprehendtarget/adapter.go
+++ b/pkg/targets/reconciler/awscomprehendtarget/adapter.go
@@ -53,12 +53,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSComprehendTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSComprehendTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envRegion,

--- a/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
+++ b/pkg/targets/reconciler/awsdynamodbtarget/adapter.go
@@ -47,12 +47,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSDynamoDBTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSDynamoDBTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awseventbridgetarget/adapter.go
+++ b/pkg/targets/reconciler/awseventbridgetarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSEventBridgeTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSEventBridgeTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awskinesistarget/adapter.go
+++ b/pkg/targets/reconciler/awskinesistarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSKinesisTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSKinesisTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awslambdatarget/adapter.go
+++ b/pkg/targets/reconciler/awslambdatarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSLambdaTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSLambdaTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awss3target/adapter.go
+++ b/pkg/targets/reconciler/awss3target/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSS3Target) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSS3Target) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awssnstarget/adapter.go
+++ b/pkg/targets/reconciler/awssnstarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSSNSTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSSNSTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/awssqstarget/adapter.go
+++ b/pkg/targets/reconciler/awssqstarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.AWSSQSTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.AWSSQSTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: common.EnvAccessKeyID,

--- a/pkg/targets/reconciler/cloudeventstarget/adapter.go
+++ b/pkg/targets/reconciler/cloudeventstarget/adapter.go
@@ -81,7 +81,7 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 	}
 
 	options = append(options,
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		// make sure that a non optional parameter is located as the last element
 		// to avoid derivative comparison issues when the environment variables
 		// tail element is removed.
@@ -92,7 +92,9 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 	return common.NewAdapterKnService(trg, nil, options...), nil
 }
 
-func makeAppEnv(o *v1alpha1.CloudEventsTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.CloudEventsTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envCloudEventsURL,

--- a/pkg/targets/reconciler/confluenttarget/adapter.go
+++ b/pkg/targets/reconciler/confluenttarget/adapter.go
@@ -50,12 +50,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.ConfluentTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.ConfluentTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  "CONFLUENT_SASL_USERNAME",

--- a/pkg/targets/reconciler/datadogtarget/adapter.go
+++ b/pkg/targets/reconciler/datadogtarget/adapter.go
@@ -52,12 +52,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.DatadogTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.DatadogTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: envDatadogAPIKey,

--- a/pkg/targets/reconciler/elasticsearchtarget/adapter.go
+++ b/pkg/targets/reconciler/elasticsearchtarget/adapter.go
@@ -52,12 +52,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.ElasticsearchTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.ElasticsearchTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  "ELASTICSEARCH_INDEX",

--- a/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudfirestoretarget/adapter.go
@@ -56,12 +56,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.GoogleCloudFirestoreTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudFirestoreTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envDefaultCollection,

--- a/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudstoragetarget/adapter.go
@@ -51,12 +51,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.GoogleCloudStorageTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudStorageTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  "GOOGLE_STORAGE_BUCKET_NAME",

--- a/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
+++ b/pkg/targets/reconciler/googlecloudworkflowstarget/adapter.go
@@ -51,12 +51,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.GoogleCloudWorkflowsTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleCloudWorkflowsTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: common.EnvGCloudSAKey,

--- a/pkg/targets/reconciler/googlesheettarget/adapter.go
+++ b/pkg/targets/reconciler/googlesheettarget/adapter.go
@@ -52,12 +52,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.GoogleSheetTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.GoogleSheetTarget) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name: common.EnvGCloudSAKey,

--- a/pkg/targets/reconciler/hasuratarget/adapter.go
+++ b/pkg/targets/reconciler/hasuratarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.HasuraTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.HasuraTarget) []corev1.EnvVar {
 	envs := []corev1.EnvVar{{
 		Name:  "HASURA_ENDPOINT",
 		Value: o.Spec.Endpoint,

--- a/pkg/targets/reconciler/httptarget/adapter.go
+++ b/pkg/targets/reconciler/httptarget/adapter.go
@@ -67,12 +67,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.HTTPTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.HTTPTarget) []corev1.EnvVar {
 	skipVerify := false
 	if o.Spec.SkipVerify != nil {
 		skipVerify = *o.Spec.SkipVerify

--- a/pkg/targets/reconciler/ibmmqtarget/adapter.go
+++ b/pkg/targets/reconciler/ibmmqtarget/adapter.go
@@ -93,7 +93,7 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
 
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 
 		resource.Volumes(secretVolumes...),
@@ -101,7 +101,9 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.IBMMQTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.IBMMQTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  common.EnvBridgeID,

--- a/pkg/targets/reconciler/infratarget/adapter.go
+++ b/pkg/targets/reconciler/infratarget/adapter.go
@@ -57,12 +57,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.InfraTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.InfraTarget) []corev1.EnvVar {
 	var env []corev1.EnvVar
 
 	if o.Spec.Script != nil {

--- a/pkg/targets/reconciler/jiratarget/adapter.go
+++ b/pkg/targets/reconciler/jiratarget/adapter.go
@@ -53,12 +53,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.JiraTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.JiraTarget) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  envJiraAuthUser,

--- a/pkg/targets/reconciler/kafkatarget/adapter.go
+++ b/pkg/targets/reconciler/kafkatarget/adapter.go
@@ -103,14 +103,16 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 		resource.Volumes(secretVolumes...),
 		resource.VolumeMounts(secretVolMounts...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.KafkaTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.KafkaTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envBootstrapServers,

--- a/pkg/targets/reconciler/logzmetricstarget/adapter.go
+++ b/pkg/targets/reconciler/logzmetricstarget/adapter.go
@@ -58,12 +58,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.LogzMetricsTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.LogzMetricsTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: envCortexBearerToken,

--- a/pkg/targets/reconciler/logztarget/adapter.go
+++ b/pkg/targets/reconciler/logztarget/adapter.go
@@ -53,12 +53,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.LogzTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.LogzTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: envShippingToken,

--- a/pkg/targets/reconciler/oracletarget/adapter.go
+++ b/pkg/targets/reconciler/oracletarget/adapter.go
@@ -47,12 +47,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.OracleTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.OracleTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: "ORACLE_API_PRIVATE_KEY",

--- a/pkg/targets/reconciler/salesforcetarget/adapter.go
+++ b/pkg/targets/reconciler/salesforcetarget/adapter.go
@@ -56,12 +56,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.SalesforceTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.SalesforceTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  envSalesforceAuthClientID,

--- a/pkg/targets/reconciler/sendgridtarget/adapter.go
+++ b/pkg/targets/reconciler/sendgridtarget/adapter.go
@@ -47,12 +47,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.SendGridTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.SendGridTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: "SENDGRID_API_KEY",

--- a/pkg/targets/reconciler/slacktarget/adapter.go
+++ b/pkg/targets/reconciler/slacktarget/adapter.go
@@ -47,12 +47,12 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.SlackTarget) []corev1.EnvVar {
+func MakeAppEnv(o *v1alpha1.SlackTarget) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name: "SLACK_TOKEN",

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -56,12 +56,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.SplunkTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.SplunkTarget) []corev1.EnvVar {
 	hecURL := apis.URL{
 		Scheme: o.Spec.Endpoint.Scheme,
 		Host:   o.Spec.Endpoint.Host,

--- a/pkg/targets/reconciler/tektontarget/adapter.go
+++ b/pkg/targets/reconciler/tektontarget/adapter.go
@@ -49,12 +49,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.TektonTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.TektonTarget) []corev1.EnvVar {
 	var envVar []corev1.EnvVar
 
 	if o.Spec.ReapPolicy != nil {

--- a/pkg/targets/reconciler/twiliotarget/adapter.go
+++ b/pkg/targets/reconciler/twiliotarget/adapter.go
@@ -55,12 +55,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.TwilioTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.TwilioTarget) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name: envTwilioSID,

--- a/pkg/targets/reconciler/uipathtarget/adapter.go
+++ b/pkg/targets/reconciler/uipathtarget/adapter.go
@@ -47,12 +47,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.UiPathTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.UiPathTarget) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "UIPATH_ROBOT_NAME",

--- a/pkg/targets/reconciler/zendesktarget/adapter.go
+++ b/pkg/targets/reconciler/zendesktarget/adapter.go
@@ -47,12 +47,14 @@ func (r *Reconciler) BuildAdapter(trg commonv1alpha1.Reconcilable, _ *apis.URL) 
 
 	return common.NewAdapterKnService(trg, nil,
 		resource.Image(r.adapterCfg.Image),
-		resource.EnvVars(makeAppEnv(typedTrg)...),
+		resource.EnvVars(MakeAppEnv(typedTrg)...),
 		resource.EnvVars(r.adapterCfg.obsConfig.ToEnvVars()...),
 	), nil
 }
 
-func makeAppEnv(o *v1alpha1.ZendeskTarget) []corev1.EnvVar {
+// MakeAppEnv extracts environment variables from the object.
+// Exported to be used in external tools for local test environments.
+func MakeAppEnv(o *v1alpha1.ZendeskTarget) []corev1.EnvVar {
 	return []corev1.EnvVar{{
 		Name: "TOKEN",
 		ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Mostly a batch update of `BuildAdapter` methods to export `makeAppEnv` function that extracts environment variables from TriggerMesh objects - I think this is the least intrusive way to enable re-use of our adapters in different platforms. Required by WIP testing tool.
No logic should have been changed, a pair of eyes may help find possible mechanic errors/typos. 