### PR TITLE
Add KafkaSource safety net for non Kubernetes users

### DIFF
--- a/pkg/sources/adapter/kafkasource/stale.go
+++ b/pkg/sources/adapter/kafkasource/stale.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kafkasource
 
 import (
@@ -44,7 +60,7 @@ func (sl *StaleList) count() int {
 	return len(sl.items)
 }
 
-// Adds new element to the list and updates the count, removing
+// AddAndCount adds a new element to the list and updates the count, removing
 // any stale items from it.
 func (sl *StaleList) AddAndCount(object interface{}) int {
 	sl.m.Lock()
@@ -58,7 +74,7 @@ func (sl *StaleList) AddAndCount(object interface{}) int {
 	return sl.count()
 }
 
-// Updates the count removing any stale items from it.
+// Count updates the count removing any stale items from it.
 func (sl *StaleList) Count() int {
 	sl.m.Lock()
 	defer sl.m.Unlock()

--- a/pkg/sources/adapter/kafkasource/stale.go
+++ b/pkg/sources/adapter/kafkasource/stale.go
@@ -1,0 +1,67 @@
+package kafkasource
+
+import (
+	"sync"
+	"time"
+)
+
+type item struct {
+	object interface{}
+	added  time.Time
+}
+
+// StaleList is a list of items that timeout lazily,
+// only checking for item expiration when a new one is added.
+//
+// This should not be used for storing a big number of items.
+type StaleList struct {
+	items   []item
+	timeout time.Duration
+	m       sync.Mutex
+}
+
+func NewStaleList(timeout time.Duration) *StaleList {
+	return &StaleList{
+		items:   []item{},
+		timeout: timeout,
+	}
+}
+
+func (sl *StaleList) count() int {
+	index := -1
+	for i := range sl.items {
+		if time.Since(sl.items[i].added) > sl.timeout {
+			index = i
+			continue
+		}
+		break
+	}
+
+	if index != -1 {
+		sl.items = sl.items[index+1:]
+	}
+
+	return len(sl.items)
+}
+
+// Adds new element to the list and updates the count, removing
+// any stale items from it.
+func (sl *StaleList) AddAndCount(object interface{}) int {
+	sl.m.Lock()
+	defer sl.m.Unlock()
+
+	sl.items = append(sl.items, item{
+		added:  time.Now(),
+		object: object,
+	})
+
+	return sl.count()
+}
+
+// Updates the count removing any stale items from it.
+func (sl *StaleList) Count() int {
+	sl.m.Lock()
+	defer sl.m.Unlock()
+
+	return sl.count()
+}

--- a/pkg/sources/adapter/kafkasource/stale_test.go
+++ b/pkg/sources/adapter/kafkasource/stale_test.go
@@ -1,0 +1,74 @@
+package kafkasource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	tTimeout = time.Duration(10 * time.Second)
+)
+
+func TestNewController(t *testing.T) {
+	testCases := map[string]struct {
+		inItems []item
+
+		expectedCount int
+	}{
+		"no expired": {
+			inItems: []item{
+				staleItem(time.Second),
+				staleItem(time.Second),
+				staleItem(time.Second),
+			},
+			expectedCount: 3,
+		},
+		"one expired": {
+			inItems: []item{
+				staleItem(20 * time.Second),
+				staleItem(time.Second),
+				staleItem(time.Second),
+			},
+			expectedCount: 2,
+		},
+		"two expired": {
+			inItems: []item{
+				staleItem(20 * time.Second),
+				staleItem(20 * time.Second),
+				staleItem(time.Second),
+			},
+			expectedCount: 1,
+		},
+		"all expired": {
+			inItems: []item{
+				staleItem(20 * time.Second),
+				staleItem(20 * time.Second),
+				staleItem(20 * time.Second),
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for name, tc := range testCases {
+		//nolint:scopelint
+		t.Run(name, func(t *testing.T) {
+			sl := &StaleList{
+				items:   tc.inItems,
+				timeout: tTimeout,
+			}
+
+			c := sl.Count()
+			assert.Equal(t, tc.expectedCount, c)
+		})
+	}
+
+}
+
+func staleItem(age time.Duration) item {
+	return item{
+		object: nil,
+		added:  time.Now().Add(age * -1),
+	}
+}

--- a/pkg/sources/adapter/kafkasource/stale_test.go
+++ b/pkg/sources/adapter/kafkasource/stale_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kafkasource
 
 import (


### PR DESCRIPTION
Non Kubernetes users raised a complain because the adapter errors when a consumer fails.

Sarama consumer will exit on broker re-balancing among other scenarios, which might happen often. This PR includes 2 safety nets mechanisms:

- Explicitly listening to context.Done, making sure that only errors will make the adapter exit.
- Upon errors of unknown nature from refreshing the Consumer, execute retries until _too many_ of them do not succeed.
