### PR TITLE
S3 source: check status' Queue ARN field

### DIFF
--- a/pkg/sources/reconciler/awss3source/adapter.go
+++ b/pkg/sources/reconciler/awss3source/adapter.go
@@ -68,13 +68,15 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 func MakeAppEnv(o *v1alpha1.AWSS3Source) []corev1.EnvVar {
 	// the user may or may not provide a queue ARN in the source's spec, so
 	// the source's status is unfortunately our only source of truth here
-	queueARN := o.Status.QueueARN
-
+	var queueARN string
+	if qa := o.Status.QueueARN; qa != nil {
+		queueARN = qa.String()
+	}
 	return append(reconciler.MakeAWSAuthEnvVars(o.Spec.Auth),
 		[]corev1.EnvVar{
 			{
 				Name:  common.EnvARN,
-				Value: queueARN.String(),
+				Value: queueARN,
 			}, {
 				Name:  envMessageProcessor,
 				Value: "s3",


### PR DESCRIPTION
As a part of local environment experiments, I noticed that the AWS S3 source is panicking because of the missing Status object. The only way to get rid of the Status object requirement is to [Move application-specific logic from controllers to adapters](https://github.com/triggermesh/triggermesh/issues/1166) but right now we can only fix the nil point dereference panic in the S3' `MakeAppEnv` function.