### PR TITLE
E2e: Update gcloud repository default branch from master to main

### DIFF
--- a/test/e2e/framework/apps/deployments.go
+++ b/test/e2e/framework/apps/deployments.go
@@ -67,7 +67,6 @@ func CreateSimpleApplication(c clientset.Interface, namespace string,
 
 	WaitUntilAvailable(c, depl)
 	WaitUntilEndpointsPopulated(c, svc)
-	time.Sleep(10 * time.Second)
 
 	return depl, svc
 }

--- a/test/e2e/framework/gcloud/repositories/repositories.go
+++ b/test/e2e/framework/gcloud/repositories/repositories.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	gitDefaultRemoteName = "origin"
-	gitDefaultBranchName = "master"
+	gitDefaultBranchName = "main"
 
 	gitCommitterName  = "TriggerMesh e2e"
 	gitCommitterEmail = "dev@triggermesh.com"


### PR DESCRIPTION

- E2e tests for gcloud repositories use main now instead of master.
- We are also removing the 10s delay after creating the event display sink.

