### PR TITLE
Restore KOFLAGS to limit number of jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,26 +134,22 @@ jobs:
           name: Publishing container images to Docker Hub
           environment:
             KO_DOCKER_REPO: docker.io/triggermesh
-            KOFLAGS: --jobs=4
+            KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64
             DIST_DIR: /tmp/dist/
           command: |
-            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} \
-            KOFLAGS="--platform linux/amd64,linux/arm64" \
-            make release
+            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
       - run:
           name: Publishing container images and creating release manifests
           environment:
             KO_DOCKER_REPO: gcr.io/triggermesh
-            KOFLAGS: --jobs=4  # adjust based on resource_class
+            KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64 # adjust based on resource_class
             DIST_DIR: /tmp/dist/
           command: |
             pushd hack/manifest-cleaner
             go install .
             popd
 
-            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} \
-            KOFLAGS="--platform linux/amd64,linux/arm64" \
-            make release
+            IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
 
             declare -a release_files=(
               triggermesh-crds.yaml


### PR DESCRIPTION
PR triggermesh/triggermesh#1317 overwrote the flag that limited the number of ko build threads. That lead to CI timeouts.