### PR TITLE
Ginkgo - Remove deprecated parameter

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -125,7 +125,7 @@ jobs:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      run: ginkgo -procs=$(($(nproc)*2)) -slow-spec-threshold=10m -randomize-all ./test/e2e/
+      run: ginkgo -procs=$(($(nproc)*2)) -randomize-all ./test/e2e/
 
     - name: Report e2e test result
       if: always()


### PR DESCRIPTION
`--slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.`