### PR TITLE
Revert "Publish adapter images for ARM64 architecture"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           name: Publishing container images to Docker Hub
           environment:
             KO_DOCKER_REPO: docker.io/triggermesh
-            KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64
+            KOFLAGS: --jobs=4
             DIST_DIR: /tmp/dist/
           command: |
             IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} make release
@@ -142,7 +142,7 @@ jobs:
           name: Publishing container images and creating release manifests
           environment:
             KO_DOCKER_REPO: gcr.io/triggermesh
-            KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64 # adjust based on resource_class
+            KOFLAGS: --jobs=4 # adjust based on resource_class
             DIST_DIR: /tmp/dist/
           command: |
             pushd hack/manifest-cleaner


### PR DESCRIPTION
Reverts #1317

Looks like we don't have enough [memory](https://app.circleci.com/pipelines/github/triggermesh/triggermesh/3647/workflows/2832ddbc-7516-40ba-a8d5-93332054d24d/jobs/10086/resources) to build effectively two sets of images, amd64 and arm64, CI build step is failing.

That's sad, would be great to have native arm64 images available, they don't even need to be build in the same time as amd64, we could build them asynchronously, nightly.