### PR TITLE
set correct kafka source event type

### DIFF
--- a/config/300-kafkasource.yaml
+++ b/config/300-kafkasource.yaml
@@ -24,7 +24,7 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "io.triggermesh.kafka.message" }
+        { "type": "io.triggermesh.kafka.event" }
       ]
 spec:
   group: sources.triggermesh.io


### PR DESCRIPTION
It seems that there is a typo in the event type set in the annotation.