### PR TITLE
HTTPTarget arbitrary CE support

### DIFF
--- a/config/301-httptarget.yaml
+++ b/config/301-httptarget.yaml
@@ -26,7 +26,8 @@ metadata:
         {
           "type": "io.triggermesh.http.request",
           "schema": "https://raw.githubusercontent.com/triggermesh/triggermesh/main/schemas/io.triggermesh.http.request.json"
-        }
+        },
+        { "type": "*" }
       ]
     registry.knative.dev/eventTypes: |
       [

--- a/pkg/apis/targets/v1alpha1/http_lifecycle.go
+++ b/pkg/apis/targets/v1alpha1/http_lifecycle.go
@@ -72,6 +72,7 @@ func (t *HTTPTarget) Validate(ctx context.Context) *apis.FieldError {
 func (*HTTPTarget) AcceptedEventTypes() []string {
 	return []string{
 		EventTypeHTTPTargetRequest,
+		EventTypeWildcard,
 	}
 }
 

--- a/pkg/targets/adapter/httptarget/adapter.go
+++ b/pkg/targets/adapter/httptarget/adapter.go
@@ -141,12 +141,10 @@ func (a *httpAdapter) Start(ctx context.Context) error {
 }
 
 func (a *httpAdapter) dispatch(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, cloudevents.Result) {
-	if event.Type() != v1alpha1.EventTypeHTTPTargetRequest {
-		return nil, a.errorHTTPResult(http.StatusBadRequest, "Incoming event type error: expected %q, got %q", v1alpha1.EventTypeHTTPTargetRequest, event.Type())
-	}
-
 	rd := &RequestData{}
-	if err := event.DataAs(rd); err != nil {
+	if event.Type() != v1alpha1.EventTypeHTTPTargetRequest {
+		rd.Body = event.Data()
+	} else if err := event.DataAs(rd); err != nil {
 		return nil, a.errorHTTPResult(http.StatusBadRequest, "Error processing incoming event data: %w", err)
 	}
 


### PR DESCRIPTION
`HTTPTarget` needs to be provided a `io.triggermesh.http.request` event type to work. We have had users trying to use it with arbitrary CloudEvents payloads expecting the target to fulfill a request to an external endpoint that uses de CloudEvent data as the body.

This PR adds support for that scenario.