### PR TITLE
Report e2e statuses to Github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,13 +311,13 @@ workflows:
               only: main
       - trigger-github-action:
           context: production
-          requires:
-            - publish-image
-          filters:
-            tags:
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
-            branches:
-              only: main
+          # requires:
+            # - publish-image
+          # filters:
+            # tags:
+              # only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            # branches:
+              # only: main
       - update-manifests:
           name: update-staging-config
           cluster: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       - store_artifacts:
           path: /tmp/dist/
 
-  trigger-github-action:
+  trigger-e2e-test:
     executor:
       name: go/default
       tag: '1.19'
@@ -179,7 +179,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               https://api.github.com/repos/triggermesh/triggermesh/dispatches \
-              -d '{"event_type":"e2e-test","client_payload":{"image_hash":"${CIRCLE_SHA1}"}}'
+              -d '{"event_type":"e2e-test","client_payload":{"commit_sha":"${CIRCLE_SHA1}"}}'
 
   update-manifests:
     description: Patches target cluster configuration
@@ -309,15 +309,15 @@ workflows:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
               only: main
-      - trigger-github-action:
+      - trigger-e2e-test:
           context: production
-          # requires:
-            # - publish-image
-          # filters:
-            # tags:
-              # only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
-            # branches:
-              # only: main
+          requires:
+            - publish-image
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              only: main
       - update-manifests:
           name: update-staging-config
           cluster: staging

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -13,6 +13,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Report test status
+      run: |
+        curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.image_hash }} \
+          -d '{"state":"pending","target_url":"https://example.com/build/status","context":"${{ github.workflow }}"}'
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
@@ -87,7 +96,7 @@ jobs:
     - name: Deploy TriggerMesh
       run: |
         sed -i config/500-*.yaml \
-          -e "s|ko://github.com/triggermesh/triggermesh/cmd/\(.*$\)|gcr.io/triggermesh/\1:"${{ !github.event.client_payload.image_hash }}"|g"
+          -e "s|ko://github.com/triggermesh/triggermesh/cmd/\(.*$\)|gcr.io/triggermesh/\1:${{ github.event.client_payload.image_hash }}|g"
 
         kubectl apply -f config/namespace/
         kubectl apply -f config/
@@ -123,6 +132,15 @@ jobs:
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: ginkgo -procs=$(($(nproc)*2)) -slow-spec-threshold=10m -randomize-all ./test/e2e/
+
+    - name: Report test status
+      run: |
+        curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.image_hash }} \
+          -d '{"state":"${{ job.status }}","target_url":"https://example.com/build/status","context":"${{ github.workflow }}"}'
 
     # The KinD cluster can get shut down before all API objects created during
     # E2E tests have been terminated, which leaks cloud resources depending on

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,8 +19,8 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.image_hash }} \
-          -d '{"state":"pending","target_url":"https://example.com/build/status","context":"${{ github.workflow }}"}'
+          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.commit_sha }} \
+          -d '{"state":"pending","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","context":"${{ github.workflow }}"}'
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -96,7 +96,7 @@ jobs:
     - name: Deploy TriggerMesh
       run: |
         sed -i config/500-*.yaml \
-          -e "s|ko://github.com/triggermesh/triggermesh/cmd/\(.*$\)|gcr.io/triggermesh/\1:${{ github.event.client_payload.image_hash }}|g"
+          -e "s|ko://github.com/triggermesh/triggermesh/cmd/\(.*$\)|gcr.io/triggermesh/\1:${{ github.event.client_payload.commit_sha }}|g"
 
         kubectl apply -f config/namespace/
         kubectl apply -f config/
@@ -140,7 +140,7 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.image_hash }} \
-          -d '{"state":"${{ job.status }}","target_url":"https://example.com/build/status","context":"${{ github.workflow }}"}'
+          -d '{"state":"${{ job.status }}","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","context":"${{ github.workflow }}"}'
 
     # The KinD cluster can get shut down before all API objects created during
     # E2E tests have been terminated, which leaks cloud resources depending on


### PR DESCRIPTION
#1070 decoupled e2e test execution with repository workflow, so there is no status reported from the test action.
This PR passes statuses from e2e workflow to repository commit details.
Part of #1069