### PR TITLE
Removes the Event Source From the File/Naming Structure

### DIFF
--- a/pkg/targets/adapter/awss3target/adapter.go
+++ b/pkg/targets/adapter/awss3target/adapter.go
@@ -112,7 +112,7 @@ func (a *adapter) dispatch(event cloudevents.Event) (*cloudevents.Event, cloudev
 
 	key := event.Subject()
 	if key == "" {
-		key = event.Type() + "/" + event.Source() + "/" + event.Time().String()
+		key = event.Type() "/" + event.Time().String()
 	}
 
 	bucket := strings.Split(a.awsArn.Resource, "/")[0]


### PR DESCRIPTION
Previously we included the event source as part of the path that we place the file. We could spend some time figuring out a fun way to sanitize special characters out of the source.. but I personally think this is a poor design choice and we should just go with `event.Type() "/" + event.Time().String()`

