### PR TITLE
Transformation: custom separator support in Data transformation

### DIFF
--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -110,6 +110,10 @@ spec:
                             description: JSON path or variable name. Depends on the operation type.
                             nullable: true
                             type: string
+                          separator:
+                            description: JSON path separator symbol. "." is used by default.
+                            nullable: true
+                            type: string
                   required:
                   - operation
               sink:


### PR DESCRIPTION
Quick fix:
#1261 introduced "custom separator" support in Transformation paths, but CRD update missed Transformation's Data part and only updated Context scheme. 