### PR TITLE
Google Sources - Add support for Workload Identity

### DIFF
--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -202,7 +202,6 @@ spec:
             - serviceName
             - methodName
             - pubsub
-            - serviceAccountKey
             - sink
           status:
             description: Reported status of the event source.

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -194,7 +194,6 @@ spec:
             - billingAccountId
             - budgetId
             - pubsub
-            - serviceAccountKey
             - sink
           status:
             description: Reported status of the event source.

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -179,7 +179,6 @@ spec:
                           format: int64
             required:
             - topic
-            - serviceAccountKey
             - sink
           status:
             description: Reported status of the event source.

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -191,7 +191,6 @@ spec:
                           format: int64
             required:
             - repository
-            - serviceAccountKey
             - sink
           status:
             description: Reported status of the event source.

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -203,7 +203,6 @@ spec:
             required:
             - bucket
             - pubsub
-            - serviceAccountKey
             - sink
           status:
             description: Reported status of the event source.

--- a/pkg/apis/common/v1alpha1/context.go
+++ b/pkg/apis/common/v1alpha1/context.go
@@ -33,3 +33,16 @@ func ReconcilableFromContext(ctx context.Context) Reconcilable {
 	}
 	return nil
 }
+
+type serviceAccountAnnotated struct{}
+
+func WithServiceAccountAnnotated(ctx context.Context, annotations map[string]string) context.Context {
+	return context.WithValue(ctx, serviceAccountAnnotated{}, annotations)
+}
+
+func ServiceAccountAnnotationsFromContext(ctx context.Context) map[string]string {
+	if a, ok := ctx.Value(serviceAccountAnnotated{}).(map[string]string); ok {
+		return a
+	}
+	return nil
+}

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -2612,7 +2612,11 @@ func (in *GoogleCloudAuditLogsSourceSpec) DeepCopyInto(out *GoogleCloudAuditLogs
 		**out = **in
 	}
 	in.PubSub.DeepCopyInto(&out.PubSub)
-	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
+	if in.ServiceAccountKey != nil {
+		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
+		*out = new(commonv1alpha1.ValueFromField)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)
@@ -2729,7 +2733,11 @@ func (in *GoogleCloudBillingSourceSpec) DeepCopyInto(out *GoogleCloudBillingSour
 	*out = *in
 	in.SourceSpec.DeepCopyInto(&out.SourceSpec)
 	in.PubSub.DeepCopyInto(&out.PubSub)
-	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
+	if in.ServiceAccountKey != nil {
+		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
+		*out = new(commonv1alpha1.ValueFromField)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)
@@ -2846,7 +2854,11 @@ func (in *GoogleCloudPubSubSourceSpec) DeepCopyInto(out *GoogleCloudPubSubSource
 		*out = new(string)
 		**out = **in
 	}
-	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
+	if in.ServiceAccountKey != nil {
+		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
+		*out = new(commonv1alpha1.ValueFromField)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)
@@ -2985,7 +2997,11 @@ func (in *GoogleCloudSourceRepositoriesSourceSpec) DeepCopyInto(out *GoogleCloud
 		*out = new(string)
 		**out = **in
 	}
-	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
+	if in.ServiceAccountKey != nil {
+		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
+		*out = new(commonv1alpha1.ValueFromField)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)
@@ -3102,7 +3118,11 @@ func (in *GoogleCloudStorageSourceSpec) DeepCopyInto(out *GoogleCloudStorageSour
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.ServiceAccountKey.DeepCopyInto(&out.ServiceAccountKey)
+	if in.ServiceAccountKey != nil {
+		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
+		*out = new(commonv1alpha1.ValueFromField)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)

--- a/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudauditlogs_types.go
@@ -72,7 +72,7 @@ type GoogleCloudAuditLogsSourceSpec struct {
 
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`
+	ServiceAccountKey *v1alpha1.ValueFromField `json:"serviceAccountKey,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudbilling_types.go
@@ -61,7 +61,7 @@ type GoogleCloudBillingSourceSpec struct {
 
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`
+	ServiceAccountKey *v1alpha1.ValueFromField `json:"serviceAccountKey,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudpubsub_types.go
@@ -63,7 +63,7 @@ type GoogleCloudPubSubSourceSpec struct {
 
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`
+	ServiceAccountKey *v1alpha1.ValueFromField `json:"serviceAccountKey,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudsourcerepositories_types.go
@@ -68,7 +68,7 @@ type GoogleCloudSourceRepositoriesSourceSpec struct {
 
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`
+	ServiceAccountKey *v1alpha1.ValueFromField `json:"serviceAccountKey,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
@@ -66,7 +66,7 @@ type GoogleCloudStorageSourceSpec struct {
 
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
-	ServiceAccountKey v1alpha1.ValueFromField `json:"serviceAccountKey"`
+	ServiceAccountKey *v1alpha1.ValueFromField `json:"serviceAccountKey,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -264,14 +264,18 @@ func commonAdapterKnServiceOptions(rcl v1alpha1.Reconcilable) []resource.ObjectO
 func newServiceAccount(ctx context.Context, rcl v1alpha1.Reconcilable, owners []kmeta.OwnerRefable) *corev1.ServiceAccount {
 	extraAnnotations := v1alpha1.ServiceAccountAnnotationsFromContext(ctx)
 
-	resource := resource.NewServiceAccount(rcl.GetNamespace(), ServiceAccountName(rcl),
+	opts := []resource.ObjectOption{
 		resource.Owners(owners...),
 		resource.Labels(CommonObjectLabels(rcl)),
+	}
+
+	for k, v := range extraAnnotations {
+		opts = append(opts, resource.Annotation(k, v))
+	}
+
+	return resource.NewServiceAccount(rcl.GetNamespace(), ServiceAccountName(rcl),
+		opts...,
 	)
-
-	resource.Annotations = extraAnnotations
-
-	return resource
 }
 
 // newConfigWatchRoleBinding returns a RoleBinding object that binds a ServiceAccount

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -260,11 +261,17 @@ func commonAdapterKnServiceOptions(rcl v1alpha1.Reconcilable) []resource.ObjectO
 
 // newServiceAccount returns a ServiceAccount object with its OwnerReferences
 // metadata attribute populated from the given owners.
-func newServiceAccount(rcl v1alpha1.Reconcilable, owners []kmeta.OwnerRefable) *corev1.ServiceAccount {
-	return resource.NewServiceAccount(rcl.GetNamespace(), ServiceAccountName(rcl),
+func newServiceAccount(ctx context.Context, rcl v1alpha1.Reconcilable, owners []kmeta.OwnerRefable) *corev1.ServiceAccount {
+	extraAnnotations := v1alpha1.ServiceAccountAnnotationsFromContext(ctx)
+
+	resource := resource.NewServiceAccount(rcl.GetNamespace(), ServiceAccountName(rcl),
 		resource.Owners(owners...),
 		resource.Labels(CommonObjectLabels(rcl)),
 	)
+
+	resource.Annotations = extraAnnotations
+
+	return resource
 }
 
 // newConfigWatchRoleBinding returns a RoleBinding object that binds a ServiceAccount

--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -297,7 +297,7 @@ func (r *GenericRBACReconciler[T, L]) reconcileRBAC(ctx context.Context,
 
 	rcl := v1alpha1.ReconcilableFromContext(ctx)
 
-	desiredSA := newServiceAccount(rcl, owners)
+	desiredSA := newServiceAccount(ctx, rcl, owners)
 	for _, m := range serviceAccountMutations(rcl) {
 		m(desiredSA)
 	}

--- a/pkg/sources/client/gcloud/billing/client.go
+++ b/pkg/sources/client/gcloud/billing/client.go
@@ -56,14 +56,6 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.GoogleCloudBillingSource) (*pubsub.Client, *billing.BudgetClient, error) {
-	requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(src.Spec.ServiceAccountKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
-	}
-
-	saKey := []byte(requestedSecrets[0])
-	credsCliOpt := option.WithCredentialsJSON(saKey)
-
 	ctx := context.Background()
 
 	var pubsubProject string
@@ -73,14 +65,37 @@ func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.GoogleCloudBillingSourc
 		pubsubProject = topic.Project
 	}
 
-	psCli, err := pubsub.NewClient(ctx, pubsubProject, credsCliOpt)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
-	}
+	var psCli *pubsub.Client
+	var biCli *billing.BudgetClient
+	var err error
+	if src.Spec.ServiceAccountKey != nil {
+		requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(*src.Spec.ServiceAccountKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
+		}
 
-	biCli, err := billing.NewBudgetClient(ctx, credsCliOpt)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating Google Cloud Billing Budget API client: %w", err)
+		saKey := []byte(requestedSecrets[0])
+		credsCliOpt := option.WithCredentialsJSON(saKey)
+
+		psCli, err = pubsub.NewClient(ctx, pubsubProject, credsCliOpt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
+
+		biCli, err = billing.NewBudgetClient(ctx, credsCliOpt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Billing Budget API client: %w", err)
+		}
+	} else {
+		psCli, err = pubsub.NewClient(ctx, pubsubProject)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
+
+		biCli, err = billing.NewBudgetClient(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Billing Budget API client: %w", err)
+		}
 	}
 
 	return psCli, biCli, nil

--- a/pkg/sources/client/gcloud/pubsub/client.go
+++ b/pkg/sources/client/gcloud/pubsub/client.go
@@ -55,17 +55,26 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.GoogleCloudPubSubSource) (*pubsub.Client, error) {
-	requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(src.Spec.ServiceAccountKey)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
-	}
-
-	saKey := []byte(requestedSecrets[0])
 	project := src.Spec.Topic.Project
 
-	cli, err := pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON(saKey))
-	if err != nil {
-		return nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+	var cli *pubsub.Client
+	var err error
+	if src.Spec.ServiceAccountKey != nil {
+		requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(*src.Spec.ServiceAccountKey)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
+		}
+		saKey := []byte(requestedSecrets[0])
+
+		cli, err = pubsub.NewClient(context.Background(), project, option.WithCredentialsJSON(saKey))
+		if err != nil {
+			return nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
+	} else {
+		cli, err = pubsub.NewClient(context.Background(), project)
+		if err != nil {
+			return nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
 	}
 
 	return cli, nil

--- a/pkg/sources/client/gcloud/storage/client.go
+++ b/pkg/sources/client/gcloud/storage/client.go
@@ -56,14 +56,6 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.GoogleCloudStorageSource) (*pubsub.Client, *storage.Client, error) {
-	requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(src.Spec.ServiceAccountKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
-	}
-
-	saKey := []byte(requestedSecrets[0])
-	credsCliOpt := option.WithCredentialsJSON(saKey)
-
 	ctx := context.Background()
 
 	var pubsubProject string
@@ -73,14 +65,37 @@ func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.GoogleCloudStorageSourc
 		pubsubProject = topic.Project
 	}
 
-	psCli, err := pubsub.NewClient(ctx, pubsubProject, credsCliOpt)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
-	}
+	var psCli *pubsub.Client
+	var stCli *storage.Client
+	var err error
+	if src.Spec.ServiceAccountKey != nil {
+		requestedSecrets, err := secret.NewGetter(g.sg(src.Namespace)).Get(*src.Spec.ServiceAccountKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("retrieving Google Cloud service account key: %w", err)
+		}
 
-	stCli, err := storage.NewClient(ctx, credsCliOpt)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating Google Cloud Storage API client: %w", err)
+		saKey := []byte(requestedSecrets[0])
+		credsCliOpt := option.WithCredentialsJSON(saKey)
+
+		psCli, err = pubsub.NewClient(ctx, pubsubProject, credsCliOpt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
+
+		stCli, err = storage.NewClient(ctx, credsCliOpt)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Storage API client: %w", err)
+		}
+	} else {
+		psCli, err = pubsub.NewClient(ctx, pubsubProject)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Pub/Sub API client: %w", err)
+		}
+
+		stCli, err = storage.NewClient(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating Google Cloud Storage API client: %w", err)
+		}
 	}
 
 	return psCli, stCli, nil

--- a/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/adapter.go
@@ -65,21 +65,25 @@ func MakeAppEnv(o *v1alpha1.GoogleCloudAuditLogsSource) []corev1.EnvVar {
 		subsName = sn.String()
 	}
 
-	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
-		[]corev1.EnvVar{
-			{
-				Name:  common.EnvGCloudPubSubSubscription,
-				Value: subsName,
-			}, {
-				Name:  common.EnvCESource,
-				Value: o.AsEventSource(),
-			}, {
-				Name:  common.EnvCEType,
-				Value: v1alpha1.GoogleCloudAuditLogsGenericEventType,
-			}, {
-				Name:  adapter.EnvConfigCEOverrides,
-				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
-			},
-		}...,
+	var envVar []corev1.EnvVar
+	if o.Spec.ServiceAccountKey != nil {
+		envVar = common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, *o.Spec.ServiceAccountKey)
+	}
+
+	return append(envVar, []corev1.EnvVar{
+		{
+			Name:  common.EnvGCloudPubSubSubscription,
+			Value: subsName,
+		}, {
+			Name:  common.EnvCESource,
+			Value: o.AsEventSource(),
+		}, {
+			Name:  common.EnvCEType,
+			Value: v1alpha1.GoogleCloudAuditLogsGenericEventType,
+		}, {
+			Name:  adapter.EnvConfigCEOverrides,
+			Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+		},
+	}...,
 	)
 }

--- a/pkg/sources/reconciler/googlecloudauditlogssource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/reconciler.go
@@ -63,6 +63,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudA
 	// inject source into context for usage in reconciliation logic
 	ctx = commonv1alpha1.WithReconcilable(ctx, o)
 
+	if o.Annotations != nil {
+		ctx = commonv1alpha1.WithServiceAccountAnnotated(ctx, o.Annotations)
+	}
+
 	pubsubCli, logadminCli, err := r.cg.Get(o)
 	switch {
 	case isNoCredentials(err):

--- a/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudauditlogssource/reconciler_test.go
@@ -81,7 +81,7 @@ func newEventSource() *v1alpha1.GoogleCloudAuditLogsSource {
 			PubSub: v1alpha1.GoogleCloudSourcePubSubSpec{
 				Project: ptr.String("my-project"),
 			},
-			ServiceAccountKey: commonv1alpha1.ValueFromField{
+			ServiceAccountKey: &commonv1alpha1.ValueFromField{
 				Value: "{}",
 			},
 		},

--- a/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/adapter.go
@@ -65,21 +65,25 @@ func MakeAppEnv(o *v1alpha1.GoogleCloudBillingSource) []corev1.EnvVar {
 		subsName = sn.String()
 	}
 
-	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
-		[]corev1.EnvVar{
-			{
-				Name:  common.EnvGCloudPubSubSubscription,
-				Value: subsName,
-			}, {
-				Name:  common.EnvCESource,
-				Value: o.AsEventSource(),
-			}, {
-				Name:  common.EnvCEType,
-				Value: v1alpha1.GoogleCloudBillingGenericEventType,
-			}, {
-				Name:  adapter.EnvConfigCEOverrides,
-				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
-			},
-		}...,
+	var envVar []corev1.EnvVar
+	if o.Spec.ServiceAccountKey != nil {
+		envVar = common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, *o.Spec.ServiceAccountKey)
+	}
+
+	return append(envVar, []corev1.EnvVar{
+		{
+			Name:  common.EnvGCloudPubSubSubscription,
+			Value: subsName,
+		}, {
+			Name:  common.EnvCESource,
+			Value: o.AsEventSource(),
+		}, {
+			Name:  common.EnvCEType,
+			Value: v1alpha1.GoogleCloudBillingGenericEventType,
+		}, {
+			Name:  adapter.EnvConfigCEOverrides,
+			Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+		},
+	}...,
 	)
 }

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
@@ -63,6 +63,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudB
 	// inject source into context for usage in reconciliation logic
 	ctx = commonv1alpha1.WithReconcilable(ctx, o)
 
+	if o.Annotations != nil {
+		ctx = commonv1alpha1.WithServiceAccountAnnotated(ctx, o.Annotations)
+	}
+
 	pubsubCli, biCli, err := r.cg.Get(o)
 	switch {
 	case isNoCredentials(err):

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler_test.go
@@ -81,7 +81,7 @@ func newEventSource() *v1alpha1.GoogleCloudBillingSource {
 			PubSub: v1alpha1.GoogleCloudSourcePubSubSpec{
 				Project: ptr.String("my-project"),
 			},
-			ServiceAccountKey: commonv1alpha1.ValueFromField{
+			ServiceAccountKey: &commonv1alpha1.ValueFromField{
 				Value: "{}",
 			},
 		},

--- a/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/adapter.go
@@ -64,10 +64,16 @@ func MakeAppEnv(o *v1alpha1.GoogleCloudPubSubSource) []corev1.EnvVar {
 		subsName = sn.String()
 	}
 
-	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
-		corev1.EnvVar{
+	var envVar []corev1.EnvVar
+	if o.Spec.ServiceAccountKey != nil {
+		envVar = common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, *o.Spec.ServiceAccountKey)
+	}
+
+	return append(envVar, []corev1.EnvVar{
+		{
 			Name:  common.EnvGCloudPubSubSubscription,
 			Value: subsName,
 		},
+	}...,
 	)
 }

--- a/pkg/sources/reconciler/googlecloudpubsubsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/reconciler.go
@@ -58,6 +58,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudP
 	// inject source into context for usage in reconciliation logic
 	ctx = commonv1alpha1.WithReconcilable(ctx, o)
 
+	if o.Annotations != nil {
+		ctx = commonv1alpha1.WithServiceAccountAnnotated(ctx, o.Annotations)
+	}
+
 	pubsubCli, err := r.cg.Get(o)
 	switch {
 	case isNoCredentials(err):

--- a/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudpubsubsource/reconciler_test.go
@@ -79,7 +79,7 @@ func newEventSource() *v1alpha1.GoogleCloudPubSubSource {
 				Collection: pubsubCollectionTopics,
 				Resource:   "my-topic",
 			},
-			ServiceAccountKey: commonv1alpha1.ValueFromField{
+			ServiceAccountKey: &commonv1alpha1.ValueFromField{
 				Value: "{}",
 			},
 		},

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/adapter.go
@@ -65,21 +65,24 @@ func MakeAppEnv(o *v1alpha1.GoogleCloudSourceRepositoriesSource) []corev1.EnvVar
 		subsName = sn.String()
 	}
 
-	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
-		[]corev1.EnvVar{
-			{
-				Name:  common.EnvGCloudPubSubSubscription,
-				Value: subsName,
-			}, {
-				Name:  common.EnvCESource,
-				Value: o.AsEventSource(),
-			}, {
-				Name:  common.EnvCEType,
-				Value: v1alpha1.GoogleCloudSourceRepoGenericEventType,
-			}, {
-				Name:  adapter.EnvConfigCEOverrides,
-				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
-			},
-		}...,
+	var envVar []corev1.EnvVar
+	if o.Spec.ServiceAccountKey != nil {
+		envVar = common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, *o.Spec.ServiceAccountKey)
+	}
+	return append(envVar, []corev1.EnvVar{
+		{
+			Name:  common.EnvGCloudPubSubSubscription,
+			Value: subsName,
+		}, {
+			Name:  common.EnvCESource,
+			Value: o.AsEventSource(),
+		}, {
+			Name:  common.EnvCEType,
+			Value: v1alpha1.GoogleCloudSourceRepoGenericEventType,
+		}, {
+			Name:  adapter.EnvConfigCEOverrides,
+			Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+		},
+	}...,
 	)
 }

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler.go
@@ -63,6 +63,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudS
 	// inject source into context for usage in reconciliation logic
 	ctx = commonv1alpha1.WithReconcilable(ctx, o)
 
+	if o.Annotations != nil {
+		ctx = commonv1alpha1.WithServiceAccountAnnotated(ctx, o.Annotations)
+	}
+
 	pubsubCli, repoCli, err := r.cg.Get(o)
 	switch {
 	case isNoCredentials(err):

--- a/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudsourcerepositoriessource/reconciler_test.go
@@ -84,7 +84,7 @@ func newEventSource() *v1alpha1.GoogleCloudSourceRepositoriesSource {
 			PubSub: v1alpha1.GoogleCloudSourcePubSubSpec{
 				Project: ptr.String("my-project"),
 			},
-			ServiceAccountKey: commonv1alpha1.ValueFromField{
+			ServiceAccountKey: &commonv1alpha1.ValueFromField{
 				Value: "{}",
 			},
 		},

--- a/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/adapter.go
@@ -65,21 +65,25 @@ func MakeAppEnv(o *v1alpha1.GoogleCloudStorageSource) []corev1.EnvVar {
 		subsName = sn.String()
 	}
 
-	return append(common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, o.Spec.ServiceAccountKey),
-		[]corev1.EnvVar{
-			{
-				Name:  common.EnvGCloudPubSubSubscription,
-				Value: subsName,
-			}, {
-				Name:  common.EnvCESource,
-				Value: o.AsEventSource(),
-			}, {
-				Name:  common.EnvCEType,
-				Value: v1alpha1.GoogleCloudStorageGenericEventType,
-			}, {
-				Name:  adapter.EnvConfigCEOverrides,
-				Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
-			},
-		}...,
+	var envVar []corev1.EnvVar
+	if o.Spec.ServiceAccountKey != nil {
+		envVar = common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, common.EnvGCloudSAKey, *o.Spec.ServiceAccountKey)
+	}
+
+	return append(envVar, []corev1.EnvVar{
+		{
+			Name:  common.EnvGCloudPubSubSubscription,
+			Value: subsName,
+		}, {
+			Name:  common.EnvCESource,
+			Value: o.AsEventSource(),
+		}, {
+			Name:  common.EnvCEType,
+			Value: v1alpha1.GoogleCloudStorageGenericEventType,
+		}, {
+			Name:  adapter.EnvConfigCEOverrides,
+			Value: cloudevents.OverridesJSON(o.Spec.CloudEventOverrides),
+		},
+	}...,
 	)
 }

--- a/pkg/sources/reconciler/googlecloudstoragesource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/reconciler.go
@@ -65,6 +65,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudS
 	// inject source into context for usage in reconciliation logic
 	ctx = commonv1alpha1.WithReconcilable(ctx, o)
 
+	if o.Annotations != nil {
+		ctx = commonv1alpha1.WithServiceAccountAnnotated(ctx, o.Annotations)
+	}
+
 	pubsubCli, storageCli, err := r.cg.Get(o)
 	switch {
 	case isNoCredentials(err):

--- a/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/reconciler_test.go
@@ -80,7 +80,7 @@ func newEventSource() *v1alpha1.GoogleCloudStorageSource {
 			PubSub: v1alpha1.GoogleCloudSourcePubSubSpec{
 				Project: ptr.String("my-project"),
 			},
-			ServiceAccountKey: commonv1alpha1.ValueFromField{
+			ServiceAccountKey: &commonv1alpha1.ValueFromField{
 				Value: "{}",
 			},
 		},


### PR DESCRIPTION
Closes #1200

Steps to use:

A GKE cluster ready with Workload Identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
Following the guide, it is needed to do some steps:

Allow the triggermesh service account to impersonate the IAM:
```
gcloud iam service-accounts add-iam-policy-binding my-sa@my-project.iam.gserviceaccount.com \
    --role roles/iam.workloadIdentityUser \
    --member "serviceAccount:my-project.svc.id.goog[triggermesh/triggermesh-controller]"
```
Also the service account for the specific source, ex: pubsub:
```
gcloud iam service-accounts add-iam-policy-binding my-sa@my-project.iam.gserviceaccount.com \
    --role roles/iam.workloadIdentityUser \
    --member "serviceAccount:my-project.svc.id.goog[my-namespace/googlecloudpubsubsource-adapter]"
```

Annotate the triggermesh-controller service account:
```
kubectl annotate serviceaccount triggermesh-controller \
    --namespace triggermesh \
    iam.gke.io/gcp-service-account=my-sa@my-project.iam.gserviceaccount.com
```

Finally add the following annotation to the Google source: ex: pubsub:
```
apiVersion: sources.triggermesh.io/v1alpha1
kind: GoogleCloudPubSubSource
metadata:
  name: sample
  annotations:
    iam.gke.io/gcp-service-account: my-sa@my-project.iam.gserviceaccount.com
spec:
  topic: projects/my-project/topics/my-topic

  sink:
    ref:
      apiVersion: eventing.knative.dev/v1
      kind: Broker
      name: default
```