### PR TITLE
CI static code analyzer fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   gomod-cache:
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     steps:
       - checkout
       - go/mod-download-cached
@@ -17,7 +17,7 @@ jobs:
   test:
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     steps:
       - checkout
       - go/load-cache
@@ -75,7 +75,7 @@ jobs:
   gen-apidocs:
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     parameters:
       committer_name:
         type: string
@@ -116,7 +116,7 @@ jobs:
   publish-image:
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     resource_class: xlarge
     steps:
       - checkout
@@ -170,7 +170,7 @@ jobs:
     description: Patches target cluster configuration
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     parameters:
       cluster:
         type: string
@@ -222,7 +222,7 @@ jobs:
   release:
     executor:
       name: go/default
-      tag: '1.18'
+      tag: '1.19'
     steps:
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -35,7 +35,7 @@ jobs:
         #   --out-format=github-actions --out-format=colored-line-number
         #
         # Ref. https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
-        args: "--out-${NO_FUTURE}format=colored-line-number"
+        args: --out-${NO_FUTURE}format=colored-line-number --timeout 15m
 
   lint-config:
     name: Configuration Linting

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     # This action takes care of caching/restoring modules and build caches.
     # Therefore, this step should remain the first one that is executed after
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Go caches
       uses: actions/cache@v3

--- a/cmd/dataweavetransformation-adapter/Dockerfile
+++ b/cmd/dataweavetransformation-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 RUN set -eux; \
     apt-get update; \

--- a/cmd/ibmmqsource-adapter/Dockerfile
+++ b/cmd/ibmmqsource-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cmd/ibmmqtarget-adapter/Dockerfile
+++ b/cmd/ibmmqtarget-adapter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cmd/xslttransformation-adapter/Dockerfile
+++ b/cmd/xslttransformation-adapter/Dockerfile
@@ -14,7 +14,7 @@
 
 # (!) Debian 11 'bullseye' must be used in both the builder and final image to
 # ensure the compatibility of the GNU libc.
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 RUN set -eux; \
     apt-get update; \

--- a/hack/rbac-check/clusterroles.go
+++ b/hack/rbac-check/clusterroles.go
@@ -172,9 +172,9 @@ func withRBACCheckTag(node *yaml.Node) bool {
 // extractRBACCheckTags parses '+rbac-check' tags from a YAML node's comments,
 // and returns them in the format:
 //
-//   map[string][]string{
-//     "subresource": {"status"},
-//   }
+//	map[string][]string{
+//	  "subresource": {"status"},
+//	}
 //
 // The returned map is empty if the parsed tag doesn't contain any key/value,
 // nil if the provided YAML node isn't tagged.

--- a/pkg/apis/sources/v1alpha1/googlecloud_common_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloud_common_types.go
@@ -26,12 +26,13 @@ import (
 
 // GCloudResourceName represents a fully qualified resource name,
 // as described at
-//  https://cloud.google.com/apis/design/resource_names
+//
+//	https://cloud.google.com/apis/design/resource_names
 //
 // Examples of such resource names include:
-//  - projects/{project_name}/topics/{topic_name}
-//  - projects/{project_name}/repos/{repo_name}
-//  - projects/{project_name}/subscriptions/{subscription_name}
+//   - projects/{project_name}/topics/{topic_name}
+//   - projects/{project_name}/repos/{repo_name}
+//   - projects/{project_name}/subscriptions/{subscription_name}
 type GCloudResourceName struct {
 	Project    string
 	Collection string

--- a/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudiot_types.go
@@ -92,10 +92,11 @@ type GoogleCloudIoTSourceList struct {
 
 // GCloudIoTResourceName represents a fully qualified IoT resource name,
 // as described at
-//  https://pkg.go.dev/google.golang.org/api/cloudiot/v1#DeviceRegistry.Name
+//
+//	https://pkg.go.dev/google.golang.org/api/cloudiot/v1#DeviceRegistry.Name
 //
 // Examples of such resource names include:
-//  - projects/{project_name}/locations/{location_name}/registries/{registry_name}
+//   - projects/{project_name}/locations/{location_name}/registries/{registry_name}
 type GCloudIoTResourceName struct {
 	Project    string
 	Location   string

--- a/pkg/apis/targets/v1alpha1/googlecloud_common_types.go
+++ b/pkg/apis/targets/v1alpha1/googlecloud_common_types.go
@@ -26,12 +26,13 @@ import (
 
 // GCloudResourceName represents a fully qualified resource name,
 // as described at
-//  https://cloud.google.com/apis/design/resource_names
+//
+//	https://cloud.google.com/apis/design/resource_names
 //
 // Examples of such resource names include:
-//  - projects/{project_name}/topics/{topic_name}
-//  - projects/{project_name}/repos/{repo_name}
-//  - projects/{project_name}/subscriptions/{subscription_name}
+//   - projects/{project_name}/topics/{topic_name}
+//   - projects/{project_name}/repos/{repo_name}
+//   - projects/{project_name}/subscriptions/{subscription_name}
 type GCloudResourceName struct {
 	Project    string
 	Collection string

--- a/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/uipath_lifecycle.go
@@ -28,6 +28,7 @@ import (
 )
 
 // Accepted event types
+//
 //nolint:stylecheck
 const (
 	// EventTypeUiPathStartJob represents job data to be initiated

--- a/pkg/client/generated/clientset/internalclientset/fake/register.go
+++ b/pkg/client/generated/clientset/internalclientset/fake/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/generated/clientset/internalclientset/scheme/register.go
+++ b/pkg/client/generated/clientset/internalclientset/scheme/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/flow/adapter/dataweavetransformation/adapter.go
+++ b/pkg/flow/adapter/dataweavetransformation/adapter.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
@@ -252,7 +251,7 @@ func registerAndPopulateSpell(spell, dwFolder string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(dwFolder+"/src/Main.dwl", []byte(spell), 0644); err != nil {
+	if err := os.WriteFile(dwFolder+"/src/Main.dwl", []byte(spell), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/flow/adapter/jqtransformation/adapter_test.go
+++ b/pkg/flow/adapter/jqtransformation/adapter_test.go
@@ -19,7 +19,7 @@ package jqtransformation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -72,7 +72,7 @@ func TestSink(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, tJSON1, string(body))
 				fmt.Fprintf(w, "OK")

--- a/pkg/flow/adapter/xmltojsontransformation/adapter.go
+++ b/pkg/flow/adapter/xmltojsontransformation/adapter.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
-	"io/ioutil"
+	"io"
 
 	"go.uber.org/zap"
 
@@ -120,7 +120,7 @@ func (a *Adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 		return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, nil)
 	}
 
-	readBuf, err := ioutil.ReadAll(jsn)
+	readBuf, err := io.ReadAll(jsn)
 	if err != nil {
 		return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, nil)
 	}

--- a/pkg/reconciler/base.go
+++ b/pkg/reconciler/base.go
@@ -288,8 +288,8 @@ func EnqueueObjectsInNamespaceOf(inf cache.SharedInformer, resyncFn filteredGlob
 }
 
 // adapterPodWithAncestorOfKind returns a filter function which returns whether a Pod:
-//  - has labels that correspond to an adapter of the given type
-//  - has an outermost ancestor of the given kind
+//   - has labels that correspond to an adapter of the given type
+//   - has an outermost ancestor of the given kind
 func adapterPodWithAncestorOfKind(ctx context.Context, typ kmeta.OwnerRefable) objectFilterFunc {
 	return func(obj interface{}) bool {
 		return hasAdapterLabelsForType(typ)(obj) &&

--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -546,8 +546,8 @@ func resolveSinkURL(ctx context.Context, r *resolver.URIResolver) (*apis.URL, er
 //
 // The result is  the following chain of ownership:
 //
-//   FooComponent/instance-a, FooComponent/instance-b, FooComponent/instance-c, ...
-//   └─ServiceAccount/foocomponent-adapter
+//	FooComponent/instance-a, FooComponent/instance-b, FooComponent/instance-c, ...
+//	└─ServiceAccount/foocomponent-adapter
 func serviceAccountOwners[T kmeta.OwnerRefable](rcl v1alpha1.Reconcilable, l Lister[T]) ([]kmeta.OwnerRefable, error) {
 	if v1alpha1.WantsOwnServiceAccount(rcl) {
 		return []kmeta.OwnerRefable{rcl}, nil

--- a/pkg/reconciler/semantic/semantic.go
+++ b/pkg/reconciler/semantic/semantic.go
@@ -31,7 +31,7 @@ import (
 //
 // For a given comparison function
 //
-//   comp(a, b interface{})
+//	comp(a, b interface{})
 //
 // 'a' should always be the desired state, and 'b' the current state for
 // DeepDerivative comparisons to work as expected.

--- a/pkg/reconciler/semantic/semantic_test.go
+++ b/pkg/reconciler/semantic/semantic_test.go
@@ -18,7 +18,7 @@ package semantic
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -288,7 +288,7 @@ func TestServiceAccountEqual(t *testing.T) {
 func loadFixture(t *testing.T, file string, obj runtime.Object) {
 	t.Helper()
 
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("Error reading fixture file: %s", err)
 	}

--- a/pkg/routing/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/routing/adapter/common/sharedmain/sharedmain.go
@@ -29,10 +29,10 @@ type namedAdapterConstructor func(component string) adapter.AdapterConstructor
 
 // MainWithController is a shared main tailored to multi-tenant receive-adapters.
 // It performs the following initializations:
-//  * process environment variables
-//  * enable leader election / HA
-//  * set the scope to a single namespace
-//  * inject the given controller constructor
+//   - process environment variables
+//   - enable leader election / HA
+//   - set the scope to a single namespace
+//   - inject the given controller constructor
 func MainWithController(envCtor env.ConfigConstructor,
 	cCtor namedControllerConstructor, aCtor namedAdapterConstructor) {
 

--- a/pkg/routing/adapter/filter/adapter_test.go
+++ b/pkg/routing/adapter/filter/adapter_test.go
@@ -19,7 +19,7 @@ package filter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -284,7 +284,7 @@ func setupSink(t *testing.T, ctx context.Context) (chan string, net.Addr) {
 	c := make(chan string, 1)
 
 	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		c <- string(body)
 		w.WriteHeader(http.StatusOK)

--- a/pkg/routing/adapter/splitter/adapter_test.go
+++ b/pkg/routing/adapter/splitter/adapter_test.go
@@ -19,7 +19,7 @@ package splitter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -220,7 +220,7 @@ func setupSink(t *testing.T, ctx context.Context) (chan string, net.Addr) {
 	c := make(chan string, 4)
 
 	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		c <- string(body)
 		w.WriteHeader(http.StatusOK)

--- a/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter_test.go
@@ -230,9 +230,9 @@ func (c *standardMockDynamoDBStreamsClient) GetRecordsWithContext(_ context.Cont
 // represents the following structure:
 //
 // []shard id
-//    \_ [] shard iterator
-//           \_ [] record
 //
+//	\_ [] shard iterator
+//	       \_ [] record
 type mockShards map[ /*shard id*/ *string][]*mockShardIterator
 type mockShardIterator struct {
 	name    *string

--- a/pkg/sources/adapter/awssnssource/handler/handler.go
+++ b/pkg/sources/adapter/awssnssource/handler/handler.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -94,7 +94,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch msgType := r.Header.Get(headerMsgTypeKey); msgType {
 	case headerMsgTypeNotification:
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			handleError("Failed to read request body", err, http.StatusInternalServerError, h.logger, w)
 			return
@@ -129,7 +129,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.logger.Debug("Successfully sent SNS notification: ", event)
 
 	case headerMsgTypeSubsConfirm:
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			handleError("Failed to read request body", err, http.StatusInternalServerError, h.logger, w)
 			return

--- a/pkg/sources/adapter/awssqssource/cloudevents.go
+++ b/pkg/sources/adapter/awssqssource/cloudevents.go
@@ -54,16 +54,16 @@ func ceExtensionAttrsForMessage(msg *sqs.Message) map[string]interface{} {
 // so that it can be used as a CloudEvent context attribute.
 //
 // The naming conventions for both formats are described at:
-//  - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#message-attribute-components
-//  - https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#context-attributes
+//   - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#message-attribute-components
+//   - https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#context-attributes
 func ceExtensionAttrForMessageAttr(attrName string) string {
 	return ceExtensionSQSMessagePrefix + stripNonAlphanumCharsAndMapToLower(attrName)
 }
 
 // stripNonAlphanumCharsAndMapToLower applies the following transformations to
 // the given string:
-//  - strips all non alphanumeric characters
-//  - maps all Unicode letters to their lower case
+//   - strips all non alphanumeric characters
+//   - maps all Unicode letters to their lower case
 func stripNonAlphanumCharsAndMapToLower(s string) string {
 	var stripped strings.Builder
 	stripped.Grow(len(s))

--- a/pkg/sources/adapter/azureeventhubsource/adapter.go
+++ b/pkg/sources/adapter/azureeventhubsource/adapter.go
@@ -271,7 +271,8 @@ func (e errList) Error() string {
 //
 // For now, this helper exists solely to fix CloudEvents sent by Azure Event
 // Grid, which often contain
-//   "dataschema": "#"
+//
+//	"dataschema": "#"
 func sanitizeEvent(validErrs event.ValidationError, origEvent *cloudevents.Event) *cloudevents.Event {
 	for attr := range validErrs {
 		// we don't bother cloning, events are garbage collected after

--- a/pkg/sources/adapter/azureservicebussource/adapter.go
+++ b/pkg/sources/adapter/azureservicebussource/adapter.go
@@ -251,13 +251,14 @@ func connectionStringFromEnvironment(namespace, entityPath string) string {
 // Start implements adapter.Adapter.
 //
 // Required permissions:
-//  Service Bus Queues:
-//    - Microsoft.ServiceBus/namespaces/queues/read
-//  Service Bus Topics:
-//    - Microsoft.ServiceBus/namespaces/topics/read
-//    - Microsoft.ServiceBus/namespaces/topics/subscriptions/read
-//  Both (DataAction):
-//  - Microsoft.ServiceBus/namespaces/messages/receive/action
+//
+//	Service Bus Queues:
+//	  - Microsoft.ServiceBus/namespaces/queues/read
+//	Service Bus Topics:
+//	  - Microsoft.ServiceBus/namespaces/topics/read
+//	  - Microsoft.ServiceBus/namespaces/topics/subscriptions/read
+//	Both (DataAction):
+//	- Microsoft.ServiceBus/namespaces/messages/receive/action
 func (a *adapter) Start(ctx context.Context) error {
 	const maxMessages = 100
 	logging.FromContext(ctx).Info("Listening for messages")
@@ -355,7 +356,8 @@ func (e errList) Error() string {
 //
 // For now, this helper exists solely to fix CloudEvents sent by Azure Event
 // Grid, which often contain
-//   "dataschema": "#"
+//
+//	"dataschema": "#"
 func sanitizeEvent(validErrs event.ValidationError, origEvent *cloudevents.Event) *cloudevents.Event {
 	for attr := range validErrs {
 		// we don't bother cloning, events are garbage collected after

--- a/pkg/sources/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/sources/adapter/common/sharedmain/sharedmain.go
@@ -29,10 +29,10 @@ type namedAdapterConstructor func(component string) adapter.AdapterConstructor
 
 // MainWithController is a shared main tailored to multi-tenant receive-adapters.
 // It performs the following initializations:
-//  * process environment variables
-//  * enable leader election / HA
-//  * set the scope to a single namespace
-//  * inject the given controller constructor
+//   - process environment variables
+//   - enable leader election / HA
+//   - set the scope to a single namespace
+//   - inject the given controller constructor
 func MainWithController(envCtor env.ConfigConstructor,
 	cCtor namedControllerConstructor, aCtor namedAdapterConstructor) {
 

--- a/pkg/sources/adapter/googlecloudpubsubsource/cloudevents.go
+++ b/pkg/sources/adapter/googlecloudpubsubsource/cloudevents.go
@@ -57,8 +57,8 @@ func ceExtensionAttrForMessageAttr(attrName string) string {
 
 // stripNonAlphanumCharsAndMapToLower applies the following transformations to
 // the given string:
-//  - strips all non alphanumeric characters
-//  - maps all Unicode letters to their lower case
+//   - strips all non alphanumeric characters
+//   - maps all Unicode letters to their lower case
 func stripNonAlphanumCharsAndMapToLower(s string) string {
 	var stripped strings.Builder
 	stripped.Grow(len(s))

--- a/pkg/sources/adapter/httppollersource/httppoller.go
+++ b/pkg/sources/adapter/httppollersource/httppoller.go
@@ -18,7 +18,7 @@ package httppollersource
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -82,7 +82,7 @@ func (h *httpPoller) dispatch(ctx context.Context) {
 	}
 
 	defer res.Body.Close()
-	resb, err := ioutil.ReadAll(res.Body)
+	resb, err := io.ReadAll(res.Body)
 	if err != nil {
 		h.logger.Errorw("Failed reading response body", zap.Error(err))
 		return

--- a/pkg/sources/adapter/salesforcesource/auth/jwt.go
+++ b/pkg/sources/adapter/salesforcesource/auth/jwt.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -113,7 +113,7 @@ func (j *JWTAuthenticator) NewCredentials() (*Credentials, error) {
 
 	if res.StatusCode >= 300 {
 		msg := fmt.Sprintf("received unexpected status code %d from authentication", res.StatusCode)
-		if resb, err := ioutil.ReadAll(res.Body); err == nil {
+		if resb, err := io.ReadAll(res.Body); err == nil {
 			msg += ": " + string(resb)
 		}
 		return nil, errors.New(msg)

--- a/pkg/sources/adapter/salesforcesource/client/bayeux.go
+++ b/pkg/sources/adapter/salesforcesource/client/bayeux.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"strconv"
@@ -396,7 +396,7 @@ func (b *bayeux) doPost(payload string) (*http.Response, error) {
 
 	if res.StatusCode >= 300 {
 		msg := fmt.Sprintf("received unexpected status code %d", res.StatusCode)
-		if resb, err := ioutil.ReadAll(res.Body); err == nil {
+		if resb, err := io.ReadAll(res.Body); err == nil {
 			msg += ": " + string(resb)
 		}
 		return nil, errors.New(msg)

--- a/pkg/sources/adapter/salesforcesource/client/types.go
+++ b/pkg/sources/adapter/salesforcesource/client/types.go
@@ -94,9 +94,11 @@ type EventDispatcher interface {
 
 // Subscription contains data about the channel and replayID for the subscription.
 // For replayID can be:
-// 		-2 for all past (stored) and new events.
-// 		-1 for new events only.
-//		replayID for receiving events after that replayID event.
+//
+//	-2 for all past (stored) and new events.
+//	-1 for new events only.
+//	replayID for receiving events after that replayID event.
+//
 // See: https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm
 type Subscription struct {
 	Channel  string

--- a/pkg/sources/adapter/slacksource/slack.go
+++ b/pkg/sources/adapter/slacksource/slack.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -101,7 +101,7 @@ func (h *slackEventAPIHandler) handleAll(ctx context.Context) http.HandlerFunc {
 		}
 
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			h.handleError(err, http.StatusInternalServerError, w)
 			return

--- a/pkg/sources/adapter/webhooksource/webhook.go
+++ b/pkg/sources/adapter/webhooksource/webhook.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -130,7 +130,7 @@ func (h *webhookHandler) handleAll(ctx context.Context) http.HandlerFunc {
 		}
 
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			h.handleError(err, http.StatusInternalServerError, w)
 			return

--- a/pkg/sources/adapter/zendesksource/handler/handler.go
+++ b/pkg/sources/adapter/zendesksource/handler/handler.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -97,7 +97,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		handleError("Failed to read request body", err, http.StatusInternalServerError, h.logger, w)
 		return

--- a/pkg/sources/auth/errors.go
+++ b/pkg/sources/auth/errors.go
@@ -27,11 +27,10 @@ package auth
 //
 // Examples of assertion:
 //
-//   _, ok := err.(PermanentCredentialsError)
+//	_, ok := err.(PermanentCredentialsError)
 //
-//   permErr := (PermanentCredentialsError)(nil)
-//   ok := errors.As(err, &permErr)
-//
+//	permErr := (PermanentCredentialsError)(nil)
+//	ok := errors.As(err, &permErr)
 type PermanentCredentialsError interface {
 	error
 	IsPermanent()

--- a/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
+++ b/pkg/sources/reconciler/azureactivitylogssource/diagsettings.go
@@ -62,9 +62,9 @@ const crudTimeout = time.Second * 15
 
 // ensureDiagnosticSettings ensures diagnostic settings exist with the expected configuration.
 // Required permissions:
-//  - Microsoft.Insights/DiagnosticSettings/Read
-//  - Microsoft.Insights/DiagnosticSettings/Write
-//  - Microsoft.EventHub/namespaces/authorizationRules/listkeys/action
+//   - Microsoft.Insights/DiagnosticSettings/Read
+//   - Microsoft.Insights/DiagnosticSettings/Write
+//   - Microsoft.EventHub/namespaces/authorizationRules/listkeys/action
 func (r *Reconciler) ensureDiagnosticSettings(ctx context.Context) error {
 	if skip.Skip(ctx) {
 		return nil
@@ -205,7 +205,7 @@ func sasPolicyResourceID(namespaceID *v1alpha1.AzureResourceID, polName string) 
 
 // ensureNoDiagnosticSettings ensures diagnostic settings are removed.
 // Required permissions:
-//  - Microsoft.Insights/DiagnosticSettings/Delete
+//   - Microsoft.Insights/DiagnosticSettings/Delete
 func (r *Reconciler) ensureNoDiagnosticSettings(ctx context.Context) reconciler.Event {
 	if skip.Skip(ctx) {
 		return nil

--- a/pkg/sources/reconciler/azureblobstoragesource/event_hub.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_hub.go
@@ -48,8 +48,8 @@ const resourceTypeEventHubs = "eventhubs"
 
 // ensureEventHub ensures the existence of an Event Hub for sending storage events.
 // Required permissions:
-//  - Microsoft.EventHub/namespaces/eventhubs/read
-//  - Microsoft.EventHub/namespaces/eventhubs/write
+//   - Microsoft.EventHub/namespaces/eventhubs/read
+//   - Microsoft.EventHub/namespaces/eventhubs/write
 func ensureEventHub(ctx context.Context, cli storage.EventHubsClient) (string /*resource ID*/, error) {
 	if skip.Skip(ctx) {
 		return "", nil
@@ -137,7 +137,7 @@ func makeEventHubID(namespaceID *v1alpha1.AzureResourceID, hubName string) *v1al
 // ensureNoEventHub ensures that the Event Hub created for sending storage
 // events is deleted.
 // Required permissions:
-//  - Microsoft.EventHub/namespaces/eventhubs/delete
+//   - Microsoft.EventHub/namespaces/eventhubs/delete
 func ensureNoEventHub(ctx context.Context, cli storage.EventHubsClient) error {
 	src := commonv1alpha1.ReconcilableFromContext(ctx).(*v1alpha1.AzureBlobStorageSource)
 

--- a/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
@@ -57,9 +57,9 @@ const (
 
 // ensureEventSubscription ensures an event subscription exists with the expected configuration.
 // Required permissions:
-//  - Microsoft.EventGrid/eventSubscriptions/read
-//  - Microsoft.EventGrid/eventSubscriptions/write
-//  - Microsoft.EventHub/namespaces/eventhubs/write
+//   - Microsoft.EventGrid/eventSubscriptions/read
+//   - Microsoft.EventGrid/eventSubscriptions/write
+//   - Microsoft.EventHub/namespaces/eventhubs/write
 func ensureEventSubscription(ctx context.Context, cli storage.EventSubscriptionsClient, eventHubResID string) error {
 	if skip.Skip(ctx) {
 		return nil
@@ -154,7 +154,7 @@ func newEventSubscription(eventHubResID string, eventTypes []string) eventgrid.E
 
 // ensureNoEventSubscription ensures the event subscription is removed.
 // Required permissions:
-//  - Microsoft.EventGrid/eventSubscriptions/delete
+//   - Microsoft.EventGrid/eventSubscriptions/delete
 func ensureNoEventSubscription(ctx context.Context, cli storage.EventSubscriptionsClient) reconciler.Event {
 	if skip.Skip(ctx) {
 		return nil

--- a/pkg/sources/reconciler/azureeventgridsource/event_hub.go
+++ b/pkg/sources/reconciler/azureeventgridsource/event_hub.go
@@ -48,8 +48,8 @@ const resourceTypeEventHubs = "eventhubs"
 
 // ensureEventHub ensures the existence of an Event Hub for sending events.
 // Required permissions:
-//  - Microsoft.EventHub/namespaces/eventhubs/read
-//  - Microsoft.EventHub/namespaces/eventhubs/write
+//   - Microsoft.EventHub/namespaces/eventhubs/read
+//   - Microsoft.EventHub/namespaces/eventhubs/write
 func ensureEventHub(ctx context.Context, cli eventgrid.EventHubsClient) (string /*resource ID*/, error) {
 	if skip.Skip(ctx) {
 		return "", nil
@@ -134,7 +134,7 @@ func makeEventHubID(namespaceID *v1alpha1.AzureResourceID, hubName string) *v1al
 // ensureNoEventHub ensures that the Event Hub created for sending events
 // is deleted.
 // Required permissions:
-//  - Microsoft.EventHub/namespaces/eventhubs/delete
+//   - Microsoft.EventHub/namespaces/eventhubs/delete
 func ensureNoEventHub(ctx context.Context, cli eventgrid.EventHubsClient) error {
 	src := commonv1alpha1.ReconcilableFromContext(ctx).(*v1alpha1.AzureEventGridSource)
 

--- a/pkg/sources/reconciler/azureeventgridsource/event_subs.go
+++ b/pkg/sources/reconciler/azureeventgridsource/event_subs.go
@@ -47,9 +47,9 @@ const (
 
 // ensureEventSubscription ensures an event subscription exists with the expected configuration.
 // Required permissions:
-//  - Microsoft.EventGrid/systemTopics/eventSubscriptions/read
-//  - Microsoft.EventGrid/systemTopics/eventSubscriptions/write
-//  - Microsoft.EventHub/namespaces/eventhubs/write
+//   - Microsoft.EventGrid/systemTopics/eventSubscriptions/read
+//   - Microsoft.EventGrid/systemTopics/eventSubscriptions/write
+//   - Microsoft.EventHub/namespaces/eventhubs/write
 func ensureEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
 	sysTopicResID *v1alpha1.AzureResourceID, eventHubResID string) error {
 
@@ -168,7 +168,7 @@ func newEventSubscription(eventHubResID string, eventTypes []string) azureeventg
 
 // ensureNoEventSubscription ensures the event subscription is removed.
 // Required permissions:
-//  - Microsoft.EventGrid/systemTopics/eventSubscriptions/delete
+//   - Microsoft.EventGrid/systemTopics/eventSubscriptions/delete
 func ensureNoEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
 	sysTopic *azureeventgrid.SystemTopic) reconciler.Event {
 

--- a/pkg/sources/reconciler/azureeventgridsource/sys_topic.go
+++ b/pkg/sources/reconciler/azureeventgridsource/sys_topic.go
@@ -61,12 +61,12 @@ const (
 
 // ensureSystemTopic ensures a system topic exists with the expected configuration.
 // Required permissions:
-//  - Microsoft.EventGrid/systemTopics/read
-//  - Microsoft.EventGrid/systemTopics/write
-//  To manage the default resource group, when the scope is an Azure subscription:
+//   - Microsoft.EventGrid/systemTopics/read
+//   - Microsoft.EventGrid/systemTopics/write
+//     To manage the default resource group, when the scope is an Azure subscription:
 //   - Microsoft.Resources/subscriptions/resourceGroups/read
 //   - Microsoft.Resources/subscriptions/resourceGroups/write
-//  Additionally, for regional resources, "read" permission on the resource (scope).
+//     Additionally, for regional resources, "read" permission on the resource (scope).
 func ensureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	providersCli eventgrid.ProvidersClient,
 	resGroupsCli eventgrid.ResourceGroupsClient) (*v1alpha1.AzureResourceID /*sysTopicResID*/, error) {
@@ -203,8 +203,8 @@ func ensureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 
 // ensureNoSystemTopic ensures the system topic is removed.
 // Required permissions:
-//  - Microsoft.EventGrid/systemTopics/read
-//  - Microsoft.EventGrid/systemTopics/delete
+//   - Microsoft.EventGrid/systemTopics/read
+//   - Microsoft.EventGrid/systemTopics/delete
 func ensureNoSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	eventSubsCli eventgrid.EventSubscriptionsClient, sysTopic *azureeventgrid.SystemTopic) reconciler.Event {
 

--- a/pkg/sources/reconciler/azureservicebustopicsource/subscription.go
+++ b/pkg/sources/reconciler/azureservicebustopicsource/subscription.go
@@ -47,8 +47,8 @@ const crudTimeout = time.Second * 15
 
 // ensureSubscription ensures a Subscription exists with the expected configuration.
 // Required permissions:
-//  - Microsoft.ServiceBus/namespaces/topics/subscriptions/read
-//  - Microsoft.ServiceBus/namespaces/topics/subscriptions/write
+//   - Microsoft.ServiceBus/namespaces/topics/subscriptions/read
+//   - Microsoft.ServiceBus/namespaces/topics/subscriptions/write
 func ensureSubscription(ctx context.Context, cli servicebustopics.SubscriptionsClient) error {
 	if skip.Skip(ctx) {
 		return nil
@@ -125,7 +125,7 @@ func ensureSubscription(ctx context.Context, cli servicebustopics.SubscriptionsC
 
 // ensureNoSubscription ensures the Subscription is removed.
 // Required permissions:
-//  - Microsoft.ServiceBus/namespaces/topics/subscriptions/delete
+//   - Microsoft.ServiceBus/namespaces/topics/subscriptions/delete
 func ensureNoSubscription(ctx context.Context, cli servicebustopics.SubscriptionsClient) reconciler.Event {
 	if skip.Skip(ctx) {
 		return nil

--- a/pkg/sources/reconciler/zendesksource/zendesk.go
+++ b/pkg/sources/reconciler/zendesksource/zendesk.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -411,7 +411,7 @@ func isNotFound(err error) bool {
 // formatError formats Zendesk errors.
 func formatError(origErr error) error {
 	if zdErr := (zendesk.Error{}); errors.As(origErr, &zdErr) {
-		rawErrBody, err := ioutil.ReadAll(zdErr.Body())
+		rawErrBody, err := io.ReadAll(zdErr.Body())
 		if err != nil {
 			return origErr
 		}

--- a/pkg/targets/adapter/azuresentineltarget/adapter.go
+++ b/pkg/targets/adapter/azuresentineltarget/adapter.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -165,7 +165,7 @@ func (a *adapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloud
 	}
 
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		a.sr.ReportProcessingError(true, ceTypeTag, ceSrcTag)
 		return a.replier.Error(&event, targetce.ErrorCodeAdapterProcess, err, "reading response body")

--- a/pkg/targets/adapter/cloudevents/doc.go
+++ b/pkg/targets/adapter/cloudevents/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 Package cloudevents provides a CloudEvents library focused on target component
 requirements and on how responses should be composed.
 
-Basics
+# Basics
 
 The package provides a Replier object that should be instantiated as a singleton,
 and a set of pubic functions that are further divided into Knative managed and
@@ -31,13 +31,13 @@ Custom managed responses on the other hand provide information through payload. 
 case of successful responses the payload is provided by the target, but when an error
 occurs, a custom managed response includes an EventError payload.
 
-		type EventError struct {
-			Code        string		// short string to identify error nature
-			Description string		// description from the error object
-			Fields interface{}	// additional information
-		}
+	type EventError struct {
+		Code        string		// short string to identify error nature
+		Description string		// description from the error object
+		Fields interface{}	// additional information
+	}
 
-Replier
+# Replier
 
 The Replier constructor can be customized by passing an array of ReplierOption objects,
 being that customization applied to all responses. Customization choices are:

--- a/pkg/targets/adapter/confluenttarget/adapter.go
+++ b/pkg/targets/adapter/confluenttarget/adapter.go
@@ -166,7 +166,7 @@ func (a *confluentAdapter) dispatch(event cloudevents.Event) cloudevents.Result 
 	return cloudevents.ResultACK
 }
 
-//ensureTopic creates a topic if missing
+// ensureTopic creates a topic if missing
 func (a *confluentAdapter) ensureTopic(ctx context.Context, topic string) error {
 	a.logger.Debug("Ensuring topic %q", topic)
 

--- a/pkg/targets/adapter/datadogtarget/adapter.go
+++ b/pkg/targets/adapter/datadogtarget/adapter.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -130,7 +130,7 @@ func (a *datadogAdapter) postLog(event cloudevents.Event) (*cloudevents.Event, c
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return a.replier.Error(&event, targetce.ErrorCodeParseResponse, err, nil)
 	}
@@ -161,7 +161,7 @@ func (a *datadogAdapter) postEvent(event cloudevents.Event) (*cloudevents.Event,
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return a.replier.Error(&event, targetce.ErrorCodeParseResponse, err, nil)
 	}
@@ -191,7 +191,7 @@ func (a *datadogAdapter) postMetric(event cloudevents.Event) (*cloudevents.Event
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return a.replier.Error(&event, targetce.ErrorCodeParseResponse, err, nil)
 	}

--- a/pkg/targets/adapter/elasticsearchtarget/adapter.go
+++ b/pkg/targets/adapter/elasticsearchtarget/adapter.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"go.uber.org/zap"
 
@@ -106,7 +106,7 @@ func (a *esAdapter) Start(ctx context.Context) error {
 	}
 	a.client = client
 	if !resp.IsError() {
-		info, err := ioutil.ReadAll(resp.Body)
+		info, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read info using Elasticsearch client: %v", err)
 		}

--- a/pkg/targets/adapter/hasuratarget/adapter.go
+++ b/pkg/targets/adapter/hasuratarget/adapter.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -188,7 +188,7 @@ func (h *hasuraAdapter) dispatch(ctx context.Context, event cloudevents.Event) (
 
 	// NOTE: All responses will return a 200 OK message as per https://hasura.io/docs/1.0/graphql/core/api-reference/graphql-api/index.html
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return h.reportError("Unable to read response body", err)
 	}

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -189,7 +189,7 @@ func (a *httpAdapter) dispatch(ctx context.Context, event cloudevents.Event) (*c
 	}
 
 	defer res.Body.Close()
-	resb, err := ioutil.ReadAll(res.Body)
+	resb, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, a.errorHTTPResult(http.StatusInternalServerError, "Error reading response body: %w", err)
 	}

--- a/pkg/targets/adapter/jiratarget/adapter.go
+++ b/pkg/targets/adapter/jiratarget/adapter.go
@@ -18,7 +18,7 @@ package jiratarget
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"path"
 
@@ -200,7 +200,7 @@ func (a *jiraAdapter) jiraCustomRequest(ctx context.Context, event cloudevents.E
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		a.logger.Errorw("Error reading response from Jira API", zap.Error(err))
 		return nil, cloudevents.ResultACK

--- a/pkg/targets/adapter/oracletarget/adapter.go
+++ b/pkg/targets/adapter/oracletarget/adapter.go
@@ -19,7 +19,7 @@ package oracletarget
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -114,7 +114,7 @@ func (a *oracleAdapter) Start(ctx context.Context) error {
 }
 
 func (a *oracleAdapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, cloudevents.Result) {
-	requestPayload := ioutil.NopCloser(bytes.NewReader(event.Data()))
+	requestPayload := io.NopCloser(bytes.NewReader(event.Data()))
 
 	request := functions.InvokeFunctionRequest{
 		FunctionId:         &a.fn,
@@ -134,7 +134,7 @@ func (a *oracleAdapter) dispatch(ctx context.Context, event cloudevents.Event) (
 
 	defer a.responseCleanup(response)
 
-	respBody, err := ioutil.ReadAll(response.Content)
+	respBody, err := io.ReadAll(response.Content)
 	if err != nil {
 		a.logger.Errorw("Error extracting response from function", zap.Error(err))
 		return nil, cloudevents.ResultNACK

--- a/pkg/targets/adapter/salesforcetarget/adapter.go
+++ b/pkg/targets/adapter/salesforcetarget/adapter.go
@@ -19,7 +19,7 @@ package salesforcetarget
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -126,7 +126,7 @@ func (a *salesforceTarget) dispatch(ctx context.Context, event cloudevents.Event
 	}
 
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return a.replier.Error(&event, targetce.ErrorCodeParseResponse, err, nil)
 	}

--- a/pkg/targets/adapter/salesforcetarget/auth/jwt.go
+++ b/pkg/targets/adapter/salesforcetarget/auth/jwt.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -126,7 +126,7 @@ func (j *JWTAuthenticator) NewCredentials() (*Credentials, error) {
 
 	if res.StatusCode >= 400 {
 		msg := fmt.Sprintf("received unexpected status code %d from authentication", res.StatusCode)
-		if resb, err := ioutil.ReadAll(res.Body); err == nil {
+		if resb, err := io.ReadAll(res.Body); err == nil {
 			msg += ": " + string(resb)
 		}
 		return nil, errors.New(msg)

--- a/pkg/targets/adapter/salesforcetarget/client/client.go
+++ b/pkg/targets/adapter/salesforcetarget/client/client.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -218,7 +218,7 @@ type salesforceError struct {
 // doNonLockingCall is not thread safe and should only be used if the client lock has been previously acquired.
 func (c *SalesforceClient) manageAPIError(res *http.Response) error {
 	msg := fmt.Sprintf("API returned an error (%d): ", res.StatusCode)
-	body := ioutil.NopCloser(res.Body)
+	body := io.NopCloser(res.Body)
 
 	// try to use the docummented Salesforce format.
 	// See: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm
@@ -229,7 +229,7 @@ func (c *SalesforceClient) manageAPIError(res *http.Response) error {
 	}
 
 	// write raw response as a string
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err == nil {
 		return fmt.Errorf(msg+"%s", string(b))
 	}

--- a/pkg/targets/adapter/uipathtarget/adapter.go
+++ b/pkg/targets/adapter/uipathtarget/adapter.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -172,7 +172,7 @@ func (a *uipathAdapter) getAccessToken() (string, error) {
 
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("reading response body from requesting the auth token: %w", err)
 	}
@@ -204,7 +204,7 @@ func (a *uipathAdapter) getReleaseKey(bearer string) (string, error) {
 
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("retrieving release key: %w", err)
 	}
@@ -234,7 +234,7 @@ func (a *uipathAdapter) getRobotID(bearer string) (int, error) {
 		return -1, fmt.Errorf("processing robot ID request: %w", err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return -1, fmt.Errorf("retrieving robot ID: %w", err)
 	}
@@ -281,7 +281,7 @@ func (a *uipathAdapter) postToQueue(qd *QueueItemData, bearer string) error {
 	defer res.Body.Close()
 
 	if a.logger.Desugar().Core().Enabled(zap.DebugLevel) {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			a.logger.Debugw("Failed to read response body from posting to a queue", zap.Error(err))
 		} else {
@@ -332,7 +332,7 @@ func (a *uipathAdapter) startJob(bearer, rK, inputArgs string, robotID int) erro
 	defer res.Body.Close()
 
 	if a.logger.Desugar().Core().Enabled(zap.DebugLevel) {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			a.logger.Debugw("Failed to read response body from starting a job", zap.Error(err))
 		} else {

--- a/test/e2e/framework/bridges/sink.go
+++ b/test/e2e/framework/bridges/sink.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -217,7 +216,7 @@ func parseCloudEvent(ce string) cloudevents.Event {
 
 			// read everything that's left to read and set
 			// it as the event's data
-			b, err := ioutil.ReadAll(r)
+			b, err := io.ReadAll(r)
 			if err != nil {
 				framework.Logf("Error reading event's data: %s", err)
 				break

--- a/test/e2e/framework/bridges/sink.go
+++ b/test/e2e/framework/bridges/sink.go
@@ -177,19 +177,24 @@ func splitEvents(logStream io.Reader) []string {
 // ☁  cloudevents.Event
 // Validation: valid
 // Context Attributes,
-//   specversion: 1.0
-//   type: io.triggermesh.some.event
-//   source: some/source
-//   subject: some-subject
-//   id: edecf007-f651-4e10-959e-e2f0a5b8ccd0
-//   time: 2020-09-14T13:59:40.693213706Z
-//   datacontenttype: application/json
+//
+//	specversion: 1.0
+//	type: io.triggermesh.some.event
+//	source: some/source
+//	subject: some-subject
+//	id: edecf007-f651-4e10-959e-e2f0a5b8ccd0
+//	time: 2020-09-14T13:59:40.693213706Z
+//	datacontenttype: application/json
+//
 // Extensions,
-//   someextension: some-value
+//
+//	someextension: some-value
+//
 // Data,
-//   {
-//     ...
-//   }
+//
+//	{
+//	  ...
+//	}
 func parseCloudEvent(ce string) cloudevents.Event {
 	e := cloudevents.NewEvent()
 

--- a/test/e2e/targets/awss3/main.go
+++ b/test/e2e/targets/awss3/main.go
@@ -19,7 +19,7 @@ package awss3
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 
@@ -147,7 +147,7 @@ var _ = Describe("AWS S3 target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := *receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object.Body)
+						receivedObj, err = io.ReadAll(object.Body)
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -194,7 +194,7 @@ var _ = Describe("AWS S3 target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := *receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object.Body)
+						receivedObj, err = io.ReadAll(object.Body)
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -241,7 +241,7 @@ var _ = Describe("AWS S3 target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := *receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object.Body)
+						receivedObj, err = io.ReadAll(object.Body)
 						Expect(err).ToNot(HaveOccurred())
 					})
 					By("inspecting the object payload", func() {

--- a/test/e2e/targets/googlecloudstorage/main.go
+++ b/test/e2e/targets/googlecloudstorage/main.go
@@ -19,7 +19,7 @@ package googlecloudstorage
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/url"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
@@ -146,7 +146,7 @@ var _ = Describe("Google Cloud Storage target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object)
+						receivedObj, err = io.ReadAll(object)
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -194,7 +194,7 @@ var _ = Describe("Google Cloud Storage target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object)
+						receivedObj, err = io.ReadAll(object)
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -242,7 +242,7 @@ var _ = Describe("Google Cloud Storage target", func() {
 							"Received %d objects instead of 1", len(receivedObjs))
 
 						object := receivedObjs[0]
-						receivedObj, err = ioutil.ReadAll(object)
+						receivedObj, err = io.ReadAll(object)
 						Expect(err).ToNot(HaveOccurred())
 					})
 					By("inspecting the object payload", func() {

--- a/test/e2e/targets/tekton/main.go
+++ b/test/e2e/targets/tekton/main.go
@@ -18,7 +18,7 @@ package tekton
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/url"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -130,7 +130,7 @@ var _ = FDescribe("Tekton Target", func() {
 
 					By("verifying the build results", func() {
 						log := tekton.GetPodLogs(f.KubeClient, ns, task.GetName()+"-12345-pod")
-						bs, err := ioutil.ReadAll(log)
+						bs, err := io.ReadAll(log)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(string(bs)).To(Equal("Hello world e2etest\n"))
 					})
@@ -158,7 +158,7 @@ var _ = FDescribe("Tekton Target", func() {
 
 					By("verifying the build results", func() {
 						log := tekton.GetPodLogs(f.KubeClient, ns, pipeline.GetName()+"-12345-greeting-pipeline-pod")
-						bs, err := ioutil.ReadAll(log)
+						bs, err := io.ReadAll(log)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(string(bs)).To(Equal("Hello world e2epipeline\n"))
 					})


### PR DESCRIPTION
CI linter complains about Go comments that are not compatible with the latest spec (1.19 release [note](https://tip.golang.org/doc/go1.19#go-doc)).
I used this chance to update our Go images to 1.19, sync comments, and remove deprecated `io/ioutil` module.
CI linter job timeout was increased since it started to fail from time to time - if execution time continues to grow we'll need to investigate what is the cause.