### PR TITLE
CI workflow variable typo

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -140,7 +140,7 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.image_hash }} \
+          https://api.github.com/repos/triggermesh/triggermesh/statuses/${{ github.event.client_payload.commit_sha }} \
           -d '{"state":"${{ steps.e2e.outcome }}","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","context":"${{ github.workflow }}"}'
 
     # The KinD cluster can get shut down before all API objects created during


### PR DESCRIPTION
Concludes #1069.
New Tekton tests are still failing, but this time not because of timeouts or resource exhaustion. They don't seem to be working and #608 needs to be reverted. All the changes that were made in #1069 are useful anyway. 