### PR TITLE
add proposed changes

### DIFF
--- a/pkg/apis/flow/v1alpha1/transformation_types.go
+++ b/pkg/apis/flow/v1alpha1/transformation_types.go
@@ -70,8 +70,9 @@ type Transform struct {
 
 // Path is a key-value pair that represents JSON object path
 type Path struct {
-	Key   string `json:"key,omitempty"`
-	Value string `json:"value,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Separator string `json:"separator,omitempty"`
+	Value     string `json:"value,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/flow/adapter/transformation/pipeline.go
+++ b/pkg/flow/adapter/transformation/pipeline.go
@@ -30,6 +30,10 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/transformer/store"
 )
 
+const (
+	DefaultEventPathSeparator = "."
+)
+
 // Pipeline is a set of Transformations that are
 // sequentially applied to JSON data.
 type Pipeline struct {
@@ -60,7 +64,12 @@ func newPipeline(transformations []v1alpha1.Transform) (*Pipeline, error) {
 			return nil, fmt.Errorf("transformation %q not found", transformation.Operation)
 		}
 		for _, kv := range transformation.Paths {
-			pipeline = append(pipeline, operation.New(kv.Key, kv.Value))
+			sep := DefaultEventPathSeparator
+			if kv.Separator != "" {
+				sep = kv.Separator
+			}
+
+			pipeline = append(pipeline, operation.New(kv.Key, kv.Value, sep))
 		}
 	}
 

--- a/pkg/flow/adapter/transformation/transformer/add/add.go
+++ b/pkg/flow/adapter/transformation/transformer/add/add.go
@@ -99,23 +99,24 @@ func (a *Add) retrieveVariable(key string) interface{} {
 func (a *Add) composeValue() interface{} {
 	result := a.Value
 	for _, key := range a.variables.ListKeys() {
-		index := strings.Index(result, key)
-		if index == -1 {
-			continue
-		}
-		// return value if it exists, or properly nil for references to empty values
-		storedValue := a.retrieveVariable(key)
+		for strings.Index(result, key) != -1 {
+			index := strings.Index(result, key)
+			if index == -1 {
+				continue
+			}
+			// return value if it exists, or properly nil for references to empty values
+			storedValue := a.retrieveVariable(key)
 
-		if result == key {
-			return storedValue
-		}
+			if result == key {
+				return storedValue
+			}
 
-		// no variable assigned to key in multi-path assignment, remove from path
-		if storedValue == nil {
-			// result = fmt.Sprintf("%s", result[:index-1])
-			result = fmt.Sprintf("%s%s", result[:index], result[index+len(key):])
-		} else {
-			result = fmt.Sprintf("%s%v%s", result[:index], storedValue, result[index+len(key):])
+			// no variable assigned to key in multi-path assignment, remove from path
+			if storedValue == nil {
+				result = fmt.Sprintf("%s", result[:index-1])
+			} else {
+				result = fmt.Sprintf("%s%v%s", result[:index], storedValue, result[index+len(key):])
+			}
 		}
 	}
 	return result

--- a/pkg/flow/adapter/transformation/transformer/delete/delete.go
+++ b/pkg/flow/adapter/transformation/transformer/delete/delete.go
@@ -62,7 +62,7 @@ func (d *Delete) InitStep() bool {
 }
 
 // New returns a new instance of Delete object.
-func (d *Delete) New(key, value string) transformer.Transformer {
+func (d *Delete) New(key, value string, _ string) transformer.Transformer {
 	return &Delete{
 		Path:  key,
 		Value: value,

--- a/pkg/flow/adapter/transformation/transformer/parse/parse.go
+++ b/pkg/flow/adapter/transformation/transformer/parse/parse.go
@@ -31,8 +31,9 @@ var _ transformer.Transformer = (*Parse)(nil)
 
 // Parse object implements Transformer interface.
 type Parse struct {
-	Path  string
-	Value string
+	Path      string
+	Value     string
+	Separator string
 
 	variables *storage.Storage
 }
@@ -63,10 +64,11 @@ func (p *Parse) InitStep() bool {
 }
 
 // New returns a new instance of Parse object.
-func (p *Parse) New(key, value string) transformer.Transformer {
+func (p *Parse) New(key, value, sep string) transformer.Transformer {
 	return &Parse{
-		Path:  key,
-		Value: value,
+		Path:      key,
+		Value:     value,
+		Separator: sep,
 
 		variables: p.variables,
 	}
@@ -75,7 +77,7 @@ func (p *Parse) New(key, value string) transformer.Transformer {
 // Apply is a main method of Transformation that parse JSON values
 // into variables that can be used by other Transformations in a pipeline.
 func (p *Parse) Apply(data []byte) ([]byte, error) {
-	path := convert.SliceToMap(strings.Split(p.Path, "."), "")
+	path := convert.SliceToMap(strings.Split(p.Path, p.Separator), "")
 
 	switch p.Value {
 	case "json", "JSON":
@@ -87,7 +89,7 @@ func (p *Parse) Apply(data []byte) ([]byte, error) {
 		if err != nil {
 			return data, err
 		}
-		newObject := convert.SliceToMap(strings.Split(p.Path, "."), jsonValue)
+		newObject := convert.SliceToMap(strings.Split(p.Path, p.Separator), jsonValue)
 		return json.Marshal(convert.MergeJSONWithMap(event, newObject))
 	default:
 		return data, fmt.Errorf("parse operation does not support %q type of value", p.Value)

--- a/pkg/flow/adapter/transformation/transformer/shift/shift.go
+++ b/pkg/flow/adapter/transformation/transformer/shift/shift.go
@@ -29,9 +29,10 @@ var _ transformer.Transformer = (*Shift)(nil)
 
 // Shift object implements Transformer interface.
 type Shift struct {
-	Path    string
-	NewPath string
-	Value   string
+	Path      string
+	NewPath   string
+	Value     string
+	Separator string
 
 	variables *storage.Storage
 }
@@ -64,16 +65,18 @@ func (s *Shift) InitStep() bool {
 }
 
 // New returns a new instance of Shift object.
-func (s *Shift) New(key, value string) transformer.Transformer {
+func (s *Shift) New(key, value, sep string) transformer.Transformer {
 	// doubtful scheme, review needed
 	keys := strings.Split(key, delimeter)
 	if len(keys) != 2 {
 		return nil
 	}
+
 	return &Shift{
-		Path:    keys[0],
-		NewPath: keys[1],
-		Value:   value,
+		Path:      keys[0],
+		NewPath:   keys[1],
+		Value:     value,
+		Separator: sep,
 
 		variables: s.variables,
 	}
@@ -82,7 +85,7 @@ func (s *Shift) New(key, value string) transformer.Transformer {
 // Apply is a main method of Transformation that moves existing
 // values to a new locations.
 func (s *Shift) Apply(data []byte) ([]byte, error) {
-	oldPath := convert.SliceToMap(strings.Split(s.Path, "."), "")
+	oldPath := convert.SliceToMap(strings.Split(s.Path, s.Separator), "")
 
 	var event interface{}
 	if err := json.Unmarshal(data, &event); err != nil {
@@ -99,7 +102,7 @@ func (s *Shift) Apply(data []byte) ([]byte, error) {
 		return data, nil
 	}
 
-	newPath := convert.SliceToMap(strings.Split(s.NewPath, "."), value)
+	newPath := convert.SliceToMap(strings.Split(s.NewPath, s.Separator), value)
 	result := convert.MergeJSONWithMap(newEvent, newPath)
 	output, err := json.Marshal(result)
 	if err != nil {

--- a/pkg/flow/adapter/transformation/transformer/store/store.go
+++ b/pkg/flow/adapter/transformation/transformer/store/store.go
@@ -30,8 +30,9 @@ var _ transformer.Transformer = (*Store)(nil)
 
 // Store object implements Transformer interface.
 type Store struct {
-	Path  string
-	Value string
+	Path      string
+	Value     string
+	Separator string
 
 	variables *storage.Storage
 }
@@ -62,10 +63,11 @@ func (s *Store) InitStep() bool {
 }
 
 // New returns a new instance of Store object.
-func (s *Store) New(key, value string) transformer.Transformer {
+func (s *Store) New(key, value, sep string) transformer.Transformer {
 	return &Store{
-		Path:  key,
-		Value: value,
+		Path:      key,
+		Value:     value,
+		Separator: sep,
 
 		variables: s.variables,
 	}
@@ -74,7 +76,7 @@ func (s *Store) New(key, value string) transformer.Transformer {
 // Apply is a main method of Transformation that stores JSON values
 // into variables that can be used by other Transformations in a pipeline.
 func (s *Store) Apply(data []byte) ([]byte, error) {
-	path := convert.SliceToMap(strings.Split(s.Value, "."), "")
+	path := convert.SliceToMap(strings.Split(s.Value, s.Separator), "")
 
 	var event interface{}
 	if err := json.Unmarshal(data, &event); err != nil {

--- a/pkg/flow/adapter/transformation/transformer/transformer.go
+++ b/pkg/flow/adapter/transformation/transformer/transformer.go
@@ -23,7 +23,7 @@ import (
 // Transformer is an interface that contains common methods
 // to work with JSON data.
 type Transformer interface {
-	New(string, string) Transformer
+	New(string, string, string) Transformer
 	Apply([]byte) ([]byte, error)
 	SetStorage(*storage.Storage)
 	InitStep() bool

--- a/pkg/reconciler/labels.go
+++ b/pkg/reconciler/labels.go
@@ -33,14 +33,14 @@ const (
 
 // Common label values
 const (
-	partOf           = "fianu"
-	managedBy        = "fianu-controller"
+	partOf           = "triggermesh"
+	managedBy        = "triggermesh-controller"
 	componentAdapter = "adapter"
 )
 
 // labelsPropagationList is a list of labels that, if present on the parent
 // object, should be propagated to the adapters.
 var labelsPropagationList = []string{
-	"bridges.fianulabs.io/id",
-	"flow.fianulabs.io/created-by",
+	"bridges.triggermesh.io/id",
+	"flow.triggermesh.io/created-by",
 }

--- a/pkg/reconciler/labels.go
+++ b/pkg/reconciler/labels.go
@@ -33,14 +33,14 @@ const (
 
 // Common label values
 const (
-	partOf           = "triggermesh"
-	managedBy        = "triggermesh-controller"
+	partOf           = "fianu"
+	managedBy        = "fianu-controller"
 	componentAdapter = "adapter"
 )
 
 // labelsPropagationList is a list of labels that, if present on the parent
 // object, should be propagated to the adapters.
 var labelsPropagationList = []string{
-	"bridges.triggermesh.io/id",
-	"flow.triggermesh.io/created-by",
+	"bridges.fianulabs.io/id",
+	"flow.fianulabs.io/created-by",
 }


### PR DESCRIPTION
Signed-off-by: Noah Kreiger <noahkreiger@gmail.com>

This change proposes a switch to the logic in the tranformation, for handling a value that does NOT exist.

In a normal coding / average coding flow, you would not usually append a `nil` value to a path, or the value would not default to the variable name. I find this to be both confusing, and cause issues in practice where you may want to perform routing based on whether a value exists or not, without defining an extra filter, and 2 transformations, etc.

I didn't see any unit tests for this file?

Scenarios:

POST with

```json
{
    "detail": "noah",
    "source": "kreiger"
}
```

store -> $detail as $detail and $source as $source

add -> $detail.$source -> results in noah.kreiger

POST with

```json
{
    "detail": "noah"
}
```

store -> $detail as $detail and $source as $source

add -> $detail.$source -> results in noah


POST with

```json
{
    "detail": "noah",
    "source": ""
}
```

store -> $detail as $detail and $source as $source

add -> $detail.$source -> results in noah.

(still unsure if this should use the empty string, or treat it like a nil)