### PR TITLE
Override AWS Lambda runtime default API port

### DIFF
--- a/pkg/extensions/reconciler/function/adapter.go
+++ b/pkg/extensions/reconciler/function/adapter.go
@@ -123,6 +123,10 @@ func MakeAppEnv(f *v1alpha1.Function) []corev1.EnvVar {
 			Name:  "CE_FUNCTION_RESPONSE_MODE",
 			Value: responseMode,
 		},
+		{
+			Name:  "INTERNAL_API_PORT",
+			Value: "8088",
+		},
 	}, sortedEnvVarsWithPrefix("CE_OVERRIDES_", ceOverrides)...)
 }
 


### PR DESCRIPTION
In order to make Function CRD work in an environment where the default HTTP port is prohibited, we need to set a custom port for the internal AWS Lambda runtime API.
Resolves #1153