### PR TITLE
Install Tekton Pipelines on test cluster

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -84,6 +84,11 @@ jobs:
               - ${{ steps.kind-subnet.outputs.prefix }}.255.200-${{ steps.kind-subnet.outputs.prefix }}.255.250
         EOM
 
+    - name: Tekton Pipeline
+      # Pin Tekton's version 0.37 until https://github.com/triggermesh/triggermesh/issues/1043 is resolved
+      run: |
+        kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.37.3/release.yaml
+
     - name: Knative default domain
       # Sets a magic default Knative domain that resolves to <gateway-ip>.sslip.io
       run: |
@@ -108,6 +113,7 @@ jobs:
         kubectl -n triggermesh      wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/part-of=triggermesh
         kubectl -n knative-serving  wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-serving
         kubectl -n knative-eventing wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-eventing
+        kubectl -n tekton-pipelines  wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/part-of=tekton-pipelines
 
     - name: Install Ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
This PR is supposed to fix the CI pipeline after Tekton tests (https://github.com/triggermesh/triggermesh/pull/608)  merge.