### PR TITLE
Add support for Splunk compatible APIs

### DIFF
--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -52,8 +52,8 @@ spec:
             properties:
               endpoint:
                 type: string
-                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated. When the URL path is not present, the
-                  one documented at Splunk is automatically used. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
+                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated.
+                  When the URL path is not present, the one documented at Splunk is automatically used. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
                 format: url
                 pattern: ^https?:\/\/.+$
               token:

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -52,8 +52,8 @@ spec:
             properties:
               endpoint:
                 type: string
-                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated,
-                  the URL path is trimmed if present. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
+                description: URL of the HTTP Event Collector (HEC). Only the scheme, hostname, and port (optionally) are evaluated. When the URL path is not present, the
+                  one documented at Splunk is automatically used. See https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Enable_HTTP_Event_Collector.
                 format: url
                 pattern: ^https?:\/\/.+$
               token:

--- a/pkg/targets/adapter/splunktarget/adapter.go
+++ b/pkg/targets/adapter/splunktarget/adapter.go
@@ -121,7 +121,9 @@ func newClient(hecURL url.URL, hecToken, index, hostname string, skipTLSVerify b
 		Transport: httpTransport,
 	}
 
-	hecURL.Path = eventURLPath
+	if hecURL.Path == "" || hecURL.Path == "/" {
+		hecURL.Path = eventURLPath
+	}
 
 	return &splunk.Client{
 		HTTPClient: httpClient,

--- a/pkg/targets/adapter/splunktarget/adapter_test.go
+++ b/pkg/targets/adapter/splunktarget/adapter_test.go
@@ -19,6 +19,7 @@ package splunktarget
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -104,4 +105,35 @@ func newEvent(t *testing.T) cloudevents.Event {
 	}
 
 	return ce
+}
+
+func TestCustomURLPath(t *testing.T) {
+	testCases := map[string]struct {
+		url      string
+		expected string
+	}{
+		"Default URL": {
+			url:      "https://mysplunk.example.com:8088",
+			expected: "https://mysplunk.example.com:8088/services/collector/event/1.0",
+		},
+		"Default URL with trailing /": {
+			url:      "https://mysplunk.example.com:8088/",
+			expected: "https://mysplunk.example.com:8088/services/collector/event/1.0",
+		},
+		"Custom URL": {
+			url:      "https://mysplunk.example.com:8088/services/collector/event",
+			expected: "https://mysplunk.example.com:8088/services/collector/event",
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			assert.NoError(t, err, "Parsing test URL")
+
+			sc := newClient(*u, "", "", "", false)
+			assert.Equal(t, tc.expected, sc.URL, "Unexpected URL at Splunk client")
+		})
+	}
 }


### PR DESCRIPTION
Splunk compatible APIS might not use the `/services/collector/event/1.0` path that is appended by the adapter.

This change keeps the user's paths instead of trimming it if present.