### PR TITLE
Add clusterrolebinding for addressables from tm-core

### DIFF
--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -113,11 +113,11 @@ roleRef:
 
 ---
 
-# Resolve sink URIs
+# Resolve sink URIs when Knative is installed
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: triggermesh-controller-addressable-resolver
+  name: triggermesh-controller-addressable-resolver-from-knative
   labels:
     app.kubernetes.io/part-of: triggermesh
 subjects:
@@ -128,3 +128,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: addressable-resolver
+
+---
+
+# Resolve sink URIs when TriggerMesh Core is installed
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: triggermesh-controller-addressable-resolver-from-triggermesh
+  labels:
+    app.kubernetes.io/part-of: triggermesh
+subjects:
+- kind: ServiceAccount
+  name: triggermesh-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver-triggermesh


### PR DESCRIPTION
Addressable `ClusterRoleBinging` are used to resolve sinks using kubernetes object references to URIs.

The existing `CRB` is assuming Knative Eventing is installed but that dependency is optional since users can use triggers and brokers from [triggermesh-core](https://github.com/triggermesh/triggermesh-core) now.

In this PR we are adding a second `CRB` from the TriggerMesh addressable ClusterRole [defined at tm-core](https://github.com/triggermesh/triggermesh-core/blob/afe304d69e2655ce010b4aa078a88bfe6a61ac76/config/200-kn-clusterrole-addressable-resolvers.yaml#L15-L31).

The previous `CRB` is being renamed, it should be manually deleted from existing installations.