### PR TITLE
Migrate Functions to the latest KLR

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -191,11 +191,11 @@ spec:
           value: ko://github.com/triggermesh/triggermesh/cmd/splitter-adapter
         # Function Runtimes
         - name: RUNTIME_KLR_PYTHON
-          value: gcr.io/triggermesh/knative-lambda-python37:v1.19.0
+          value: gcr.io/triggermesh/knative-lambda-python310:latest
         - name: RUNTIME_KLR_NODE
-          value: gcr.io/triggermesh/knative-lambda-node10:v1.19.0
+          value: gcr.io/triggermesh/knative-lambda-node18:latest
         - name: RUNTIME_KLR_RUBY
-          value: gcr.io/triggermesh/knative-lambda-ruby25:v1.19.0
+          value: gcr.io/triggermesh/knative-lambda-ruby32:latest
         # Custom build adapters
         - name: IBMMQSOURCE_IMAGE
           value: gcr.io/triggermesh/ibmmqsource-adapter:latest


### PR DESCRIPTION
Function adapters upgrade to the [latest KLR](https://github.com/triggermesh/knative-lambda-runtime/pull/81) and [runtime wrapper](https://github.com/triggermesh/aws-custom-runtime/pull/53):
- Python 3.7 -> Python 3.10
- NodeJS 10 -> NodeJS 18
- Ruby 2.5 -> Ruby 3.2

New images are passing scans with 0 warnings.