### PR TITLE
Concurrent store operation update

### DIFF
--- a/pkg/flow/adapter/transformation/adapter.go
+++ b/pkg/flow/adapter/transformation/adapter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
 	"strings"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 
 	"github.com/triggermesh/triggermesh/pkg/apis/flow"
 	"github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
+	"github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation/common/storage"
 	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
@@ -48,8 +48,8 @@ type envConfig struct {
 
 // adapter contains Pipelines for CE transformations and CloudEvents client.
 type adapter struct {
-	ContextPipeline []v1alpha1.Transform
-	DataPipeline    []v1alpha1.Transform
+	ContextPipeline *Pipeline
+	DataPipeline    *Pipeline
 
 	mt *pkgadapter.MetricTag
 	sr *metrics.EventProcessingStatsReporter
@@ -94,14 +94,28 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		logger.Fatalf("Cannot unmarshal data transformation env variable: %v", err)
 	}
 
+	sharedStorage := storage.New()
+
+	contextPl, err := newPipeline(trnContext, sharedStorage)
+	if err != nil {
+		logger.Fatalf("Cannot create context transformation pipeline: %v", err)
+	}
+
+	dataPl, err := newPipeline(trnData, sharedStorage)
+	if err != nil {
+		logger.Fatalf("Cannot create data transformation pipeline: %v", err)
+	}
+
 	return &adapter{
-		mt:              mt,
-		sr:              metrics.MustNewEventProcessingStatsReporter(mt),
-		ContextPipeline: trnContext,
-		DataPipeline:    trnData,
-		sink:            env.Sink,
-		client:          ceClient,
-		logger:          logger,
+		ContextPipeline: contextPl,
+		DataPipeline:    dataPl,
+
+		mt: mt,
+		sr: metrics.MustNewEventProcessingStatsReporter(mt),
+
+		sink:   env.Sink,
+		client: ceClient,
+		logger: logger,
 	}
 }
 
@@ -166,22 +180,6 @@ func (t *adapter) receiveAndSend(ctx context.Context, event cloudevents.Event) e
 }
 
 func (t *adapter) applyTransformations(event cloudevents.Event) (*cloudevents.Event, error) {
-	contextPl, err := newPipeline(t.ContextPipeline)
-	if err != nil {
-		t.logger.Fatalf("Cannot create context transformation pipeline: %v", err)
-	}
-
-	dataPl, err := newPipeline(t.DataPipeline)
-	if err != nil {
-		t.logger.Fatalf("Cannot create data transformation pipeline: %v", err)
-	}
-
-	// set shared storage, scoped too the application function
-	sharedStorage := storage.New()
-
-	contextPl.setStorage(sharedStorage)
-	dataPl.setStorage(sharedStorage)
-
 	// HTTPTargets sets content type from HTTP headers, i.e.:
 	// "datacontenttype: application/json; charset=utf-8"
 	// so we must use "contains" instead of strict equality
@@ -206,18 +204,19 @@ func (t *adapter) applyTransformations(event cloudevents.Event) (*cloudevents.Ev
 	var init = true
 	var errs []error
 
+	eventUniqueID := fmt.Sprintf("%s-%s", event.ID(), event.Source())
 	// Run init step such as load Pipeline variables first
-	eventContext, err := contextPl.apply(localContextBytes, init)
+	eventContext, err := t.ContextPipeline.apply(eventUniqueID, localContextBytes, init)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	eventPayload, err := dataPl.apply(event.Data(), init)
+	eventPayload, err := t.DataPipeline.apply(eventUniqueID, event.Data(), init)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
 	// CE Context transformation
-	if eventContext, err = contextPl.apply(eventContext, !init); err != nil {
+	if eventContext, err = t.ContextPipeline.apply(eventUniqueID, eventContext, !init); err != nil {
 		errs = append(errs, err)
 	}
 	if err := json.Unmarshal(eventContext, &localContext); err != nil {
@@ -233,7 +232,7 @@ func (t *adapter) applyTransformations(event cloudevents.Event) (*cloudevents.Ev
 	}
 
 	// CE Data transformation
-	if eventPayload, err = dataPl.apply(eventPayload, !init); err != nil {
+	if eventPayload, err = t.DataPipeline.apply(eventUniqueID, eventPayload, !init); err != nil {
 		errs = append(errs, err)
 	}
 	if err = event.SetData(cloudevents.ApplicationJSON, eventPayload); err != nil {
@@ -245,6 +244,10 @@ func (t *adapter) applyTransformations(event cloudevents.Event) (*cloudevents.Ev
 	if len(errs) != 0 {
 		t.logger.Errorw("Event transformation errors", zap.Errors("errors", errs))
 	}
+
+	// remove event-related variables after the transformation is done.
+	// since the storage is shared, flush can be done for one pipeline.
+	t.ContextPipeline.Storage.Flush(eventUniqueID)
 
 	return &event, nil
 }

--- a/pkg/flow/adapter/transformation/common/storage/storage.go
+++ b/pkg/flow/adapter/transformation/common/storage/storage.go
@@ -16,39 +16,58 @@ limitations under the License.
 
 package storage
 
-import "sync"
+import (
+	"sync"
+)
 
 // Storage is a simple object that provides thread safe
 // methods to read and write into a map.
 type Storage struct {
-	data map[string]interface{}
+	data map[string]map[string]interface{}
 	mux  sync.RWMutex
 }
 
 // New returns an instance of Storage.
 func New() *Storage {
 	return &Storage{
-		data: make(map[string]interface{}),
+		data: make(map[string]map[string]interface{}),
 		mux:  sync.RWMutex{},
 	}
 }
 
 // Set writes a value interface to a string key.
-func (s *Storage) Set(k string, v interface{}) {
+func (s *Storage) Set(eventID, key string, value interface{}) {
 	s.mux.Lock()
-	s.data[k] = v
-	s.mux.Unlock()
+	defer s.mux.Unlock()
+	if s.data[eventID] == nil {
+		s.data[eventID] = make(map[string]interface{})
+	}
+	s.data[eventID][key] = value
 }
 
 // Get reads value by a key.
-func (s *Storage) Get(k string) interface{} {
+func (s *Storage) Get(eventID string, key string) interface{} {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	return s.data[k]
+	if s.data[eventID] == nil {
+		return nil
+	}
+	return s.data[eventID][key]
 }
 
-// ListKeys returns the slice of var keys stored in memory.
-func (s *Storage) ListKeys() []string {
+// ListEventVariables returns the slice of variables created for EventID.
+func (s *Storage) ListEventVariables(eventID string) []string {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	list := []string{}
+	for k := range s.data[eventID] {
+		list = append(list, k)
+	}
+	return list
+}
+
+// ListEventIDs returns the list of stored event IDs.
+func (s *Storage) ListEventIDs() []string {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 	list := []string{}
@@ -56,4 +75,11 @@ func (s *Storage) ListKeys() []string {
 		list = append(list, k)
 	}
 	return list
+}
+
+// Flush removes variables by their parent event ID.
+func (s *Storage) Flush(eventID string) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	delete(s.data, eventID)
 }

--- a/pkg/flow/adapter/transformation/transformer/add/add.go
+++ b/pkg/flow/adapter/transformation/transformer/add/add.go
@@ -73,8 +73,8 @@ func (a *Add) New(key, value string) transformer.Transformer {
 
 // Apply is a main method of Transformation that adds any type of
 // variables into existing JSON.
-func (a *Add) Apply(data []byte) ([]byte, error) {
-	input := convert.SliceToMap(strings.Split(a.Path, "."), a.composeValue())
+func (a *Add) Apply(eventID string, data []byte) ([]byte, error) {
+	input := convert.SliceToMap(strings.Split(a.Path, "."), a.composeValue(eventID))
 	var event interface{}
 	if err := json.Unmarshal(data, &event); err != nil {
 		return data, err
@@ -89,24 +89,24 @@ func (a *Add) Apply(data []byte) ([]byte, error) {
 	return output, nil
 }
 
-func (a *Add) retrieveVariable(key string) interface{} {
-	if value := a.variables.Get(key); value != nil {
+func (a *Add) retrieveVariable(eventID, key string) interface{} {
+	if value := a.variables.Get(eventID, key); value != nil {
 		return value
 	}
 	return key
 }
 
-func (a *Add) composeValue() interface{} {
+func (a *Add) composeValue(eventID string) interface{} {
 	result := a.Value
-	for _, key := range a.variables.ListKeys() {
+	for _, key := range a.variables.ListEventVariables(eventID) {
 		index := strings.Index(result, key)
 		if index == -1 {
 			continue
 		}
 		if result == key {
-			return a.retrieveVariable(key)
+			return a.retrieveVariable(eventID, key)
 		}
-		result = fmt.Sprintf("%s%v%s", result[:index], a.retrieveVariable(key), result[index+len(key):])
+		result = fmt.Sprintf("%s%v%s", result[:index], a.retrieveVariable(eventID, key), result[index+len(key):])
 	}
 	return result
 }

--- a/pkg/flow/adapter/transformation/transformer/delete/delete.go
+++ b/pkg/flow/adapter/transformation/transformer/delete/delete.go
@@ -73,8 +73,8 @@ func (d *Delete) New(key, value string) transformer.Transformer {
 
 // Apply is a main method of Transformation that removed any type of
 // variables from existing JSON.
-func (d *Delete) Apply(data []byte) ([]byte, error) {
-	d.Value = d.retrieveString(d.Value)
+func (d *Delete) Apply(eventID string, data []byte) ([]byte, error) {
+	d.Value = d.retrieveString(eventID, d.Value)
 
 	result, err := d.parse(data, "", "")
 	if err != nil {
@@ -89,8 +89,8 @@ func (d *Delete) Apply(data []byte) ([]byte, error) {
 	return output, nil
 }
 
-func (d *Delete) retrieveString(key string) string {
-	if value := d.variables.Get(key); value != nil {
+func (d *Delete) retrieveString(eventID, key string) string {
+	if value := d.variables.Get(eventID, key); value != nil {
 		if str, ok := value.(string); ok {
 			return str
 		}

--- a/pkg/flow/adapter/transformation/transformer/parse/parse.go
+++ b/pkg/flow/adapter/transformation/transformer/parse/parse.go
@@ -74,7 +74,7 @@ func (p *Parse) New(key, value string) transformer.Transformer {
 
 // Apply is a main method of Transformation that parse JSON values
 // into variables that can be used by other Transformations in a pipeline.
-func (p *Parse) Apply(data []byte) ([]byte, error) {
+func (p *Parse) Apply(eventID string, data []byte) ([]byte, error) {
 	path := convert.SliceToMap(strings.Split(p.Path, "."), "")
 
 	switch p.Value {

--- a/pkg/flow/adapter/transformation/transformer/shift/shift.go
+++ b/pkg/flow/adapter/transformation/transformer/shift/shift.go
@@ -81,7 +81,7 @@ func (s *Shift) New(key, value string) transformer.Transformer {
 
 // Apply is a main method of Transformation that moves existing
 // values to a new locations.
-func (s *Shift) Apply(data []byte) ([]byte, error) {
+func (s *Shift) Apply(eventID string, data []byte) ([]byte, error) {
 	oldPath := convert.SliceToMap(strings.Split(s.Path, "."), "")
 
 	var event interface{}
@@ -91,7 +91,7 @@ func (s *Shift) Apply(data []byte) ([]byte, error) {
 
 	newEvent, value := extractValue(event, oldPath)
 	if s.Value != "" {
-		if !equal(s.retrieveInterface(s.Value), value) {
+		if !equal(s.retrieveInterface(eventID, s.Value), value) {
 			return data, nil
 		}
 	}
@@ -109,8 +109,8 @@ func (s *Shift) Apply(data []byte) ([]byte, error) {
 	return output, nil
 }
 
-func (s *Shift) retrieveInterface(key string) interface{} {
-	if value := s.variables.Get(key); value != nil {
+func (s *Shift) retrieveInterface(eventID, key string) interface{} {
+	if value := s.variables.Get(eventID, key); value != nil {
 		return value
 	}
 	return key

--- a/pkg/flow/adapter/transformation/transformer/store/store.go
+++ b/pkg/flow/adapter/transformation/transformer/store/store.go
@@ -73,7 +73,7 @@ func (s *Store) New(key, value string) transformer.Transformer {
 
 // Apply is a main method of Transformation that stores JSON values
 // into variables that can be used by other Transformations in a pipeline.
-func (s *Store) Apply(data []byte) ([]byte, error) {
+func (s *Store) Apply(eventID string, data []byte) ([]byte, error) {
 	path := convert.SliceToMap(strings.Split(s.Value, "."), "")
 
 	var event interface{}
@@ -83,7 +83,7 @@ func (s *Store) Apply(data []byte) ([]byte, error) {
 
 	value := common.ReadValue(event, path)
 
-	s.variables.Set(s.Path, value)
+	s.variables.Set(eventID, s.Path, value)
 
 	return data, nil
 }

--- a/pkg/flow/adapter/transformation/transformer/transformer.go
+++ b/pkg/flow/adapter/transformation/transformer/transformer.go
@@ -23,8 +23,8 @@ import (
 // Transformer is an interface that contains common methods
 // to work with JSON data.
 type Transformer interface {
-	New(string, string) Transformer
-	Apply([]byte) ([]byte, error)
+	New(key, value string) Transformer
+	Apply(eventID string, data []byte) ([]byte, error)
 	SetStorage(*storage.Storage)
 	InitStep() bool
 }

--- a/pkg/reconciler/base_test.go
+++ b/pkg/reconciler/base_test.go
@@ -18,9 +18,10 @@ package reconciler
 
 import (
 	"context"
-	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 	"testing"
 	"time"
+
+	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Bumblebee's Storage fix introduced in #1134 opened up a question of sharing transformation state/vars between CloudEvents processing sessions. While this PR fixed nasty race conditions in the storage, it also closed the transformation "visibility" scope to a single CloudEvent. Not that the "shared variables" is something that we rely on now, but still, ideologically it is a big step aside from the planned direction. Having that in mind, I got back to the original Storage code, added the test that helped to consistently reproduce the bug, and considered other possible fixes. This PR is my take on a more optimal approach for the Storage concurrent write operation issue.

In the nutshell - the storage's hashmap is extended with an additional index that contains the Event's ID. This provides both proper variables separation and the ability to share variables between sessions. Besides, the pipeline and storage allocation for each event didn't seem to provide good performance. A super simple [benchmark](https://github.com/triggermesh/triggermesh/blob/d983acacc7a2d37fb0fe3aa71164a83074326d38/pkg/flow/adapter/transformation/adapter_test.go#L441) proved this theory to be true:

Original storage - simple but with concurrency issues:
```console
triggermesh@bumblebee-original-bench$ go test -benchmem -benchtime=10s -run=^$ --count 10 -bench ^BenchmarkStorage$ github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
goos: darwin
goarch: arm64
pkg: github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
BenchmarkStorage-10      4355290              2754 ns/op            3566 B/op         61 allocs/op
BenchmarkStorage-10      4380092              2793 ns/op            3566 B/op         61 allocs/op
BenchmarkStorage-10      4303740              2783 ns/op            3566 B/op         61 allocs/op
BenchmarkStorage-10      4308248              2747 ns/op            3566 B/op         61 allocs/op
BenchmarkStorage-10      4285021              2794 ns/op            3566 B/op         61 allocs/op
BenchmarkStorage-10      4274460              2779 ns/op            3565 B/op         61 allocs/op
BenchmarkStorage-10      4313953              2768 ns/op            3565 B/op         61 allocs/op
BenchmarkStorage-10      4339528              2783 ns/op            3565 B/op         61 allocs/op
BenchmarkStorage-10      4394559              2776 ns/op            3565 B/op         61 allocs/op
BenchmarkStorage-10      4352595              2789 ns/op            3565 B/op         61 allocs/op
PASS
ok      github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation      148.948s
```

Current solution - create a new pipeline for each event:
```console
triggermesh@main$ go test -benchmem -benchtime=10s -run=^$ --count 10 -bench ^BenchmarkStorage$ github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
goos: darwin
goarch: arm64
pkg: github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
BenchmarkStorage-10      3721282              3230 ns/op            4656 B/op         80 allocs/op
BenchmarkStorage-10      3764277              3231 ns/op            4656 B/op         80 allocs/op
BenchmarkStorage-10      3731672              3217 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3706922              3209 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3771895              3202 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3751029              3205 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3726537              3237 ns/op            4656 B/op         80 allocs/op
BenchmarkStorage-10      3740560              3214 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3736903              3201 ns/op            4655 B/op         80 allocs/op
BenchmarkStorage-10      3737474              3387 ns/op            4655 B/op         80 allocs/op
PASS
ok      github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation      153.160s
```

The proposed solution - the storage with the Event ID support:
```console
triggermesh@bumblebee-concurrent-store$ go test -benchmem -benchtime=10s -run=^$ --count 10 -bench ^BenchmarkStorage$ github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
goos: darwin
goarch: arm64
pkg: github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation
BenchmarkStorage-10      4106563              2910 ns/op            3747 B/op         62 allocs/op
BenchmarkStorage-10      4090596              2900 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      4114050              2932 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      4116086              2932 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      4119424              2917 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      3871779              2937 ns/op            3747 B/op         62 allocs/op
BenchmarkStorage-10      4073181              2966 ns/op            3747 B/op         62 allocs/op
BenchmarkStorage-10      4093299              2943 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      4065358              2952 ns/op            3748 B/op         62 allocs/op
BenchmarkStorage-10      4055644              2943 ns/op            3747 B/op         62 allocs/op
PASS
ok      github.com/triggermesh/triggermesh/pkg/flow/adapter/transformation      151.130s

```

As seen from the benchmark results - the proposed solution is much closer in its performance to the original code but also solves both concurrency and variables scoping issues.