### PR TITLE
Splunktarget events encoding compatible with the client

### DIFF
--- a/pkg/targets/adapter/splunktarget/adapter.go
+++ b/pkg/targets/adapter/splunktarget/adapter.go
@@ -19,6 +19,7 @@ package splunktarget
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
@@ -166,7 +167,10 @@ func (a *adapter) receive(ctx context.Context, event cloudevents.Event) cloudeve
 		a.defaultIndex,
 	)
 	if a.discardCEContext {
-		e.Event = event.Data()
+		e.Event = string(event.Data())
+		if event.DataContentType() == cloudevents.ApplicationJSON {
+			e.Event = json.RawMessage(event.Data())
+		}
 	}
 
 	err := a.spClient.LogEvent(e)


### PR DESCRIPTION
In this PR Splunktarget generates an event payload that can be processed by the Splunk client.

Splunk client accepts `interface{}` as an event payload. The whole event then `json.Marshal`ed. As a result, the bytes payload ends up base64-encoded. Since the client doesn't make any type assertion, we'll do it in the adapter.