### PR TITLE
clusterroles: split clusterroles for fine-grained namespace access

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ Deploy the platform:
 kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/download/triggermesh.yaml
 ```
 
+> By default the `triggermesh-controller` can manage resources in all namespaces, to explicitly specify the 
+> namespaces, first delete the default `triggermesh-controller` ClusterRoleBinding
+> 
+> ```shell
+> $ kubectl delete clusterrolebinding triggermesh-controller
+> ```
+> 
+> and create the following RoleBinding in the namespaces you want to be accessible by the `triggermesh-controller`
+> 
+> ```yaml
+> apiVersion: rbac.authorization.k8s.io/v1
+> kind: RoleBinding
+> metadata:
+>   name: triggermesh-controller
+>   labels:
+>     app.kubernetes.io/part-of: triggermesh
+> subjects:
+>   - kind: ServiceAccount
+>     name: triggermesh-controller
+>     namespace: triggermesh
+> roleRef:
+>   apiGroup: rbac.authorization.k8s.io
+>   kind: ClusterRole
+>   name: triggermesh-controller
+> ```
+
 ## Contributing
 
 Please refer to our [guidelines for contributors](CONTRIBUTING.md).

--- a/config/200-clusterrole-webhook.yaml
+++ b/config/200-clusterrole-webhook.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: triggermesh-webhook
+  name: triggermesh-webhook-namespaced
   labels:
     app.kubernetes.io/part-of: triggermesh
 
@@ -92,6 +92,16 @@ rules:
   - list
   - watch
 
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triggermesh-webhook
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+
+rules:
 # Validation webhook gets system namespace to use it as an owner.
 - apiGroups:
   - ''

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -15,6 +15,102 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: triggermesh-controller-watcher
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+
+rules:
+# List and watch receive-adapters
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - watch
+
+# List and watch reconciled TriggerMesh resources
+# +rbac-check
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awscloudwatchlogssources
+  - awscloudwatchsources
+  - awscodecommitsources
+  - awscognitoidentitysources
+  - awscognitouserpoolsources
+  - awsdynamodbsources
+  - awseventbridgesources
+  - awskinesissources
+  - awsperformanceinsightssources
+  - awss3sources
+  - awssnssources
+  - awssqssources
+  - azureactivitylogssources
+  - azureblobstoragesources
+  - azureeventgridsources
+  - azureeventhubsources
+  - azureiothubsources
+  - azurequeuestoragesources
+  - azureservicebusqueuesources
+  - azureservicebustopicsources
+  - cloudeventssources
+  - googlecloudauditlogssources
+  - googlecloudbillingsources
+  - googlecloudiotsources
+  - googlecloudpubsubsources
+  - googlecloudsourcerepositoriessources
+  - googlecloudstoragesources
+  - httppollersources
+  - ibmmqsources
+  - kafkasources
+  - ocimetricssources
+  - salesforcesources
+  - slacksources
+  - twiliosources
+  - webhooksources
+  - zendesksources
+  verbs:
+  - list
+  - watch
+
+# List and watch resource-specific ServiceAccounts and RoleBindings
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - serviceaccounts/finalizers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - watch
+
+# Observe status of Pods and their ancestors
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
+  - watch
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: triggermesh-controller
   labels:
     app.kubernetes.io/part-of: triggermesh

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -15,6 +15,21 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: triggermesh-controller-watcher
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+subjects:
+- kind: ServiceAccount
+  name: triggermesh-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: triggermesh-controller-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: triggermesh-controller
   labels:
     app.kubernetes.io/part-of: triggermesh

--- a/config/rolebindings/202-rolebindings.yaml
+++ b/config/rolebindings/202-rolebindings.yaml
@@ -12,33 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Gives the triggermesh-controller access to namespaces in which this RoleBinding is created.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: triggermesh-webhook-namespaced
-  namespace: triggermesh
+  name: triggermesh-controller
   labels:
     app.kubernetes.io/part-of: triggermesh
 subjects:
 - kind: ServiceAccount
-  name: triggermesh-webhook
+  name: triggermesh-controller
   namespace: triggermesh
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: triggermesh-webhook-namespaced
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: triggermesh-webhook
-  labels:
-    app.kubernetes.io/part-of: triggermesh
-subjects:
-- kind: ServiceAccount
-  name: triggermesh-webhook
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: triggermesh-webhook
+  name: triggermesh-controller


### PR DESCRIPTION
By default the `triggermesh-controller` has access to all namespaces of
the cluster and therefore can manage resources in any namespace.

This default may not be desirable for all users who which to explicitly
specify the namespaces that the triggermesh-controller can create
resources in.

In this PR, we have segregated the clusterrole in such a way that users
can achieve this fine grained access simply by deleting the
`triggermesh-controller` ClusterRoles and creating the following
RoleBinding in the namespaces that the controller should be able to
create resources in:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: triggermesh-controller
  labels:
    app.kubernetes.io/part-of: triggermesh
subjects:
  - kind: ServiceAccount
    name: triggermesh-controller
    namespace: triggermesh
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: triggermesh-controller
```