### PR TITLE
End-to-end tests workflow update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,21 @@ jobs:
       - store_artifacts:
           path: /tmp/dist/
 
+  trigger-github-action:
+    executor:
+      name: go/default
+      tag: '1.19'
+    steps:
+      - run:
+          name: Sending dispatch event
+          command: |
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              https://api.github.com/repos/triggermesh/triggermesh/dispatches \
+              -d '{"event_type":"e2e-test","client_payload":{"image_hash":"${CIRCLE_SHA1}"}}'
+
   update-manifests:
     description: Patches target cluster configuration
     executor:
@@ -289,6 +304,15 @@ workflows:
           context: production
           requires:
             - gen-apidocs
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              only: main
+      - trigger-github-action:
+          context: production
+          requires:
+            - publish-image
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,19 +1,8 @@
 name: End-to-End Testing
 
 on:
-  push:
-    # NOTE(antoineco): To avoid exposing repository secrets to user supplied
-    # code in pull requests, we only allow this workflow to run on the 'main'
-    # branch, where all code changes are expected to have been reviewed by
-    # maintainers.
-    #
-    # We may want to relax this in the future, on condition that safeguards are
-    # added to prevent the workflow from running automatically when an external
-    # contributor submits code changes inside the .github/workflows/ or
-    # test/e2e/ directories.
-    #
-    # Ref. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    branches: [ main ]
+  repository_dispatch:
+    types: [e2e-test]
 
 jobs:
 
@@ -95,21 +84,14 @@ jobs:
         kubectl create -f https://github.com/knative/serving/releases/download/knative-v1.0.0/serving-default-domain.yaml
         kubectl -n knative-serving wait --timeout=1m --for=condition=Complete jobs.batch/default-domain
 
-    - name: Install ko
-      run: go install github.com/google/ko@v0.11.2
-
     - name: Deploy TriggerMesh
-      env:
-        KO_DOCKER_REPO: kind.local
       run: |
-        yq -yi 'del(.spec.template.spec.containers[]?.resources)' config/500-controller.yaml
+        sed -i config/500-*.yaml \
+          -e "s|ko://github.com/triggermesh/triggermesh/cmd/\(.*$\)|gcr.io/triggermesh/\1:"${{ !github.event.client_payload.image_hash }}"|g"
 
-        ko apply -f config/namespace/
-        ko apply -f config/
+        kubectl apply -f config/namespace/
+        kubectl apply -f config/
 
-        # Building TriggerMesh may cause existing Pods to crash due to resources
-        # exhaustion, including the TriggerMesh webhook. We need to allow enough
-        # time for Pods in CrashLoopBackoff to recover before moving on.
         kubectl -n triggermesh      wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/part-of=triggermesh
         kubectl -n knative-serving  wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-serving
         kubectl -n knative-eventing wait deployments.app --timeout=5m --for=condition=Available -l app.kubernetes.io/name=knative-eventing


### PR DESCRIPTION
I haven't been able to fully test this workflow update because the `repository_dispatch` webhook works only if the config is merged to the default branch ([doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch)). Therefore, after this PR is merged, I may need to update these configs once again to ensure that everything works as expected. 
Related to #1069 