### PR TITLE
Split non-array event objects

### DIFF
--- a/pkg/routing/adapter/splitter/adapter.go
+++ b/pkg/routing/adapter/splitter/adapter.go
@@ -143,12 +143,12 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 }
 
 func (h *Handler) split(path string, e *event.Event) []*event.Event {
-	var result []*event.Event
-
 	val := gjson.Get(string(e.Data()), path)
 	if !val.IsArray() {
-		return result
+		val = gjson.Parse("[" + val.Raw + "]")
 	}
+
+	var result []*event.Event
 	for _, v := range val.Array() {
 		newCE := cloudevents.NewEvent()
 		if err := newCE.SetData(cloudevents.ApplicationJSON, []byte(v.Raw)); err != nil {

--- a/pkg/routing/adapter/splitter/adapter_test.go
+++ b/pkg/routing/adapter/splitter/adapter_test.go
@@ -110,6 +110,12 @@ var tCases = map[string]struct {
 			}`,
 		numberOfParts: 3,
 	},
+	"event4": {
+		input: `{
+			"items":"not-an-array"
+			}`,
+		numberOfParts: 1,
+	},
 }
 
 func TestAdapter(t *testing.T) {


### PR DESCRIPTION
As [noted](https://triggermesh-community.slack.com/archives/C02GHUAQDCH/p1674070249713809) in our slack, Splitter is dropping events if provided JSON path is not an array. With this update, if the incoming event does not contain an array in the **path** that is supposed to be split, the splitter will return a single event with the payload extracted from the event's **path**. I think that this behavior makes the splitter a bit more versatile.

Splitter:
```yaml
...
spec:
  path: items
...
```

Incoming event's payload:

```json
{
  "foo": "bar",
  "items": {"type": "not-an-array"}
}
```

- Result before this PR:
    _None, the splitter will not emit an event_

- Result after this PR:
   _Single event with the following payload_

    ```json
    {
      "type": "not-an-array"
    }
    ```