### PR TITLE
Add "labels" to adapterOverrides

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -156,6 +156,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -216,6 +216,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -167,6 +167,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -153,6 +153,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -153,6 +153,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -153,6 +153,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -178,6 +178,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -152,6 +152,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -161,6 +161,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -233,6 +233,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -168,6 +168,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -176,6 +176,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -223,6 +223,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -276,6 +276,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -217,6 +217,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureeventhubssource.yaml
+++ b/config/300-azureeventhubssource.yaml
@@ -251,6 +251,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -108,6 +108,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -107,6 +107,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -255,6 +255,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -182,6 +182,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -150,6 +150,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -140,6 +140,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -132,6 +132,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -119,6 +119,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -131,6 +131,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -142,6 +142,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -140,6 +140,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -225,6 +225,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-kafkasource.yaml
+++ b/config/300-kafkasource.yaml
@@ -264,6 +264,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -184,6 +184,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -135,6 +135,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -114,6 +114,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -87,6 +87,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -135,6 +135,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -143,6 +143,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-alibabaosstarget.yaml
+++ b/config/301-alibabaosstarget.yaml
@@ -98,6 +98,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -128,6 +128,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -124,6 +124,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -129,6 +129,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -131,6 +131,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -129,6 +129,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -130,6 +130,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -129,6 +129,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -132,6 +132,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -233,6 +233,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-azuresentineltarget.yaml
+++ b/config/301-azuresentineltarget.yaml
@@ -227,6 +227,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-cloudeventstarget.yaml
+++ b/config/301-cloudeventstarget.yaml
@@ -101,6 +101,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-confluenttarget.yaml
+++ b/config/301-confluenttarget.yaml
@@ -99,6 +99,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -79,6 +79,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -117,6 +117,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -94,6 +94,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-googlecloudpubsubtarget.yaml
+++ b/config/301-googlecloudpubsubtarget.yaml
@@ -79,6 +79,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -88,6 +88,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -78,6 +78,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -81,6 +81,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-hasuratarget.yaml
+++ b/config/301-hasuratarget.yaml
@@ -96,6 +96,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -129,6 +129,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -204,6 +204,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -96,6 +96,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-kafkatarget.yaml
+++ b/config/301-kafkatarget.yaml
@@ -249,6 +249,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -113,6 +113,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -85,6 +85,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -112,6 +112,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -104,6 +104,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -95,6 +95,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -71,6 +71,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -86,6 +86,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-tektontarget.yaml
+++ b/config/301-tektontarget.yaml
@@ -71,6 +71,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -94,6 +94,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -80,6 +80,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -90,6 +90,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -109,6 +109,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -125,6 +125,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-dataweavetransformation.yaml
+++ b/config/304-dataweavetransformation.yaml
@@ -131,6 +131,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -91,6 +91,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -107,6 +107,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -148,6 +148,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -88,6 +88,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -123,6 +123,11 @@ spec:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object
                 properties:
+                  labels:
+                    description: Adapter labels.
+                    type: object
+                    additionalProperties:
+                      type: string
                   env:
                     description: Adapter environment variables.
                     type: array

--- a/hack/crd-update/crd-update.py
+++ b/hack/crd-update/crd-update.py
@@ -17,6 +17,11 @@ try:
           description: Kubernetes object parameters to apply on top of default adapter values.
           type: object
           properties:
+            labels:
+              description: Adapter labels.
+              type: object
+              additionalProperties:
+                type: string
             env:
               description: Adapter environment variables.
               type: array

--- a/pkg/apis/common/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/common/v1alpha1/deepcopy_generated.go
@@ -119,6 +119,13 @@ func (in *AdapterOverrides) DeepCopyInto(out *AdapterOverrides) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/common/v1alpha1/types.go
+++ b/pkg/apis/common/v1alpha1/types.go
@@ -46,4 +46,6 @@ type AdapterOverrides struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Environment variables applied on adapter container.
 	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Labels applied on adapter container.
+	Labels map[string]string `json:"labels,omitempty"`
 }

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -404,6 +404,10 @@ func adapterOverrideOptions(overrides *v1alpha1.AdapterOverrides) []resource.Obj
 		opts = append(opts, resource.EnvVar(t.Name, t.Value))
 	}
 
+	for k, v := range overrides.Labels {
+		opts = append(opts, resource.Label(k, v))
+		opts = append(opts, resource.PodLabel(k, v))
+	}
 	return opts
 }
 


### PR DESCRIPTION
`adapterOverrides` extended with labels that should be passed to adapter pod meta:

```yaml
...
spec:
  adapterOverrides:
    labels:
      label1: value1
      label2: value2
```

Related to #1275