### PR TITLE
Add support for AWS SQS Targets #1039

### DIFF
--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -85,6 +85,9 @@ spec:
                 description: ARN of the SQS queue that will receive events. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
+              messageGroupId:
+                description: FIFO queue grouping to ensure proper ordering. Should be unique per target
+                type: string
               discardCloudEventContext:
                 description: Whether to omit CloudEvent context attributes in messages sent to SQS. When this property is
                   false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent

--- a/pkg/apis/targets/v1alpha1/aws_sqs_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_types.go
@@ -55,6 +55,7 @@ type AWSSQSTargetSpec struct {
 
 	// Message Group ID is required for FIFO based queues, and is used to uniquely identify the event producer
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-understanding-logic.html
+	// +optional
 	MessageGroupID string `json:"messageGroupId,omitempty"`
 
 	// Whether to omit CloudEvent context attributes in messages sent to SQS.

--- a/pkg/apis/targets/v1alpha1/aws_sqs_types.go
+++ b/pkg/apis/targets/v1alpha1/aws_sqs_types.go
@@ -53,6 +53,10 @@ type AWSSQSTargetSpec struct {
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html#amazonsqs-resources-for-iam-policies
 	ARN string `json:"arn"`
 
+	// Message Group ID is required for FIFO based queues, and is used to uniquely identify the event producer
+	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-understanding-logic.html
+	MessageGroupID string `json:"messageGroupId,omitempty"`
+
 	// Whether to omit CloudEvent context attributes in messages sent to SQS.
 	// When this property is false (default), the entire CloudEvent payload is included.
 	// When this property is true, only the CloudEvent data is included.

--- a/pkg/targets/adapter/awssqstarget/adapter.go
+++ b/pkg/targets/adapter/awssqstarget/adapter.go
@@ -113,12 +113,12 @@ func (a *adapter) dispatch(event cloudevents.Event) (*cloudevents.Event, cloudev
 	var err error
 	var result *sqs.SendMessageOutput
 	if strings.HasSuffix(url, ".fifo") {
-		ceID := event.ID()
+		dedupID := event.ID() + ";" + event.Source()
 		result, err = a.sqsClient.SendMessage(&sqs.SendMessageInput{
 			MessageBody:            aws.String(string(msg)),
 			QueueUrl:               &url,
 			MessageGroupId:         &a.messageGroupID,
-			MessageDeduplicationId: &ceID,
+			MessageDeduplicationId: &dedupID,
 		})
 	} else {
 		result, err = a.sqsClient.SendMessage(&sqs.SendMessageInput{

--- a/pkg/targets/adapter/awssqstarget/adapter.go
+++ b/pkg/targets/adapter/awssqstarget/adapter.go
@@ -113,12 +113,12 @@ func (a *adapter) dispatch(event cloudevents.Event) (*cloudevents.Event, cloudev
 	var err error
 	var result *sqs.SendMessageOutput
 	if strings.HasSuffix(url, ".fifo") {
-		ceId := event.ID()
+		ceID := event.ID()
 		result, err = a.sqsClient.SendMessage(&sqs.SendMessageInput{
 			MessageBody:            aws.String(string(msg)),
 			QueueUrl:               &url,
 			MessageGroupId:         &a.messageGroupID,
-			MessageDeduplicationId: &ceId,
+			MessageDeduplicationId: &ceID,
 		})
 	} else {
 		result, err = a.sqsClient.SendMessage(&sqs.SendMessageInput{

--- a/pkg/targets/adapter/awssqstarget/config.go
+++ b/pkg/targets/adapter/awssqstarget/config.go
@@ -31,9 +31,10 @@ func NewEnvConfig() pkgadapter.EnvConfigAccessor {
 type envAccessor struct {
 	pkgadapter.EnvConfig
 
-	AWSApiKey    string `envconfig:"AWS_ACCESS_KEY_ID" required:"true"`
-	AWSApiSecret string `envconfig:"AWS_SECRET_ACCESS_KEY" required:"true"`
-	AwsTargetArn string `envconfig:"ARN" required:"true"`
+	AWSApiKey      string `envconfig:"AWS_ACCESS_KEY_ID" required:"true"`
+	AWSApiSecret   string `envconfig:"AWS_SECRET_ACCESS_KEY" required:"true"`
+	AwsTargetArn   string `envconfig:"ARN" required:"true"`
+	MessageGroupID string `envconfig:"AWS_MESSAGE_GROUP_ID"`
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 }

--- a/pkg/targets/reconciler/awssqstarget/adapter.go
+++ b/pkg/targets/reconciler/awssqstarget/adapter.go
@@ -72,6 +72,9 @@ func makeAppEnv(o *v1alpha1.AWSSQSTarget) []corev1.EnvVar {
 		}, {
 			Name:  "AWS_DISCARD_CE_CONTEXT",
 			Value: strconv.FormatBool(o.Spec.DiscardCEContext),
+		}, {
+			Name:  "AWS_MESSAGE_GROUP_ID",
+			Value: o.Spec.MessageGroupID,
 		},
 	}
 


### PR DESCRIPTION
Add support for the AWS SQS FIFO queues by introducing a new optional environment variable `AWS_GROUP_MESSGE_ID` that can be set as a string, and use the CloudEvent ID as the message deduplication ID.

Closes #1039 