### PR TITLE
Export GCP Billing and Azure EventGrid reconcilers

### DIFF
--- a/pkg/sources/reconciler/azureeventgridsource/event_hub.go
+++ b/pkg/sources/reconciler/azureeventgridsource/event_hub.go
@@ -46,11 +46,11 @@ const (
 
 const resourceTypeEventHubs = "eventhubs"
 
-// ensureEventHub ensures the existence of an Event Hub for sending events.
+// EnsureEventHub ensures the existence of an Event Hub for sending events.
 // Required permissions:
 //   - Microsoft.EventHub/namespaces/eventhubs/read
 //   - Microsoft.EventHub/namespaces/eventhubs/write
-func ensureEventHub(ctx context.Context, cli eventgrid.EventHubsClient) (string /*resource ID*/, error) {
+func EnsureEventHub(ctx context.Context, cli eventgrid.EventHubsClient) (string /*resource ID*/, error) {
 	if skip.Skip(ctx) {
 		return "", nil
 	}
@@ -131,11 +131,11 @@ func makeEventHubID(namespaceID *v1alpha1.AzureResourceID, hubName string) *v1al
 	return &hubID
 }
 
-// ensureNoEventHub ensures that the Event Hub created for sending events
+// EnsureNoEventHub ensures that the Event Hub created for sending events
 // is deleted.
 // Required permissions:
 //   - Microsoft.EventHub/namespaces/eventhubs/delete
-func ensureNoEventHub(ctx context.Context, cli eventgrid.EventHubsClient) error {
+func EnsureNoEventHub(ctx context.Context, cli eventgrid.EventHubsClient) error {
 	src := commonv1alpha1.ReconcilableFromContext(ctx).(*v1alpha1.AzureEventGridSource)
 
 	if userProvidedHub := src.Spec.Endpoint.EventHubs.HubName; userProvidedHub != nil {

--- a/pkg/sources/reconciler/azureeventgridsource/event_subs.go
+++ b/pkg/sources/reconciler/azureeventgridsource/event_subs.go
@@ -45,12 +45,12 @@ const (
 	defaultEventTTL            = 1440
 )
 
-// ensureEventSubscription ensures an event subscription exists with the expected configuration.
+// EnsureEventSubscription ensures an event subscription exists with the expected configuration.
 // Required permissions:
 //   - Microsoft.EventGrid/systemTopics/eventSubscriptions/read
 //   - Microsoft.EventGrid/systemTopics/eventSubscriptions/write
 //   - Microsoft.EventHub/namespaces/eventhubs/write
-func ensureEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
+func EnsureEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
 	sysTopicResID *v1alpha1.AzureResourceID, eventHubResID string) error {
 
 	if skip.Skip(ctx) {
@@ -166,10 +166,10 @@ func newEventSubscription(eventHubResID string, eventTypes []string) azureeventg
 	}
 }
 
-// ensureNoEventSubscription ensures the event subscription is removed.
+// EnsureNoEventSubscription ensures the event subscription is removed.
 // Required permissions:
 //   - Microsoft.EventGrid/systemTopics/eventSubscriptions/delete
-func ensureNoEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
+func EnsureNoEventSubscription(ctx context.Context, cli eventgrid.EventSubscriptionsClient,
 	sysTopic *azureeventgrid.SystemTopic) reconciler.Event {
 
 	if skip.Skip(ctx) {

--- a/pkg/sources/reconciler/azureeventgridsource/reconciler.go
+++ b/pkg/sources/reconciler/azureeventgridsource/reconciler.go
@@ -72,12 +72,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AzureEventGr
 			"Error obtaining Azure clients: %s", err))
 	}
 
-	sysTopicResID, err := ensureSystemTopic(ctx, sysTopicsCli, providersCli, resGroupsCli)
+	sysTopicResID, err := EnsureSystemTopic(ctx, sysTopicsCli, providersCli, resGroupsCli)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Event Grid system topic: %w", err)
 	}
 
-	eventHubResID, err := ensureEventHub(ctx, eventHubsCli)
+	eventHubResID, err := EnsureEventHub(ctx, eventHubsCli)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Event Hub: %w", err)
 	}
@@ -86,7 +86,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.AzureEventGr
 		return fmt.Errorf("failed to reconcile Event Hubs event source adapter: %w", err)
 	}
 
-	return ensureEventSubscription(ctx, eventSubsCli, sysTopicResID, eventHubResID)
+	return EnsureEventSubscription(ctx, eventSubsCli, sysTopicResID, eventHubResID)
 }
 
 // FinalizeKind is called when the resource is deleted.
@@ -111,7 +111,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.AzureEventGri
 	// deletion of the event subscription, Event Hub, and system topic
 	// succeed to ensure that we don't leave any dangling resources behind us.
 
-	systemTopic, err := findSystemTopic(ctx, sysTopicsCli, o)
+	systemTopic, err := FindSystemTopic(ctx, sysTopicsCli, o)
 	switch {
 	case isDenied(err):
 		// it is unlikely that we recover from auth errors in the
@@ -122,15 +122,15 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.AzureEventGri
 		return fmt.Errorf("looking up system topic: %w", err)
 	}
 
-	if err := ensureNoEventSubscription(ctx, eventSubsCli, systemTopic); err != nil {
+	if err := EnsureNoEventSubscription(ctx, eventSubsCli, systemTopic); err != nil {
 		return fmt.Errorf("failed to finalize event subscription: %w", err)
 	}
 
-	if err := ensureNoEventHub(ctx, eventHubsCli); err != nil {
+	if err := EnsureNoEventHub(ctx, eventHubsCli); err != nil {
 		return fmt.Errorf("failed to finalize Event Hub: %w", err)
 	}
 
-	if err := ensureNoSystemTopic(ctx, sysTopicsCli, eventSubsCli, systemTopic); err != nil {
+	if err := EnsureNoSystemTopic(ctx, sysTopicsCli, eventSubsCli, systemTopic); err != nil {
 		return fmt.Errorf("failed to finalize event subscription: %w", err)
 	}
 

--- a/pkg/sources/reconciler/azureeventgridsource/sys_topic.go
+++ b/pkg/sources/reconciler/azureeventgridsource/sys_topic.go
@@ -59,7 +59,7 @@ const (
 	defaultResourceGroupRegion = "westus2"
 )
 
-// ensureSystemTopic ensures a system topic exists with the expected configuration.
+// EnsureSystemTopic ensures a system topic exists with the expected configuration.
 // Required permissions:
 //   - Microsoft.EventGrid/systemTopics/read
 //   - Microsoft.EventGrid/systemTopics/write
@@ -67,7 +67,7 @@ const (
 //   - Microsoft.Resources/subscriptions/resourceGroups/read
 //   - Microsoft.Resources/subscriptions/resourceGroups/write
 //     Additionally, for regional resources, "read" permission on the resource (scope).
-func ensureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
+func EnsureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	providersCli eventgrid.ProvidersClient,
 	resGroupsCli eventgrid.ResourceGroupsClient) (*v1alpha1.AzureResourceID /*sysTopicResID*/, error) {
 
@@ -82,7 +82,7 @@ func ensureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 
 	scope := typedSrc.Spec.Scope.String()
 
-	sysTopic, err := findSystemTopic(ctx, cli, typedSrc)
+	sysTopic, err := FindSystemTopic(ctx, cli, typedSrc)
 	switch {
 	case isDenied(err):
 		status.MarkNotSubscribed(v1alpha1.AzureReasonAPIError, "Access denied to system topic API: "+toErrMsg(err))
@@ -201,11 +201,11 @@ func ensureSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	return sysTopicResID, nil
 }
 
-// ensureNoSystemTopic ensures the system topic is removed.
+// EnsureNoSystemTopic ensures the system topic is removed.
 // Required permissions:
 //   - Microsoft.EventGrid/systemTopics/read
 //   - Microsoft.EventGrid/systemTopics/delete
-func ensureNoSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
+func EnsureNoSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	eventSubsCli eventgrid.EventSubscriptionsClient, sysTopic *azureeventgrid.SystemTopic) reconciler.Event {
 
 	if skip.Skip(ctx) {
@@ -302,10 +302,10 @@ func ensureNoSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	return nil
 }
 
-// findSystemTopic returns the system topic that matches the scope of the given
+// FindSystemTopic returns the system topic that matches the scope of the given
 // source, if such system topic exists.
 // If no system topic matches the description, nil is returned.
-func findSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
+func FindSystemTopic(ctx context.Context, cli eventgrid.SystemTopicsClient,
 	src *v1alpha1.AzureEventGridSource) (*azureeventgrid.SystemTopic, error) {
 
 	restCtx, cancel := context.WithTimeout(ctx, crudTimeout)

--- a/pkg/sources/reconciler/googlecloudbillingsource/billing.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/billing.go
@@ -32,12 +32,12 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/reconciler/skip"
 )
 
-// ensureBudgetNotification ensures the existence of a notification
+// EnsureBudgetNotification ensures the existence of a notification
 // configuration targetting the given Pub/Sub topic on a Cloud Billing budget.
 // Required permissions:
 // - billing.budgets.get
 // - billing.budgets.update
-func ensureBudgetNotification(ctx context.Context, cli *billing.BudgetClient, topicResName *v1alpha1.GCloudResourceName) error {
+func EnsureBudgetNotification(ctx context.Context, cli *billing.BudgetClient, topicResName *v1alpha1.GCloudResourceName) error {
 	if skip.Skip(ctx) {
 		return nil
 	}
@@ -94,12 +94,12 @@ func ensureBudgetNotification(ctx context.Context, cli *billing.BudgetClient, to
 	return nil
 }
 
-// ensureNoBudgetNotification ensures that the notification
+// EnsureNoBudgetNotification ensures that the notification
 // configuration is deleted.
 // Required permissions:
 // - billing.budgets.get
 // - billing.budgets.update
-func ensureNoBudgetNotification(ctx context.Context, cli *billing.BudgetClient) error {
+func EnsureNoBudgetNotification(ctx context.Context, cli *billing.BudgetClient) error {
 	if skip.Skip(ctx) {
 		return nil
 	}

--- a/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/pubsub.go
@@ -46,9 +46,9 @@ const (
 	pubsubLabelOwnerName      = "io-triggermesh_owner-name"
 )
 
-// ensurePubSub ensures the existence of a Pub/Sub topic and associated
+// EnsurePubSub ensures the existence of a Pub/Sub topic and associated
 // subscription for receiving notifications from a Cloud Billing budget.
-func ensurePubSub(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GCloudResourceName /*topic*/, error) {
+func EnsurePubSub(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GCloudResourceName /*topic*/, error) {
 	if skip.Skip(ctx) {
 		return nil, nil
 	}
@@ -65,9 +65,9 @@ func ensurePubSub(ctx context.Context, cli *pubsub.Client) (*v1alpha1.GCloudReso
 	return topic, nil
 }
 
-// ensureNoPubSub ensures the Pub/Sub topic and associated subscription used
+// EnsureNoPubSub ensures the Pub/Sub topic and associated subscription used
 // for receiving notifications from a Cloud Billing budget are deleted.
-func ensureNoPubSub(ctx context.Context, cli *pubsub.Client) error {
+func EnsureNoPubSub(ctx context.Context, cli *pubsub.Client) error {
 	if skip.Skip(ctx) {
 		return nil
 	}

--- a/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
+++ b/pkg/sources/reconciler/googlecloudbillingsource/reconciler.go
@@ -80,12 +80,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.GoogleCloudB
 			"Error obtaining Google Cloud clients: %s", err))
 	}
 
-	topic, err := ensurePubSub(ctx, pubsubCli)
+	topic, err := EnsurePubSub(ctx, pubsubCli)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Pub/Sub resources: %w", err)
 	}
 
-	if err = ensureBudgetNotification(ctx, biCli, topic); err != nil {
+	if err = EnsureBudgetNotification(ctx, biCli, topic); err != nil {
 		return fmt.Errorf("failed to reconcile Billing notification: %w", err)
 	}
 
@@ -114,11 +114,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, o *v1alpha1.GoogleCloudBi
 	// ensureNoBudgetNotification and ensureNoPubSub succeed to ensure that
 	// we don't leave any dangling resources behind us.
 
-	if err := ensureNoBudgetNotification(ctx, biCli); err != nil {
+	if err := EnsureNoBudgetNotification(ctx, biCli); err != nil {
 		return fmt.Errorf("failed to clean up Billing notification: %w", err)
 	}
 
-	if err := ensureNoPubSub(ctx, pubsubCli); err != nil {
+	if err := EnsureNoPubSub(ctx, pubsubCli); err != nil {
 		return fmt.Errorf("failed to clean up Pub/Sub resources: %w", err)
 	}
 


### PR DESCRIPTION
A few more of reconciliation functions exported to be re-used in tmctl for local env deployment. Corresponding tmctl PR: triggermesh/tmctl#212