### PR TITLE
Transformation operations support full CE body

### DIFF
--- a/pkg/flow/adapter/transformation/adapter_test.go
+++ b/pkg/flow/adapter/transformation/adapter_test.go
@@ -196,6 +196,21 @@ func TestReceiveAndTransform(t *testing.T) {
 				},
 			},
 		}, {
+			name: "Shift full body",
+			originalEvent: setData(t, newEvent(),
+				json.RawMessage(`[{"key1":"value1"}]`)),
+			expectedEventData: `{"body":[{"key1":"value1"}]}`,
+			data: []v1alpha1.Transform{
+				{
+					Operation: "shift",
+					Paths: []v1alpha1.Path{
+						{
+							Key: ".:body",
+						},
+					},
+				},
+			},
+		}, {
 			name: "Store operation",
 			originalEvent: setData(t, newEvent(),
 				json.RawMessage(`{"key1":"value1","object":{"foo":"bar"}}`)),
@@ -221,6 +236,37 @@ func TestReceiveAndTransform(t *testing.T) {
 						}, {
 							Key:   "object.foo",
 							Value: "$var1",
+						},
+					},
+				},
+			},
+		}, {
+			name: "Store full body",
+			originalEvent: setData(t, newEvent(),
+				json.RawMessage(`[{"key1":"value1"}]`)),
+			expectedEventData: `{"body":[{"key1":"value1"}]}`,
+			data: []v1alpha1.Transform{
+				{
+					Operation: "store",
+					Paths: []v1alpha1.Path{
+						{
+							Key:   "$body",
+							Value: ".",
+						},
+					},
+				}, {
+					Operation: "delete",
+					Paths: []v1alpha1.Path{
+						{
+							Key: "",
+						},
+					},
+				}, {
+					Operation: "add",
+					Paths: []v1alpha1.Path{
+						{
+							Key:   "body",
+							Value: "$body",
 						},
 					},
 				},

--- a/pkg/flow/adapter/transformation/common/utils.go
+++ b/pkg/flow/adapter/transformation/common/utils.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// ReadValue returns the source object item located at the requested path.
+func ReadValue(source interface{}, path map[string]interface{}) interface{} {
+	var result interface{}
+	for k, v := range path {
+		switch value := v.(type) {
+		case float64, bool, string:
+			sourceMap, ok := source.(map[string]interface{})
+			if !ok {
+				break
+			}
+			result = sourceMap[k]
+		case []interface{}:
+			if k != "" {
+				// array is inside the object
+				// {"foo":[{},{},{}]}
+				sourceMap, ok := source.(map[string]interface{})
+				if !ok {
+					break
+				}
+				source, ok = sourceMap[k]
+				if !ok {
+					break
+				}
+			}
+			// array is a root object
+			// [{},{},{}]
+			sourceArr, ok := source.([]interface{})
+			if !ok {
+				break
+			}
+
+			index := len(value) - 1
+			if index >= len(sourceArr) {
+				break
+			}
+			result = ReadValue(sourceArr[index], value[index].(map[string]interface{}))
+		case map[string]interface{}:
+			if k == "" {
+				result = source
+				break
+			}
+			sourceMap, ok := source.(map[string]interface{})
+			if !ok {
+				break
+			}
+			if _, ok := sourceMap[k]; !ok {
+				break
+			}
+			result = ReadValue(sourceMap[k], value)
+		}
+	}
+	return result
+}

--- a/pkg/flow/adapter/transformation/transformer/shift/shift.go
+++ b/pkg/flow/adapter/transformation/transformer/shift/shift.go
@@ -166,6 +166,10 @@ func extractValue(source interface{}, path map[string]interface{}) (map[string]i
 				sourceMap[k] = append(sourceArr[:index], sourceArr[index+1:]...)
 			}
 		case map[string]interface{}:
+			if k == "" {
+				result = source
+				break
+			}
 			sourceMap, ok = source.(map[string]interface{})
 			if !ok {
 				break


### PR DESCRIPTION
In some cases CE Data needs to be transformed as a whole, eg:
```
...
Data: [
    {"key1": "value1"},
    {"key2": "value2"}
]
```
should be changed to:
```
...
Data: {
    "body": [
        {
            "key1": "value1"
        }, {
            "key2": "value2"
        }
    ]
}
```

Before, shift/store operation required the object's key to apply the transformation, with this update empty key (or `.`) will be interpreted as the whole object:

```
apiVersion: flow.triggermesh.io/v1alpha1
kind: Transformation
metadata:
  name: sample
spec:
  data:
  - operation: shift
    paths:
    - key: .:body
```
-will do the required transformation.