### PR TITLE
Add "DiscardCEContext" to SplunkTarget

### DIFF
--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -82,6 +82,11 @@ spec:
               skipTLSVerify:
                 description: Control whether the target should verify the SSL/TLS certificate used by the event collector.
                 type: boolean
+              discardCloudEventContext:
+                description: Whether to omit CloudEvent context attributes in messages sent to Splunk. When this property
+                  is false (default), the entire CloudEvent payload is included. When this property is true, only the CloudEvent
+                  data is included.
+                type: boolean
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object

--- a/pkg/apis/targets/v1alpha1/splunk_types.go
+++ b/pkg/apis/targets/v1alpha1/splunk_types.go
@@ -64,6 +64,11 @@ type SplunkTargetSpec struct {
 	// Adapter spec overrides parameters.
 	// +optional
 	AdapterOverrides *v1alpha1.AdapterOverrides `json:"adapterOverrides,omitempty"`
+
+	// Whether to omit CloudEvent context attributes in messages sent to Splunk.
+	// When this property is false (default), the entire CloudEvent payload is included.
+	// When this property is true, only the CloudEvent data is included.
+	DiscardCEContext bool `json:"discardCloudEventContext"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/targets/reconciler/splunktarget/adapter.go
+++ b/pkg/targets/reconciler/splunktarget/adapter.go
@@ -74,6 +74,10 @@ func MakeAppEnv(o *v1alpha1.SplunkTarget) []corev1.EnvVar {
 			Name:  envHECEndpoint,
 			Value: hecURL.String(),
 		},
+		{
+			Name:  "DISCARD_CE_CONTEXT",
+			Value: strconv.FormatBool(o.Spec.DiscardCEContext),
+		},
 	}
 
 	env = common.MaybeAppendValueFromEnvVar(env, envHECToken, o.Spec.Token)


### PR DESCRIPTION
Add ability for Splunk target to discard CE context attributes.

`discardCloudEventContext: false` (default):
```json
{
    "time": 1676344740.301,
    "host": "io.triggermesh.splunktarget.default.splunk",
    "source": "splitter",
    "sourcetype": "onus.azuread",
    "event": {
        "specversion": "1.0",
        "id": "05939872-8278-4fe1-8699-615c80c5e19c-1",
        "source": "splitter",
        "type": "onus.azuread",
        "datacontenttype": "application/json",
        "data": {
            "time": "2023-02-13T14:15:37.8604902Z",
            "id": 2
        }
    }
}
```

`discardCloudEventContext: true`:
```json
{
	"time": 1676344740.301,
	"host": "io.triggermesh.splunktarget.default.splunk",
	"source": "splitter",
	"sourcetype": "onus.azuread",
	"event": {
		"time": "2023-02-13T14:15:37.8604902Z",
		"id": 2
	}
}
```