### PR TITLE
HTTPTarget improvements

### DIFF
--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -56,6 +56,7 @@ spec:
             description: Desired state of event target.
             properties:
               response:
+                description: HTTP target response event attributes.
                 type: object
                 properties:
                   eventType:
@@ -218,6 +219,18 @@ spec:
               observedGeneration:
                 type: integer
                 format: int64
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
               conditions:
                 type: array
                 items:

--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -23,7 +23,10 @@ metadata:
   annotations:
     registry.triggermesh.io/acceptedEventTypes: |
       [
-        { "type": "*" }
+        {
+          "type": "io.triggermesh.http.request",
+          "schema": "https://raw.githubusercontent.com/triggermesh/triggermesh/main/schemas/io.triggermesh.http.request.json"
+        }
       ]
     registry.knative.dev/eventTypes: |
       [

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -62,4 +63,32 @@ func (t *HTTPTarget) SetDefaults(ctx context.Context) {
 // Validate implements apis.Validatable
 func (t *HTTPTarget) Validate(ctx context.Context) *apis.FieldError {
 	return nil
+}
+
+// AcceptedEventTypes implements IntegrationTarget.
+func (*HTTPTarget) AcceptedEventTypes() []string {
+	return []string{
+		EventTypeWildcard,
+	}
+}
+
+// GetEventTypes implements EventSource.
+func (t *HTTPTarget) GetEventTypes() []string {
+	eventType := EventTypeResponse
+	if t.Spec.Response.EventType != "" {
+		eventType = t.Spec.Response.EventType
+	}
+	return []string{
+		eventType,
+	}
+}
+
+// AsEventSource implements EventSource.
+func (t *HTTPTarget) AsEventSource() string {
+	eventSource := t.Spec.Response.EventSource
+	if eventSource == "" {
+		kind := strings.ToLower(t.GetGroupVersionKind().Kind)
+		eventSource = "io.triggermesh." + kind + "." + t.Namespace + "." + t.Name
+	}
+	return eventSource
 }

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -28,6 +28,9 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/apis/common/v1alpha1"
 )
 
+// EventTypeHTTPTargetRequest is the event type for HTTP target request.
+const EventTypeHTTPTargetRequest = "io.triggermesh.http.request"
+
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (*HTTPTarget) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("HTTPTarget")
@@ -68,7 +71,7 @@ func (t *HTTPTarget) Validate(ctx context.Context) *apis.FieldError {
 // AcceptedEventTypes implements IntegrationTarget.
 func (*HTTPTarget) AcceptedEventTypes() []string {
 	return []string{
-		EventTypeWildcard,
+		EventTypeHTTPTargetRequest,
 	}
 }
 

--- a/pkg/apis/targets/v1alpha1/http_types.go
+++ b/pkg/apis/targets/v1alpha1/http_types.go
@@ -38,6 +38,8 @@ type HTTPTarget struct {
 
 // Check the interfaces the event target should be implementing.
 var (
+	_ v1alpha1.EventSource         = (*HTTPTarget)(nil)
+	_ v1alpha1.EventReceiver       = (*HTTPTarget)(nil)
 	_ v1alpha1.Reconcilable        = (*HTTPTarget)(nil)
 	_ v1alpha1.AdapterConfigurable = (*HTTPTarget)(nil)
 )

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package httptarget
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -24,7 +25,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strings"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -164,7 +164,7 @@ func (a *httpAdapter) dispatch(ctx context.Context, event cloudevents.Event) (*c
 		u.Path = path.Join(u.Path, rd.PathSuffix)
 	}
 
-	req, err := http.NewRequest(a.method, u.String(), strings.NewReader(rd.Body))
+	req, err := http.NewRequest(a.method, u.String(), bytes.NewBuffer(rd.Body))
 	if err != nil {
 		return nil, a.errorHTTPResult(http.StatusInternalServerError, "Could not create HTTP request: %w", err)
 	}

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/triggermesh/triggermesh/pkg/apis/targets"
+	"github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 	"github.com/triggermesh/triggermesh/pkg/metrics"
 )
 
@@ -140,6 +141,10 @@ func (a *httpAdapter) Start(ctx context.Context) error {
 }
 
 func (a *httpAdapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, cloudevents.Result) {
+	if event.Type() != v1alpha1.EventTypeHTTPTargetRequest {
+		return nil, a.errorHTTPResult(http.StatusBadRequest, "Incoming event type error: expected %q, got %q", v1alpha1.EventTypeHTTPTargetRequest, event.Type())
+	}
+
 	rd := &RequestData{}
 	if err := event.DataAs(rd); err != nil {
 		return nil, a.errorHTTPResult(http.StatusBadRequest, "Error processing incoming event data: %w", err)

--- a/pkg/targets/adapter/httptarget/adapter_test.go
+++ b/pkg/targets/adapter/httptarget/adapter_test.go
@@ -40,7 +40,7 @@ const (
 
 	tID          = "abc123"
 	tContentType = "application/json"
-	tCEType      = "test.type"
+	tCEType      = "io.triggermesh.http.request"
 	tCESource    = "test.source"
 )
 

--- a/pkg/targets/adapter/httptarget/adapter_test.go
+++ b/pkg/targets/adapter/httptarget/adapter_test.go
@@ -244,7 +244,7 @@ func TestHTTPRequests(t *testing.T) {
 			rd := RequestData{
 				Query:      tc.query,
 				PathSuffix: tc.pathsuffix,
-				Body:       string(body),
+				Body:       body,
 				Headers:    tc.reqHeaders,
 			}
 

--- a/pkg/targets/adapter/httptarget/types.go
+++ b/pkg/targets/adapter/httptarget/types.go
@@ -16,11 +16,13 @@ limitations under the License.
 
 package httptarget
 
+import "encoding/json"
+
 // RequestData contains the parametrizable fields that users can provide
 // for each request.
 type RequestData struct {
 	Query      string            `json:"query_string,omitempty"`
 	PathSuffix string            `json:"path_suffix,omitempty"`
-	Body       string            `json:"body,omitempty"`
+	Body       json.RawMessage   `json:"body,omitempty"`
 	Headers    map[string]string `json:"headers,omitempty"`
 }

--- a/pkg/targets/reconciler/httptarget/adapter.go
+++ b/pkg/targets/reconciler/httptarget/adapter.go
@@ -80,19 +80,18 @@ func MakeAppEnv(o *v1alpha1.HTTPTarget) []corev1.EnvVar {
 		skipVerify = *o.Spec.SkipVerify
 	}
 
-	eventSource := o.Spec.Response.EventSource
-	if eventSource == "" {
-		kind := strings.ToLower(o.GetGroupVersionKind().Kind)
-		eventSource = "io.triggermesh." + kind + "." + o.Namespace + "." + o.Name
+	eventType := v1alpha1.EventTypeResponse
+	if o.Spec.Response.EventType != "" {
+		eventType = o.Spec.Response.EventType
 	}
 
 	env := []corev1.EnvVar{
 		{
 			Name:  envHTTPEventType,
-			Value: o.Spec.Response.EventType,
+			Value: eventType,
 		}, {
 			Name:  envHTTPEventSource,
-			Value: eventSource,
+			Value: o.AsEventSource(),
 		}, {
 			Name:  envHTTPURL,
 			Value: o.Spec.Endpoint.String(),

--- a/schemas/io.triggermesh.http.request.json
+++ b/schemas/io.triggermesh.http.request.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$ref": "#/$defs/RequestData",
+	"$defs": {
+		"RequestData": {
+			"properties": {
+				"query_string": {
+					"type": "string"
+				},
+				"path_suffix": {
+					"type": "string"
+				},
+				"body": true,
+				"headers": {
+					"patternProperties": {
+						".*": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		}
+	},
+	"examples": [{
+			"path_suffix": "/send",
+			"body": "Hello from TriggerMesh!",
+			"headers": {
+				"User-Agent": "Mozilla/5.0",
+				"Accept": "application/json"
+			}
+		},
+		{
+			"path_suffix": "/items/1234",
+			"body": {
+				"name": "Apple",
+				"price": 2.99
+			}
+		}
+	]
+}


### PR DESCRIPTION
HTTPTarget improvements:
1. Expected request body type switched from `string` to `json.RawMessage` to handle JSON data. The use-case to reproduce the issue is simple: Webhook source -> Transformation -> HTTP Target. Transformation in this context can either shift the whole Webhook payload to the `body` key or compose it from the multiple values of the source event. In both cases, the resulting `body` will be a JSON object, which is expected transformation behavior. Before this update, the target adapter complained about it: `json: cannot unmarshal object into Go struct field RequestData.body of type string`,
2. CR's `spec.response.*` parameters are not required and without them the adapter fails to send back the responses (CE context validation). Default values for CE type and source attributes are added,
3. HTTPTarget resource implements `EventSource` and `EventReceiver` interfaces to comply with the rest of the components. Resource's status exposes expected and produced CE attributes.

_Upd:_ 
4. Since the target's expected event has a rather strict [format requirement](https://github.com/triggermesh/triggermesh/blob/8b1373837239390c017809faf3347ac18a3afe9c/pkg/targets/adapter/httptarget/adapter.go#L148-L151), JSON schema was added to explicitly announce the request contract. The target adapter requires an incoming event to be of `io.triggermesh.http.request` type, otherwise event processing will fail.  