### PR TITLE
Avoid deleting SQS message in case of sink error

### DIFF
--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -169,7 +169,7 @@ spec:
                     description: URI to use as the destination of events.
                     type: string
                     format: uri
-                anyOf:
+                oneOf:
                 - required: [ref]
                 - required: [uri]
               adapterOverrides:

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -169,7 +169,7 @@ spec:
                     description: URI to use as the destination of events.
                     type: string
                     format: uri
-                oneOf:
+                anyOf:
                 - required: [ref]
                 - required: [uri]
               adapterOverrides:

--- a/pkg/sources/adapter/awssqssource/process.go
+++ b/pkg/sources/adapter/awssqssource/process.go
@@ -54,7 +54,7 @@ func (a *adapter) runMessagesProcessor(ctx context.Context) {
 				continue
 			}
 
-			var sendError bool = false
+			sendError := false
 			for _, event := range events {
 				if err := sendSQSEvent(ctx, a.ceClient, event); err != nil {
 					a.logger.Errorw("Failed to send event to the sink", zap.Error(err))

--- a/pkg/sources/adapter/awssqssource/process.go
+++ b/pkg/sources/adapter/awssqssource/process.go
@@ -54,11 +54,17 @@ func (a *adapter) runMessagesProcessor(ctx context.Context) {
 				continue
 			}
 
+			var sendError bool = false
 			for _, event := range events {
 				if err := sendSQSEvent(ctx, a.ceClient, event); err != nil {
 					a.logger.Errorw("Failed to send event to the sink", zap.Error(err))
-					continue
+					sendError = true
+					break
 				}
+			}
+
+			if sendError {
+				continue
 			}
 
 			a.deleteQueue <- msg


### PR DESCRIPTION
Previously messages were deleted from AWS SQS queue even in case of sink error. Corrected error handling. 