### PR TITLE
Auto refresh kafkatarget connections

### DIFF
--- a/pkg/common/kafka/kafkaclient.go
+++ b/pkg/common/kafka/kafkaclient.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2023 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"go.uber.org/zap"
+)
+
+type SaramaCachedClientOption func(*SaramaCachedClient)
+
+func WithSaramaCachedClientRefresh(d time.Duration) SaramaCachedClientOption {
+	return func(scc *SaramaCachedClient) {
+		scc.refresh = &d
+	}
+}
+
+func NewSaramaCachedClient(ctx context.Context, bootstrapServers []string, cfg *sarama.Config, logger *zap.Logger, opts ...SaramaCachedClientOption) (*SaramaCachedClient, error) {
+	sarama.Logger = zap.NewStdLog(logger)
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("sarama kafka client configuration is not valid: %w", err)
+	}
+
+	scc := &SaramaCachedClient{
+		bootstrapServers: bootstrapServers,
+		cfg:              cfg,
+	}
+	for _, opt := range opts {
+		opt(scc)
+	}
+
+	// Initialize
+	if err := scc.RefreshProducerClients(); err != nil {
+		return nil, fmt.Errorf("could not create kafka client: %w", err)
+	}
+
+	// All methods that operate on kafka have an error management pattern that will
+	// re-create connections and try again. The refresh routine adds a more pro-active
+	// approach, re-creating connections when they reach the refresh period.
+	if scc.refresh != nil {
+		go func() {
+			for {
+				select {
+				case <-time.After(*scc.refresh):
+					scc.RefreshProducerClients()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	return scc, nil
+}
+
+type SaramaCachedClient struct {
+	bootstrapServers []string
+	cfg              *sarama.Config
+
+	client       sarama.Client
+	admin        sarama.ClusterAdmin
+	syncProducer sarama.SyncProducer
+
+	refresh *time.Duration
+
+	m sync.RWMutex
+}
+
+func (sc *SaramaCachedClient) Close() error {
+	sc.m.Lock()
+	defer sc.m.Unlock()
+
+	if sc.client == nil {
+		// no client connection is expected to exist.
+		return nil
+	}
+
+	var err error
+	if e := sc.syncProducer.Close(); e != nil {
+		err = e
+	}
+
+	if e := sc.admin.Close(); e != nil {
+		if err == nil {
+			err = e
+		} else {
+			err = fmt.Errorf("%w; %w", err, e)
+		}
+	}
+
+	if e := sc.client.Close(); e != nil {
+		if err == nil {
+			err = e
+		} else {
+			err = fmt.Errorf("%w; %w", err, e)
+		}
+	}
+
+	return err
+}
+
+func (sc *SaramaCachedClient) RefreshProducerClients() error {
+	sc.m.Lock()
+	defer sc.m.Unlock()
+
+	client, err := sarama.NewClient(
+		sc.bootstrapServers,
+		sc.cfg,
+	)
+	if err != nil {
+		return fmt.Errorf("could not create sarama kafka client: %w", err)
+	}
+
+	// ignore errors since we are discarding the existing connection.
+	if sc.client != nil {
+		_ = sc.client.Close()
+	}
+	if sc.admin != nil {
+		_ = sc.admin.Close()
+	}
+	if sc.syncProducer != nil {
+		_ = sc.syncProducer.Close()
+	}
+
+	sc.client = client
+
+	admin, err := sarama.NewClusterAdminFromClient(client)
+	if err != nil {
+		return fmt.Errorf("could not create sarama kafka admin client: %w", err)
+	}
+
+	sc.admin = admin
+
+	sp, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		return fmt.Errorf("could not create sarama kafka sync producer client: %w", err)
+	}
+
+	sc.syncProducer = sp
+
+	return nil
+}
+
+func (sc *SaramaCachedClient) ensureTopic(topic string, replicas int16, partitions int32) error {
+	topicDetail := &sarama.TopicDetail{
+		ReplicationFactor: replicas,
+		NumPartitions:     partitions,
+	}
+
+	sc.m.RLock()
+	defer sc.m.RUnlock()
+
+	err := sc.admin.CreateTopic(topic, topicDetail, false)
+	if err, ok := err.(*sarama.TopicError); ok && err.Err != sarama.ErrTopicAlreadyExists {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *SaramaCachedClient) EnsureTopic(topic string, replicas int16, partitions int32) error {
+	if err := sc.ensureTopic(topic, replicas, partitions); err == nil {
+		return nil
+	}
+
+	// if there is an error, try to re-create the producer clients
+	if err := sc.RefreshProducerClients(); err != nil {
+		return err
+	}
+
+	return sc.ensureTopic(topic, replicas, partitions)
+}
+
+func (sc *SaramaCachedClient) pingTopic(topic string) error {
+	sc.m.RLock()
+	defer sc.m.RUnlock()
+
+	_, err := sc.admin.DescribeTopics([]string{topic})
+	if err, ok := err.(*sarama.TopicError); ok && err.Err != sarama.ErrTopicAlreadyExists {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *SaramaCachedClient) PingTopic(topic string) error {
+	if err := sc.pingTopic(topic); err == nil {
+		return nil
+	}
+
+	// if there is an error, try to re-create the producer clients
+	if err := sc.RefreshProducerClients(); err != nil {
+		return err
+	}
+
+	return sc.pingTopic(topic)
+}
+
+func (sc *SaramaCachedClient) sendMessageSync(message *sarama.ProducerMessage) error {
+	_, _, err := sc.syncProducer.SendMessage(message)
+	return err
+}
+
+func (sc *SaramaCachedClient) SendMessageSync(message *sarama.ProducerMessage) error {
+	if err := sc.sendMessageSync(message); err == nil {
+		return nil
+	}
+
+	// if there is an error, try to re-create the producer clients
+	if err := sc.RefreshProducerClients(); err != nil {
+		return err
+	}
+
+	return sc.sendMessageSync(message)
+}

--- a/pkg/targets/adapter/kafkatarget/config.go
+++ b/pkg/targets/adapter/kafkatarget/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kafkatarget
 
 import (
+	"time"
+
 	pkgadapter "knative.dev/eventing/pkg/adapter/v2"
 )
 
@@ -49,6 +51,11 @@ type envAccessor struct {
 	ClientCert string `envconfig:"CLIENT_CERT" required:"false"`
 	ClientKey  string `envconfig:"CLIENT_KEY" required:"false"`
 	SkipVerify bool   `envconfig:"SKIP_VERIFY" required:"false"`
+
+	// The connection refresh routine will discard the existing connection and create a new
+	// one. The Kafka broker is usually configured to close idle connections at its side after 10 minutes,
+	// 5 minutes is a safe guess for most instances.
+	ConnectionRefreshPeriod time.Duration `envconfig:"CONNECTION_REFRESH_PERIOD" default:"5m"`
 
 	// This set of variables are experimental and not graduated to the CRD.
 	CreateTopicIfMissing        bool  `envconfig:"CREATE_MISSING_TOPIC" default:"true"`


### PR DESCRIPTION
Fixes #1263 

- Creates a wrapper around the sarama library that only exposes the methods used by the target.
- A routine (optional) refresh the connection, every 5 minutes by default.
- If a method fails, the connection will be refreshed and the method will be retried.

Caveats:
- The change does not modify the spec. This change and the default parameter for the refresh period (5m) should be good for all kafka clusters. If that is proven to be a wrong assumption, a further PR will need to expose a new parameter at the spec.
- The refresh routing and method's retry management are redundant. I would like to stick to the pro-active one (refresh routine), but if someone for some reason configures a broker idle connections under 5 minutes the method retries will act as a safe-net mechanism.
- The library lives at `pkg/common/...` because all generic kafka management libraries, for sources, targets, flows ... should be shared somewhere. Common is a lazy name, if there is a better location I'll be happy to switch.
