### PR TITLE
Add sarama zap logger

### DIFF
--- a/pkg/sources/adapter/kafkasource/adapter.go
+++ b/pkg/sources/adapter/kafkasource/adapter.go
@@ -46,6 +46,7 @@ type kafkasourceAdapter struct {
 // NewAdapter satisfies pkgadapter.AdapterConstructor.
 func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClient cloudevents.Client) pkgadapter.Adapter {
 	logger := logging.FromContext(ctx)
+	sarama.Logger = zap.NewStdLog(logger.Named("sarama").Desugar())
 
 	mt := &pkgadapter.MetricTag{
 		ResourceGroup: sources.CloudEventsSourceResource.String(),


### PR DESCRIPTION
Related to https://github.com/triggermesh/triggermesh/issues/1255

This PR will add the configured zap logger to the sarama library.