### PR TITLE
Sync MongoDBTargetSpec with its CRD

### DIFF
--- a/config/301-mongodbtarget.yaml
+++ b/config/301-mongodbtarget.yaml
@@ -62,11 +62,11 @@ spec:
             description: Desired state of event target.
             type: object
             properties:
-              defaultDatabase:
+              database:
                 description: Define the default (over-writeable at runtime) database to write new events to.
                 type: string
                 minLength: 1
-              defaultCollection:
+              collection:
                 description: Define the default (over-writeable at runtime) collection to write new events to.
                 type: string
                 minLength: 1


### PR DESCRIPTION
CRD [names](https://github.com/triggermesh/triggermesh/blob/v1.24.0/config/301-mongodbtarget.yaml#L65-L72) don't match their internal values [here](https://github.com/triggermesh/triggermesh/blob/v1.24.0/pkg/apis/targets/v1alpha1/mongodb_types.go#L49-L52). We need to sync them, otherwise they are ignored.

