### PR TITLE
CloudEventsTarget: add support for replies

### DIFF
--- a/pkg/targets/adapter/cloudeventstarget/adapter_test.go
+++ b/pkg/targets/adapter/cloudeventstarget/adapter_test.go
@@ -124,7 +124,8 @@ func TestCloudEventsDispatch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res := adapter.dispatch(ctx, tc.ce)
+			evres, res := adapter.dispatch(ctx, tc.ce)
+			assert.Nil(t, evres, "got a response but expected nil")
 
 			metricstest.CheckDistributionCount(t,
 				"event_processing_latencies",


### PR DESCRIPTION
Fixes https://github.com/triggermesh/triggermesh/issues/1182

Replies to the CloudEventsTarget are now returned to the caller.
No replies will behave just like before.