### PR TITLE
ci: upload YAML artifacts from CI runs

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -124,11 +124,11 @@ jobs:
         done
 
     - name: Upload artifact
-      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@master
       with:
         name: manifests
         path: /tmp/dist
+        retention-days: 14
 
   update-config:
     if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
the artifacts can be downloaded  from the job run page as described in https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts