### PR TITLE
export CommonObjectLables into function that can be optionally overriden

### DIFF
--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -326,9 +326,9 @@ func OwnByServiceAccount(obj metav1.Object, owner *corev1.ServiceAccount) {
 	})
 }
 
-// CommonObjectLabels returns a set of labels which are always applied to
-// objects reconciled for the given component type.
-func CommonObjectLabels(o kmeta.OwnerRefable) labels.Set {
+// TMCommonObjectLabels returns a set of labels which are always applied to
+// triggermesh objects reconciled for the given component type.
+func TMCommonObjectLabels(o kmeta.OwnerRefable) labels.Set {
 	return labels.Set{
 		appNameLabel:      ComponentName(o),
 		appComponentLabel: componentAdapter,
@@ -336,6 +336,10 @@ func CommonObjectLabels(o kmeta.OwnerRefable) labels.Set {
 		appManagedByLabel: managedBy,
 	}
 }
+
+// CommonObjectLabels set of labels which are always applied to
+// resource objects reconciled for the given component type
+var CommonObjectLabels = TMCommonObjectLabels
 
 // MaybeAppendValueFromEnvVar conditionally appends an EnvVar to env based on
 // the contents of valueFrom.

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -338,7 +338,7 @@ func TMCommonObjectLabels(o kmeta.OwnerRefable) labels.Set {
 }
 
 // CommonObjectLabels set of labels which are always applied to
-// resource objects reconciled for the given component type
+// resource objects reconciled for the given component type.
 var CommonObjectLabels = TMCommonObjectLabels
 
 // MaybeAppendValueFromEnvVar conditionally appends an EnvVar to env based on

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -327,7 +327,7 @@ func OwnByServiceAccount(obj metav1.Object, owner *corev1.ServiceAccount) {
 }
 
 // TMCommonObjectLabels returns a set of labels which are always applied to
-// triggermesh objects reconciled for the given component type.
+// TriggerMesh objects reconciled for the given component type.
 func TMCommonObjectLabels(o kmeta.OwnerRefable) labels.Set {
 	return labels.Set{
 		appNameLabel:      ComponentName(o),


### PR DESCRIPTION
the Triggermesh `Generic$ResourceReconciler` reconciler is a really nice use of generics to maintain custom k8s resources when developing a controller.

The resources it creates during the underlying adapter-receiver process are automatically stamped with the triggermesh common labels...this PR would expose those as a variable, maintaining current functionality, but allowing developers to leverage the triggermesh reconciler code to create/stamp resources with labels of their choice to decouple the underlying controllers.

Open to a better way to do this, threw it up quick!