### PR TITLE
Bump kn for e2e tests to v1.6.0

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -41,9 +41,9 @@ jobs:
       uses: container-tools/kind-action@v2
       with:
         version: v0.13.0
-        knative_eventing: v1.4.0
-        knative_serving: v1.4.0
-        knative_kourier: v1.4.0
+        knative_eventing: v1.6.0
+        knative_serving: v1.6.0
+        knative_kourier: v1.6.0
         # ko loads images directly into KinD's container runtime when
         # KO_DOCKER_REPO is set to the rogue value "kind.local", so we have no
         # use for a container registry.


### PR DESCRIPTION
E2e tests are using v1.4.0.

This PR jumps to v1.6.0 to test compatibility with OpenShift serverless.