### PR TITLE
Add support for setting adapter nodeSelector

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -220,7 +220,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -220,8 +220,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -219,6 +219,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -279,6 +279,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - region
             - metricQueries

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -280,8 +280,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -280,7 +280,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -231,7 +231,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -231,8 +231,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -230,6 +230,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - branch

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -216,6 +216,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -217,7 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -217,8 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -216,6 +216,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -217,7 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -217,8 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -216,6 +216,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -217,7 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -217,8 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -241,6 +241,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -242,7 +242,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -242,8 +242,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -216,8 +216,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -215,6 +215,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -216,7 +216,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -224,6 +224,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - pollingInterval

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -225,8 +225,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -225,7 +225,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -297,7 +297,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -296,6 +296,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - eventTypes

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -297,8 +297,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -232,8 +232,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -231,6 +231,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awssnssource.yaml
+++ b/config/300-awssnssource.yaml
@@ -232,7 +232,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -240,7 +240,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -239,6 +239,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - sink

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -240,8 +240,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -292,6 +292,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - subscriptionID
             - destination

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -293,8 +293,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureactivitylogssource.yaml
+++ b/config/300-azureactivitylogssource.yaml
@@ -293,7 +293,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -346,8 +346,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -346,7 +346,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureblobstoragesource.yaml
+++ b/config/300-azureblobstoragesource.yaml
@@ -345,6 +345,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - storageAccountID
             - endpoint

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -286,6 +286,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - scope
             - endpoint

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -287,7 +287,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -287,8 +287,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureeventhubssource.yaml
+++ b/config/300-azureeventhubssource.yaml
@@ -319,6 +319,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - eventHubID
             - sink

--- a/config/300-azureeventhubssource.yaml
+++ b/config/300-azureeventhubssource.yaml
@@ -320,7 +320,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureeventhubssource.yaml
+++ b/config/300-azureeventhubssource.yaml
@@ -320,8 +320,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -172,8 +172,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -171,6 +171,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - auth
             - sink

--- a/config/300-azureiothubsource.yaml
+++ b/config/300-azureiothubsource.yaml
@@ -172,7 +172,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -171,8 +171,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -171,7 +171,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -170,6 +170,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - accountName
             - accountKey

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -319,8 +319,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -318,6 +318,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - queueID
             - sink

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -319,7 +319,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -245,6 +245,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - topicID
             - sink

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -246,7 +246,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -246,8 +246,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -216,6 +216,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - sink
           status:

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -217,7 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-cloudeventssource.yaml
+++ b/config/300-cloudeventssource.yaml
@@ -217,8 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -238,7 +238,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -237,6 +237,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - serviceName
             - methodName

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -238,8 +238,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -230,7 +230,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -229,6 +229,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - billingAccountId
             - budgetId

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -230,8 +230,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -216,6 +216,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - topic
             - sink

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -217,7 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -217,8 +217,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -228,6 +228,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - repository
             - sink

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -229,7 +229,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -229,8 +229,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -239,6 +239,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - bucket
             - pubsub

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -240,7 +240,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -240,8 +240,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -204,8 +204,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -203,6 +203,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - eventType
             - method

--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -204,7 +204,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -289,7 +289,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -289,8 +289,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-ibmmqsource.yaml
+++ b/config/300-ibmmqsource.yaml
@@ -288,6 +288,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - connectionName
             - channelName

--- a/config/300-kafkasource.yaml
+++ b/config/300-kafkasource.yaml
@@ -328,7 +328,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-kafkasource.yaml
+++ b/config/300-kafkasource.yaml
@@ -327,6 +327,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - bootstrapServers
             - topic

--- a/config/300-kafkasource.yaml
+++ b/config/300-kafkasource.yaml
@@ -328,8 +328,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -247,6 +247,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - oracleApiPrivateKey
             - oracleApiPrivateKeyPassphrase

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -248,8 +248,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-ocimetricssource.yaml
+++ b/config/300-ocimetricssource.yaml
@@ -248,7 +248,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -199,8 +199,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -199,7 +199,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-salesforcesource.yaml
+++ b/config/300-salesforcesource.yaml
@@ -198,6 +198,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - auth
             - subscription

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -181,8 +181,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -181,7 +181,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -180,6 +180,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - sink
           status:

--- a/config/300-solacesource.yaml
+++ b/config/300-solacesource.yaml
@@ -248,8 +248,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-solacesource.yaml
+++ b/config/300-solacesource.yaml
@@ -247,6 +247,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - url
             - queueName

--- a/config/300-solacesource.yaml
+++ b/config/300-solacesource.yaml
@@ -248,7 +248,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -154,8 +154,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -153,6 +153,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - sink
           status:

--- a/config/300-twiliosource.yaml
+++ b/config/300-twiliosource.yaml
@@ -154,7 +154,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -202,8 +202,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -202,7 +202,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -201,6 +201,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - eventType
             - sink

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -207,8 +207,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -207,7 +207,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -206,6 +206,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - subdomain
             - email

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -195,7 +195,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -194,6 +194,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - region
             - language

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -195,8 +195,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -191,7 +191,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -190,6 +190,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -191,8 +191,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -196,7 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -196,8 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -195,6 +195,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -197,6 +197,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -198,8 +198,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -198,7 +198,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -196,7 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -196,8 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -195,6 +195,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -197,8 +197,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -196,6 +196,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -197,7 +197,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -196,7 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -196,8 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -195,6 +195,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -198,6 +198,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - arn
             - auth

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -199,8 +199,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -199,7 +199,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -300,8 +300,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -300,7 +300,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -299,6 +299,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - eventHubID
             - auth

--- a/config/301-azuresentineltarget.yaml
+++ b/config/301-azuresentineltarget.yaml
@@ -294,7 +294,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-azuresentineltarget.yaml
+++ b/config/301-azuresentineltarget.yaml
@@ -293,6 +293,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - subscriptionID
             - resourceGroup

--- a/config/301-azuresentineltarget.yaml
+++ b/config/301-azuresentineltarget.yaml
@@ -294,8 +294,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-cloudeventstarget.yaml
+++ b/config/301-cloudeventstarget.yaml
@@ -168,8 +168,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-cloudeventstarget.yaml
+++ b/config/301-cloudeventstarget.yaml
@@ -167,6 +167,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - endpoint
 

--- a/config/301-cloudeventstarget.yaml
+++ b/config/301-cloudeventstarget.yaml
@@ -168,7 +168,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -146,7 +146,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -145,6 +145,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - apiKey
           status:

--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -146,8 +146,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -183,6 +183,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - connection
             - indexName

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -184,8 +184,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-elasticsearchtarget.yaml
+++ b/config/301-elasticsearchtarget.yaml
@@ -184,7 +184,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -160,6 +160,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - credentialsJson
             - projectID

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -161,8 +161,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudfirestoretarget.yaml
+++ b/config/301-googlecloudfirestoretarget.yaml
@@ -161,7 +161,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudpubsubtarget.yaml
+++ b/config/301-googlecloudpubsubtarget.yaml
@@ -143,7 +143,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudpubsubtarget.yaml
+++ b/config/301-googlecloudpubsubtarget.yaml
@@ -142,6 +142,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - topic
             - credentialsJson

--- a/config/301-googlecloudpubsubtarget.yaml
+++ b/config/301-googlecloudpubsubtarget.yaml
@@ -143,8 +143,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -155,8 +155,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -155,7 +155,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudstoragetarget.yaml
+++ b/config/301-googlecloudstoragetarget.yaml
@@ -154,6 +154,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - credentialsJson
             - bucketName

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -144,6 +144,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - credentialsJson
           status:

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -145,8 +145,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlecloudworkflowstarget.yaml
+++ b/config/301-googlecloudworkflowstarget.yaml
@@ -145,7 +145,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -148,8 +148,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -148,7 +148,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-googlesheettarget.yaml
+++ b/config/301-googlesheettarget.yaml
@@ -147,6 +147,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - id
             - googleServiceAccount

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -196,7 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -195,6 +195,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - endpoint
             - method

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -196,8 +196,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -271,7 +271,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -270,6 +270,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - connectionName
             - channelName

--- a/config/301-ibmmqtarget.yaml
+++ b/config/301-ibmmqtarget.yaml
@@ -271,8 +271,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -163,7 +163,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -162,6 +162,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - auth
             - url

--- a/config/301-jiratarget.yaml
+++ b/config/301-jiratarget.yaml
@@ -163,8 +163,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-kafkatarget.yaml
+++ b/config/301-kafkatarget.yaml
@@ -316,8 +316,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-kafkatarget.yaml
+++ b/config/301-kafkatarget.yaml
@@ -315,6 +315,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - bootstrapServers
             - topic

--- a/config/301-kafkatarget.yaml
+++ b/config/301-kafkatarget.yaml
@@ -316,7 +316,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -179,6 +179,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - connection
             - instruments

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -180,7 +180,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -180,8 +180,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -152,7 +152,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -152,8 +152,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -151,6 +151,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - shippingToken
             - logsListenerURL

--- a/config/301-mongodbtarget.yaml
+++ b/config/301-mongodbtarget.yaml
@@ -163,7 +163,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-mongodbtarget.yaml
+++ b/config/301-mongodbtarget.yaml
@@ -162,6 +162,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - connectionString
             - collection

--- a/config/301-mongodbtarget.yaml
+++ b/config/301-mongodbtarget.yaml
@@ -163,8 +163,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -179,8 +179,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -179,7 +179,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-oracletarget.yaml
+++ b/config/301-oracletarget.yaml
@@ -178,6 +178,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             oneOf:
             - required: [function]
           status:

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -170,6 +170,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - auth
           status:

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -171,8 +171,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-salesforcetarget.yaml
+++ b/config/301-salesforcetarget.yaml
@@ -171,7 +171,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -162,7 +162,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -161,6 +161,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - apiKey
           status:

--- a/config/301-sendgridtarget.yaml
+++ b/config/301-sendgridtarget.yaml
@@ -162,8 +162,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -138,8 +138,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -137,6 +137,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - token
           status:

--- a/config/301-slacktarget.yaml
+++ b/config/301-slacktarget.yaml
@@ -138,7 +138,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-solacetarget.yaml
+++ b/config/301-solacetarget.yaml
@@ -229,7 +229,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-solacetarget.yaml
+++ b/config/301-solacetarget.yaml
@@ -229,8 +229,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-solacetarget.yaml
+++ b/config/301-solacetarget.yaml
@@ -228,6 +228,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - url
             - queueName

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -158,8 +158,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -157,6 +157,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - endpoint
             - token

--- a/config/301-splunktarget.yaml
+++ b/config/301-splunktarget.yaml
@@ -158,7 +158,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -161,8 +161,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -161,7 +161,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-twiliotarget.yaml
+++ b/config/301-twiliotarget.yaml
@@ -160,6 +160,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - sid
             - token

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -147,8 +147,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -147,7 +147,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/301-zendesktarget.yaml
+++ b/config/301-zendesktarget.yaml
@@ -146,6 +146,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - subdomain
             - email

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -157,7 +157,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -157,8 +157,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/302-filter.yaml
+++ b/config/302-filter.yaml
@@ -156,6 +156,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             type: object
             properties:

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -175,6 +175,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             type: object
             properties:

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -176,8 +176,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/302-splitter.yaml
+++ b/config/302-splitter.yaml
@@ -176,7 +176,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -192,7 +192,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -192,8 +192,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/303-function.yaml
+++ b/config/303-function.yaml
@@ -191,6 +191,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             type: object
             properties:

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -158,8 +158,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -157,6 +157,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             description: Reported status of the transformer.
             type: object

--- a/config/304-jqtransformation.yaml
+++ b/config/304-jqtransformation.yaml
@@ -158,7 +158,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -173,6 +173,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             required:
             - correlationKey
             - response

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -174,7 +174,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-synchronizer.yaml
+++ b/config/304-synchronizer.yaml
@@ -174,8 +174,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -214,6 +214,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             description: Reported status of Transformation.
             type: object

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -215,7 +215,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-transformation.yaml
+++ b/config/304-transformation.yaml
@@ -215,8 +215,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -155,8 +155,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -155,7 +155,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-xmltojsontransformation.yaml
+++ b/config/304-xmltojsontransformation.yaml
@@ -154,6 +154,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
           status:
             description: Reported status of the transformer.
             type: object

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -190,8 +190,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
-                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+                    description: NodeSelector only allow the object pods to be created at nodes where all selector labels
+                      are present, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -190,7 +190,8 @@ spec:
                           type: integer
                           format: int64
                   nodeSelector:
-                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented
+                      at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
                     type: object
                     additionalProperties:
                       type: string

--- a/config/304-xslttransformation.yaml
+++ b/config/304-xslttransformation.yaml
@@ -189,6 +189,11 @@ spec:
                           description: Period of time a toleration of effect NoExecute tolerates the taint.
                           type: integer
                           format: int64
+                  nodeSelector:
+                    description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+                    type: object
+                    additionalProperties:
+                      type: string
             anyOf:
             - required: [xslt]
             - required: [allowPerEventXSLT]

--- a/hack/crd-update/crd-update.py
+++ b/hack/crd-update/crd-update.py
@@ -88,7 +88,7 @@ try:
                     type: integer
                     format: int64
             nodeSelector:
-              description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at
+              description: NodeSelector only allow the object pods to be created at nodes where all selector labels are present, as documented at
                 https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
               type: object
               additionalProperties:

--- a/hack/crd-update/crd-update.py
+++ b/hack/crd-update/crd-update.py
@@ -87,6 +87,12 @@ try:
                     description: Period of time a toleration of effect NoExecute tolerates the taint.
                     type: integer
                     format: int64
+            nodeSelector:
+              description: NodeSelector is a selector which must be true for the pod to fit on a node, as documented at
+                https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+              type: object
+              additionalProperties:
+                type: string
         """
     )
 except (scanner.ScannerError) as e:

--- a/pkg/apis/common/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/common/v1alpha1/deepcopy_generated.go
@@ -112,6 +112,13 @@ func (in *AdapterOverrides) DeepCopyInto(out *AdapterOverrides) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/pkg/apis/common/v1alpha1/types.go
+++ b/pkg/apis/common/v1alpha1/types.go
@@ -44,6 +44,8 @@ type AdapterOverrides struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Pod tolerations.
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// NodeSelector to control which nodes the pod can be scheduled on.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Environment variables applied on adapter container.
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Labels applied on adapter container.

--- a/pkg/reconciler/adapter.go
+++ b/pkg/reconciler/adapter.go
@@ -389,6 +389,10 @@ func adapterOverrideOptions(overrides *v1alpha1.AdapterOverrides) []resource.Obj
 		opts = append(opts, resource.Toleration(t))
 	}
 
+	for k, v := range overrides.NodeSelector {
+		opts = append(opts, resource.NodeSelector(map[string]string{k: v}))
+	}
+
 	for _, t := range overrides.Env {
 		opts = append(opts, resource.EnvVar(t.Name, t.Value))
 	}

--- a/pkg/reconciler/resource/deployment_test.go
+++ b/pkg/reconciler/resource/deployment_test.go
@@ -103,6 +103,9 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 					Tolerations: []corev1.Toleration{{
 						Key: "taint", Operator: "Exists",
 					}},
+					NodeSelector: map[string]string{
+						"disktype": "ssd",
+					},
 					Containers: []corev1.Container{{
 						Name:  defaultContainerName,
 						Image: tImg,

--- a/pkg/reconciler/resource/deployment_test.go
+++ b/pkg/reconciler/resource/deployment_test.go
@@ -69,6 +69,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		Limits(&cpuRes, nil),
 		TerminationErrorToLogs,
 		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
+		NodeSelector(map[string]string{"disktype": "ssd"}),
 		Volumes(v),
 		VolumeMounts(vm),
 	)

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -66,6 +66,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		Requests(&cpuRes, &memRes),
 		Limits(&cpuRes, nil),
 		Toleration(corev1.Toleration{Key: "taint", Operator: corev1.TolerationOpExists}),
+		NodeSelector(map[string]string{"disktype": "ssd"}),
 		VisibilityClusterLocal,
 		Volumes(v),
 		VolumeMounts(vm),

--- a/pkg/reconciler/resource/knservice_test.go
+++ b/pkg/reconciler/resource/knservice_test.go
@@ -96,6 +96,9 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 							Tolerations: []corev1.Toleration{{
 								Key: "taint", Operator: "Exists",
 							}},
+							NodeSelector: map[string]string{
+								"disktype": "ssd",
+							},
 							Containers: []corev1.Container{{
 								Name:  defaultContainerName,
 								Image: tImg,

--- a/pkg/reconciler/resource/podspecable.go
+++ b/pkg/reconciler/resource/podspecable.go
@@ -86,6 +86,28 @@ func Toleration(t corev1.Toleration) ObjectOption {
 	}
 }
 
+// NodeSelector sets a NodeSelector on a PodSpecable.
+func NodeSelector(selector map[string]string) ObjectOption {
+	return func(object interface{}) {
+		var nodeSelector *map[string]string
+
+		switch o := object.(type) {
+		case *appsv1.Deployment:
+			nodeSelector = &o.Spec.Template.Spec.NodeSelector
+		case *servingv1.Service:
+			nodeSelector = &o.Spec.Template.Spec.NodeSelector
+		}
+
+		if *nodeSelector == nil {
+			*nodeSelector = make(map[string]string, len(selector))
+		}
+
+		for k, v := range selector {
+			(*nodeSelector)[k] = v
+		}
+	}
+}
+
 // Volumes attaches Volumes to a PodSpecable.
 func Volumes(vs ...corev1.Volume) ObjectOption {
 	return func(object interface{}) {


### PR DESCRIPTION
Addresses one of the features requested in https://github.com/triggermesh/triggermesh/issues/768.

Example:
```
spec:
  # ...
  adapterOverrides:
    nodeSelector:
      disktype: ssd
```

Result:
```
kubectl get deployment awss3source-sample -o jsonpath='{.spec.template.spec.nodeSelector}'
{"disktype":"ssd"}

```