### PR TITLE
Publish adapter images for ARM64 architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,9 @@ jobs:
             KOFLAGS: --jobs=4
             DIST_DIR: /tmp/dist/
           command: |
-            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
+            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} \
+            KOFLAGS="--platform linux/amd64,linux/arm64" \
+            make release
       - run:
           name: Publishing container images and creating release manifests
           environment:
@@ -149,7 +151,9 @@ jobs:
             go install .
             popd
 
-            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
+            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} \
+            KOFLAGS="--platform linux/amd64,linux/arm64" \
+            make release
 
             declare -a release_files=(
               triggermesh-crds.yaml


### PR DESCRIPTION
Since we're not Kubernetes-only platform anymore, it may be useful to build images for user's local env. In my case our default linux/amd64 run in the emulation mode which affects negatively components performance. This PR adds native ARM64 platforms support, eg. Docker Desktop on Apple silicon.

<img width="496" alt="Screenshot 2023-02-09 at 3 36 14 PM" src="https://user-images.githubusercontent.com/13515865/217774445-3ea96816-31c0-469e-8313-620dfb171e3c.png">
