### PR TITLE
feat(src/sqs): customizable serviceAccount name

### DIFF
--- a/pkg/apis/common/v1alpha1/aws_types.go
+++ b/pkg/apis/common/v1alpha1/aws_types.go
@@ -72,3 +72,29 @@ func AwsIamRoleAnnotation(iamRole apis.ARN) resource.ServiceAccountOption {
 		metav1.SetMetaDataAnnotation(&sa.ObjectMeta, annotationEksIAMRole, iamRole.String())
 	}
 }
+
+const annotationAlphaIamRoleServiceAccount = "alpha.triggermesh.io/aws-iam-service-account"
+
+// AlphaAwsIamRoleCustomServiceAccountName returns a functional option that
+// sets a custom name on a ServiceAccount, if requested by the component.
+// Alpha feature, only relevant for components with IAM Role authentication.
+func AlphaAwsIamRoleCustomServiceAccountName(r Reconcilable) resource.ServiceAccountOption {
+	if name := AlphaCustomServiceAccountName(r); name != "" {
+		return func(sa *corev1.ServiceAccount) {
+			sa.SetName(name)
+		}
+	}
+
+	return func(*corev1.ServiceAccount) {}
+}
+
+// AlphaCustomServiceAccountName returns a custom name for a ServiceAccount, if
+// requested by the component.
+// Alpha feature, only relevant for components with IAM Role authentication.
+func AlphaCustomServiceAccountName(r Reconcilable) string {
+	if WantsOwnServiceAccount(r) {
+		return r.GetAnnotations()[annotationAlphaIamRoleServiceAccount]
+	}
+
+	return ""
+}

--- a/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/awssqs_lifecycle.go
@@ -84,6 +84,8 @@ func (s *AWSSQSSource) ServiceAccountOptions() []resource.ServiceAccountOption {
 		saOpts = append(saOpts, v1alpha1.AwsIamRoleAnnotation(*iamRole))
 	}
 
+	saOpts = append(saOpts, v1alpha1.AlphaAwsIamRoleCustomServiceAccountName(s))
+
 	return saOpts
 }
 

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -71,6 +71,10 @@ func MTAdapterObjectName(o kmeta.OwnerRefable) string {
 // with the given component instance.
 func ServiceAccountName(rcl v1alpha1.Reconcilable) string {
 	if v1alpha1.WantsOwnServiceAccount(rcl) {
+		if name := v1alpha1.AlphaCustomServiceAccountName(rcl); name != "" {
+			return name
+		}
+
 		rclName := rcl.GetName()
 
 		// Edge case: we need to make sure some characters are inserted

--- a/pkg/reconciler/reconcile.go
+++ b/pkg/reconciler/reconcile.go
@@ -535,7 +535,7 @@ func resolveSinkURL(ctx context.Context, r *resolver.URIResolver) (*apis.URL, er
 	return r.URIFromDestinationV1(ctx, *sink, rcl)
 }
 
-// serviceAccountOwners returns a list of OwnerRefable to be set as a the
+// serviceAccountOwners returns a list of OwnerRefable to be set as the
 // OwnerReferences metadata attribute of a ServiceAccount.
 //
 // By setting multiple owners on a single ServiceAccount object, we ensure that
@@ -544,7 +544,7 @@ func resolveSinkURL(ctx context.Context, r *resolver.URIResolver) (*apis.URL, er
 // collected by Kubernetes as soon as the last instance of that component type
 // gets deleted from the namespace.
 //
-// The result is  the following chain of ownership:
+// The result is the following chain of ownership:
 //
 //	FooComponent/instance-a, FooComponent/instance-b, FooComponent/instance-c, ...
 //	└─ServiceAccount/foocomponent-adapter


### PR DESCRIPTION
### Context

Users have been expressing concerns regarding the usage of the IAM role auth feature of AWS sources (https://github.com/triggermesh/triggermesh/pull/248#issuecomment-1413980675).

Per Amazon's design, users must create one _IAM Role_ and one _Trust Relationship_ **per Service Account** (hence, per source instance). This is quite a tedious process, and for some people it is just fine to use a shared serviceAccount for selected sources.

### Proposal

This PR introduces an **alpha** feature  — currently only enabled in the event source for Amazon SQS (`AWSSQSSource` kind) — which allows overriding the name of the service account by annotating the source object with `alpha.triggermesh.io/aws-iam-service-account: <service account name>`.

I have no intention to introduce API changes here. An annotation is easier to test and less intrusive.
If it works, implementing this "properly" inside CRDs will be trivial.

### Demo

```yaml
apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSSQSSource
metadata:
  name: sample1
  annotations:
    alpha.triggermesh.io/aws-iam-service-account: my-shared-serviceaccount  # arbitrary name
spec:
  arn: arn:aws:sqs:eu-central-1:123456789012:queue1
  auth:
    iamRole: arn:aws:iam::123456789012:role/foo  # MUST be identical in sample1 and sample2
  sink:
    ref:
      apiVersion: v1
      kind: Service
      name: event-display

---

apiVersion: sources.triggermesh.io/v1alpha1
kind: AWSSQSSource
metadata:
  name: sample2
  annotations:
    alpha.triggermesh.io/aws-iam-service-account: my-shared-serviceaccount  # arbitrary name
spec:
  arn: arn:aws:sqs:eu-central-1:123456789012:queue2
  auth:
    iamRole: arn:aws:iam::123456789012:role/foo  # MUST be identical in sample1 and sample2
  sink:
    ref:
      apiVersion: v1
      kind: Service
      name: event-display
```

```console
$ kubectl get serviceaccounts
NAME                       SECRETS   AGE
default                    1         13d
my-shared-serviceaccount   1         28s
```

```console
$ kubectl get deployments
NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
awssqssource-sample1             1/1     1            1           3m56s
awssqssource-sample2             1/1     1            1           3m56s
event-display-00001-deployment   1/1     1            1           3m58s
```

```console
$ kubectl get deployments -o jsonpath='{.items[*].spec.template.spec.serviceAccount}'
my-shared-serviceaccount my-shared-serviceaccount
```

### Caveats

- There is no check whatsoever whether the serviceAccount already exists, is used by someone else, etc.
- There is no check whatsoever whether all sources that share a given service account are using the same iamRole value. If not, the iamRole will always be updated to the last reconciled source that uses this serviceAccount.
- The `ownerReferences` of the serviceAccount will always be updated to the last reconciled source that uses this serviceAccount.

Because this is an **alpha**, undocumented feature, I believe that none of the above caveats should prevent its testing.

cc. @sebgoa