### PR TITLE
Match a regexp for backward compatibility with k8s 1.23 and below

### DIFF
--- a/test/e2e/sources/awscodecommit/main.go
+++ b/test/e2e/sources/awscodecommit/main.go
@@ -195,7 +195,7 @@ var _ = Describe("AWS CodeCommit source", func() {
 					withCredentials(awsCreds),
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(`spec.eventTypes[0]: Unsupported value: "invalid"`))
+				Expect(err.Error()).To(MatchRegexp(`spec\.eventTypes(\[0\])?: Unsupported value: "invalid"`))
 			})
 		})
 	})


### PR DESCRIPTION
Hey Folks. For awscodecommit e2e test, in k8s v 1.24 the error message we get for test `a client creates a source object with invalid specs` -> `setting invalid event types` . The current version is OK for k8s v1.24, but if we want to run this in 1.23 and below this would fail.

This little change will match either error message with k8s v1.24 as well as k8s 1.23 and below.

Error message in k8s 1.23 and below is something like this
```
AWSCodeCommitSource.sources.triggermesh.io "test-invalid-eventtypes-qbrk7" is invalid: spec.eventTypes: Unsupported value: "invalid": supported values: "push", "pull_request"
```

For k8s 1.24 error message is like this:
```
AWSCodeCommitSource.sources.triggermesh.io "test-invalid-eventtypes-pgp7p" is invalid: spec.eventTypes[0]: Unsupported value: "invalid": supported values: "push", "pull_request"
```