### PR TITLE
Azure Queue Storage Source - Add Visibility timeout parameter

### DIFF
--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -76,6 +76,14 @@ spec:
                     required:
                     - name
                     - key
+              visibilityTimeout:
+                description: Specifies the new visibility timeout value, in seconds, relative to server time.
+                  The new value must be larger than or equal to 0, and can't be larger than 7 days.
+                  The visibility timeout of a message can't be set to a value later than the expiry time.
+                  You can update a message until it has been deleted or has expired. Default PT20S (20s)
+                  More information on Duration format - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601
+                type: string
+                pattern: '^P(?:([0-6]D)?(?:T(?:([0-9]|1[0-9]|2[0-3])H)?(?:([0-5]?[0-9])M)?(?:([0-5]?[0-9]|60)S)?)?|7D)$'
               sink:
                 description: The destination of events sourced from Azure Storage.
                 type: object

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -80,8 +80,8 @@ spec:
                 description: Specifies the new visibility timeout value, in seconds, relative to server time. The new value
                   must be larger than or equal to 0, and can't be larger than 7 days. The visibility timeout of a message
                   can't be set to a value later than the expiry time. You can update a message until it has been deleted or
-                  has expired. Default PT20S (20s) More information on Duration format - https://www.iso.org/iso-8601-date-and-time-format.html
-                  - https://en.wikipedia.org/wiki/ISO_8601
+                  has expired. Expressed as a duration string, which format is documented at https://pkg.go.dev/time#ParseDuration.
+                  Default 20s.
                 type: string
               sink:
                 description: The destination of events sourced from Azure Storage.

--- a/config/300-azurequeuestoragesource.yaml
+++ b/config/300-azurequeuestoragesource.yaml
@@ -77,13 +77,12 @@ spec:
                     - name
                     - key
               visibilityTimeout:
-                description: Specifies the new visibility timeout value, in seconds, relative to server time.
-                  The new value must be larger than or equal to 0, and can't be larger than 7 days.
-                  The visibility timeout of a message can't be set to a value later than the expiry time.
-                  You can update a message until it has been deleted or has expired. Default PT20S (20s)
-                  More information on Duration format - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601
+                description: Specifies the new visibility timeout value, in seconds, relative to server time. The new value
+                  must be larger than or equal to 0, and can't be larger than 7 days. The visibility timeout of a message
+                  can't be set to a value later than the expiry time. You can update a message until it has been deleted or
+                  has expired. Default PT20S (20s) More information on Duration format - https://www.iso.org/iso-8601-date-and-time-format.html
+                  - https://en.wikipedia.org/wiki/ISO_8601
                 type: string
-                pattern: '^P(?:([0-6]D)?(?:T(?:([0-9]|1[0-9]|2[0-3])H)?(?:([0-5]?[0-9])M)?(?:([0-5]?[0-9]|60)S)?)?|7D)$'
               sink:
                 description: The destination of events sourced from Azure Storage.
                 type: object

--- a/config/samples/sources/azurequeuestoragesource.yaml
+++ b/config/samples/sources/azurequeuestoragesource.yaml
@@ -26,6 +26,7 @@ metadata:
 spec:
   accountName: demoaccount
   queueName: testqueue
+  visibilityTimeout: 45s
 
   accountKey:
     valueFromSecret:

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.25.0
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible
+	github.com/rickb777/date v1.13.0
 	github.com/sendgrid/sendgrid-go v3.12.0+incompatible
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/stretchr/testify v1.8.2
@@ -197,7 +198,6 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20210928085443-fafb309d4027 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/rickb777/date v1.13.0 // indirect
 	github.com/rickb777/plural v1.2.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.25.0
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible
-	github.com/rickb777/date v1.13.0
 	github.com/sendgrid/sendgrid-go v3.12.0+incompatible
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/stretchr/testify v1.8.2
@@ -198,6 +197,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20210928085443-fafb309d4027 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/rickb777/date v1.13.0 // indirect
 	github.com/rickb777/plural v1.2.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
+++ b/pkg/apis/sources/v1alpha1/azurequeuestorage_types.go
@@ -51,6 +51,8 @@ type AzureQueueStorageSourceSpec struct {
 	AccountName string                  `json:"accountName"`
 	QueueName   string                  `json:"queueName"`
 	AccountKey  v1alpha1.ValueFromField `json:"accountKey"`
+	// +optional
+	VisibilityTimeout *string `json:"visibilityTimeout,omitempty"`
 
 	// Adapter spec overrides parameters.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/sources/v1alpha1/deepcopy_generated.go
@@ -2068,6 +2068,11 @@ func (in *AzureQueueStorageSourceSpec) DeepCopyInto(out *AzureQueueStorageSource
 	*out = *in
 	in.SourceSpec.DeepCopyInto(&out.SourceSpec)
 	in.AccountKey.DeepCopyInto(&out.AccountKey)
+	if in.VisibilityTimeout != nil {
+		in, out := &in.VisibilityTimeout, &out.VisibilityTimeout
+		*out = new(string)
+		**out = **in
+	}
 	if in.AdapterOverrides != nil {
 		in, out := &in.AdapterOverrides, &out.AdapterOverrides
 		*out = new(commonv1alpha1.AdapterOverrides)

--- a/pkg/sources/adapter/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/adapter/azurequeuestoragesource/adapter.go
@@ -61,7 +61,7 @@ type adapter struct {
 	messagesURL       azqueue.MessagesURL
 	ceClient          cloudevents.Client
 	eventsource       string
-	visibilityTimeout *string
+	visibilityTimeout string
 	logger            *zap.SugaredLogger
 	mt                *pkgadapter.MetricTag
 }
@@ -104,7 +104,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		messagesURL:       messagesURL,
 		ceClient:          ceClient,
 		eventsource:       queueURL.String(),
-		visibilityTimeout: &env.VisibilityTimeout,
+		visibilityTimeout: env.VisibilityTimeout,
 		logger:            logger,
 		mt:                mt,
 	}
@@ -150,7 +150,7 @@ func (h *adapter) processQueueEvents(ctx context.Context, msgCh chan *azqueue.De
 				popReceipt := msg.PopReceipt // This message's most-recent pop receipt
 
 				// Parse visibilityTimeout from ISO 8601 format
-				visibilityTimeoutDuration, err := period.Parse(*h.visibilityTimeout)
+				visibilityTimeoutDuration, err := period.Parse(h.visibilityTimeout)
 				if err != nil {
 					h.logger.Errorw("Unable to parse visibilityTimeout", zap.Error(err))
 					return

--- a/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
+++ b/pkg/sources/reconciler/azurequeuestoragesource/adapter.go
@@ -57,7 +57,7 @@ func (r *Reconciler) BuildAdapter(src commonv1alpha1.Reconcilable, sinkURI *apis
 func MakeAppEnv(o *v1alpha1.AzureQueueStorageSource) []corev1.EnvVar {
 	storageQueueEnvs := common.MaybeAppendValueFromEnvVar([]corev1.EnvVar{}, "AZURE_ACCOUNT_KEY", o.Spec.AccountKey)
 
-	return append(storageQueueEnvs, []corev1.EnvVar{
+	envs := append(storageQueueEnvs, []corev1.EnvVar{
 		{
 			Name:  "AZURE_ACCOUNT_NAME",
 			Value: o.Spec.AccountName,
@@ -65,6 +65,14 @@ func MakeAppEnv(o *v1alpha1.AzureQueueStorageSource) []corev1.EnvVar {
 			Name:  "AZURE_QUEUE_NAME",
 			Value: o.Spec.QueueName,
 		},
-	}...,
-	)
+	}...)
+
+	if o.Spec.VisibilityTimeout != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "AZURE_VISIBILITY_TIMEOUT",
+			Value: *o.Spec.VisibilityTimeout,
+		})
+	}
+
+	return envs
 }


### PR DESCRIPTION
Closes #1382

This PR adds a new optional parameter to set the visibility timeout to Azure Queue Storage Source following the ISO8601, more info: https://en.wikipedia.org/wiki/ISO_8601