### PR TITLE
AWS sources and targets cross-account/remote IAM support

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -119,7 +119,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -116,6 +116,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -179,7 +179,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -176,6 +176,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -130,7 +130,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -127,6 +127,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -113,6 +113,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -116,7 +116,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -113,6 +113,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -116,7 +116,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -113,6 +113,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -116,7 +116,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -131,6 +131,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: |-
                       (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions. For

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -134,7 +134,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -112,6 +112,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -115,7 +115,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -127,7 +127,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -124,6 +124,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -186,6 +186,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: |-
                       (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions. For

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -189,7 +189,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -128,6 +128,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -131,7 +131,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -111,6 +111,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -114,7 +114,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -113,7 +113,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -110,6 +110,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -113,7 +113,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -110,6 +110,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -109,6 +109,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -112,7 +112,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -107,6 +107,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -110,7 +110,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -111,6 +111,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -114,7 +114,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -113,7 +113,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -110,6 +110,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -107,6 +107,15 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      assumeIamRole:
+                        description: |-
+                          The ARN of an IAM role for cross-account or remote EKS cluster authorization.
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                        type: string
+                        pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
+                    required:
+                    - accessKeyID
+                    - secretAccessKey
                   iamRole:
                     description: (Amazon EKS only) The ARN of an IAM role which can be impersonated to obtain AWS permissions.
                       For more information about IAM roles for service accounts, please refer to the Amazon EKS User Guide

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -110,7 +110,7 @@ spec:
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.
-                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html 
+                          For more information please refer to the AWS General Reference at https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
                         type: string
                         pattern: ^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/.+$
                     required:

--- a/pkg/apis/common/v1alpha1/aws_types.go
+++ b/pkg/apis/common/v1alpha1/aws_types.go
@@ -50,6 +50,11 @@ type AWSAuth struct {
 type AWSSecurityCredentials struct {
 	AccessKeyID     ValueFromField `json:"accessKeyID"`
 	SecretAccessKey ValueFromField `json:"secretAccessKey"`
+
+	// The ARN of an IAM role for cross-account or remote impersonation on EKS.
+	// Require the access key credentials to create a client session.
+	// +optional
+	AssumeIAMRole *apis.ARN `json:"assumeIamRole,omitempty"`
 }
 
 // AWSEndpoint contains parameters which are used to override the destination

--- a/pkg/apis/common/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/common/v1alpha1/deepcopy_generated.go
@@ -79,6 +79,11 @@ func (in *AWSSecurityCredentials) DeepCopyInto(out *AWSSecurityCredentials) {
 	*out = *in
 	in.AccessKeyID.DeepCopyInto(&out.AccessKeyID)
 	in.SecretAccessKey.DeepCopyInto(&out.SecretAccessKey)
+	if in.AssumeIAMRole != nil {
+		in, out := &in.AssumeIAMRole, &out.AssumeIAMRole
+		*out = new(apis.ARN)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/env.go
+++ b/pkg/reconciler/env.go
@@ -35,6 +35,7 @@ const (
 	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
 	EnvEndpointURL     = "AWS_ENDPOINT_URL"
+	EnvAssumeIamRole   = "AWS_ASSUME_ROLE_ARN"
 
 	// Common Azure attributes
 	EnvAADTenantID     = "AZURE_TENANT_ID"

--- a/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
+++ b/pkg/sources/adapter/awscloudwatchlogssource/adapter.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
@@ -49,6 +50,9 @@ type envConfig struct {
 	ARN string `envconfig:"ARN"`
 
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"` // free tier is 5m
+
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
 
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
@@ -91,9 +95,14 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	a := common.MustParseARN(env.ARN)
 
-	cfg := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(a.Region),
 	))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	interval, err := time.ParseDuration(env.PollingInterval)
 	if err != nil {
@@ -106,7 +115,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		logger: logger,
 		mt:     mt,
 
-		cwLogsClient: cloudwatchlogs.New(cfg),
+		cwLogsClient: cloudwatchlogs.New(sess, config),
 		ceClient:     ceClient,
 
 		arn: a,

--- a/pkg/sources/adapter/awscognitoidentitysource/adapter.go
+++ b/pkg/sources/adapter/awscognitoidentitysource/adapter.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity/cognitoidentityiface"
@@ -46,6 +47,9 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
 
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
@@ -86,17 +90,22 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	arn := common.MustParseARN(env.ARN)
 
-	cfg := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(arn.Region).
 		WithMaxRetries(5),
 	))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	return &adapter{
 		logger: logger,
 		mt:     mt,
 
-		cgnIdentityClient: cognitoidentity.New(cfg),
-		cgnSyncClient:     cognitosync.New(cfg),
+		cgnIdentityClient: cognitoidentity.New(sess, config),
+		cgnSyncClient:     cognitosync.New(sess, config),
 		ceClient:          ceClient,
 
 		arn:            arn,

--- a/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
+++ b/pkg/sources/adapter/awscognitouserpoolsource/adapter.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider/cognitoidentityprovideriface"
@@ -47,6 +48,9 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
 
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
@@ -86,16 +90,21 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	arn := common.MustParseARN(env.ARN)
 
-	cfg := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(arn.Region).
 		WithMaxRetries(5),
 	))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	return &adapter{
 		logger: logger,
 		mt:     mt,
 
-		cgnIdentityClient: cognitoidentityprovider.New(cfg),
+		cgnIdentityClient: cognitoidentityprovider.New(sess, config),
 		ceClient:          ceClient,
 
 		arn:        arn,

--- a/pkg/sources/adapter/awsdynamodbsource/adapter.go
+++ b/pkg/sources/adapter/awsdynamodbsource/adapter.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -62,6 +63,9 @@ type envConfig struct {
 	pkgadapter.EnvConfig
 
 	ARN string `envconfig:"ARN" required:"true"`
+
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
 
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
@@ -108,16 +112,21 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	arn := common.MustParseARN(env.ARN)
 
-	cfg := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(arn.Region),
 	))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	return &adapter{
 		logger: logger,
 		mt:     mt,
 
-		dyndbClient:    dynamodb.New(cfg),
-		dyndbStrClient: dynamodbstreams.New(cfg),
+		dyndbClient:    dynamodb.New(sess, config),
+		dyndbStrClient: dynamodbstreams.New(sess, config),
 		ceClient:       ceClient,
 
 		arn: arn,

--- a/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
+++ b/pkg/sources/adapter/awsperformanceinsightssource/adapter.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/pi"
 	"github.com/aws/aws-sdk-go/service/pi/piiface"
@@ -51,6 +52,9 @@ type envConfig struct {
 	PollingInterval string `envconfig:"POLLING_INTERVAL" required:"true"`
 
 	Metrics []string `envconfig:"PI_METRICS" required:"true"`
+
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
 
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
@@ -98,9 +102,14 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 
 	a := common.MustParseARN(env.ARN)
 
-	cfg := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(a.Region),
 	))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	interval, err := time.ParseDuration(env.PollingInterval)
 	if err != nil {
@@ -114,7 +123,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		mql = append(mql, mq)
 	}
 
-	r := rds.New(cfg)
+	r := rds.New(sess, config)
 
 	dbi, err := r.DescribeDBInstances(&rds.DescribeDBInstancesInput{
 		Filters: []*rds.Filter{
@@ -138,7 +147,7 @@ func NewAdapter(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClie
 		logger: logger,
 		mt:     mt,
 
-		pIClient: pi.New(cfg),
+		pIClient: pi.New(sess, config),
 		ceClient: ceClient,
 
 		arn: a,

--- a/pkg/sources/client/sns/client.go
+++ b/pkg/sources/client/sns/client.go
@@ -17,13 +17,13 @@ limitations under the License.
 package sns
 
 import (
-	"errors"
 	"fmt"
 
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	awscore "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
@@ -61,19 +61,31 @@ var _ ClientGetter = (*ClientGetterWithSecretGetter)(nil)
 
 // Get implements ClientGetter.
 func (g *ClientGetterWithSecretGetter) Get(src *v1alpha1.AWSSNSSource) (Client, error) {
-	if src.Spec.Auth.Credentials == nil {
-		return nil, errors.New("AWS security credentials were not specified")
+	var sess *session.Session
+	config := &awscore.Config{}
+
+	switch {
+	case src.Spec.Auth.Credentials != nil:
+		creds, err := aws.Credentials(g.sg(src.Namespace), src.Spec.Auth.Credentials)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving AWS security credentials: %w", err)
+		}
+		sess = session.Must(session.NewSession(awscore.NewConfig().
+			WithRegion(src.Spec.ARN.Region).
+			WithCredentials(credentials.NewStaticCredentialsFromCreds(*creds)),
+		))
+		if assumeRole := src.Spec.Auth.Credentials.AssumeIAMRole; assumeRole != nil {
+			config.Credentials = stscreds.NewCredentials(sess, assumeRole.String())
+		}
+	case src.Spec.Auth.EksIAMRole != nil:
+		sess = session.Must(session.NewSession(awscore.NewConfig().
+			WithRegion(src.Spec.ARN.Region),
+		))
+	default:
+		return nil, fmt.Errorf("neither AWS security credentials nor IAM Role were specified")
 	}
 
-	creds, err := aws.Credentials(g.sg(src.Namespace), src.Spec.Auth.Credentials)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving AWS security credentials: %w", err)
-	}
-
-	return sns.New(session.Must(session.NewSession(awscore.NewConfig().
-		WithRegion(src.Spec.ARN.Region).
-		WithCredentials(credentials.NewStaticCredentialsFromCreds(*creds)),
-	))), nil
+	return sns.New(sess, config), nil
 }
 
 // ClientGetterFunc allows the use of ordinary functions as ClientGetter.

--- a/pkg/sources/reconciler/aws.go
+++ b/pkg/sources/reconciler/aws.go
@@ -31,6 +31,13 @@ func MakeAWSAuthEnvVars(auth v1alpha1.AWSAuth) []corev1.EnvVar {
 	if creds := auth.Credentials; creds != nil {
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvAccessKeyID, creds.AccessKeyID)
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSecretAccessKey, creds.SecretAccessKey)
+
+		if creds.AssumeIAMRole != nil {
+			authEnvVars = append(authEnvVars, corev1.EnvVar{
+				Name:  reconciler.EnvAssumeIamRole,
+				Value: creds.AssumeIAMRole.String(),
+			})
+		}
 	}
 
 	return authEnvVars

--- a/pkg/targets/adapter/awscomphrehendtarget/config.go
+++ b/pkg/targets/adapter/awscomphrehendtarget/config.go
@@ -37,6 +37,9 @@ type envAccessor struct {
 	// BridgeIdentifier is the name of the bridge workflow this target is part of
 	BridgeIdentifier string `envconfig:"EVENTS_BRIDGE_IDENTIFIER"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awsdynamodbtarget/config.go
+++ b/pkg/targets/adapter/awsdynamodbtarget/config.go
@@ -30,6 +30,9 @@ type envAccessor struct {
 
 	AwsTargetArn string `envconfig:"ARN" required:"true"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
 	// The environment variables below aren't read from the envConfig struct

--- a/pkg/targets/adapter/awseventbridgetarget/config.go
+++ b/pkg/targets/adapter/awseventbridgetarget/config.go
@@ -32,6 +32,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awskinesistarget/config.go
+++ b/pkg/targets/adapter/awskinesistarget/config.go
@@ -33,6 +33,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awslambdatarget/adapter.go
+++ b/pkg/targets/adapter/awslambdatarget/adapter.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 
@@ -53,15 +54,20 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 
 	a := MustParseARN(env.AwsTargetArn)
 
-	lambdaSession := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(a.Region).
 		WithMaxRetries(5)))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	return &adapter{
 		awsArnString:     env.AwsTargetArn,
 		awsArn:           a,
 		discardCEContext: env.DiscardCEContext,
-		lambdaClient:     lambda.New(lambdaSession),
+		lambdaClient:     lambda.New(sess, config),
 		ceClient:         ceClient,
 
 		logger: logger,

--- a/pkg/targets/adapter/awslambdatarget/config.go
+++ b/pkg/targets/adapter/awslambdatarget/config.go
@@ -32,6 +32,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awss3target/config.go
+++ b/pkg/targets/adapter/awss3target/config.go
@@ -32,6 +32,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awss3target/region.go
+++ b/pkg/targets/adapter/awss3target/region.go
@@ -18,6 +18,7 @@ package awss3target
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -32,7 +33,12 @@ func getBucketRegion(bucketName string, env *envAccessor) (string, error) {
 	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(defaultS3Region)))
 
-	resp, err := s3.New(sess).GetBucketLocation(&s3.GetBucketLocationInput{
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
+
+	resp, err := s3.New(sess, config).GetBucketLocation(&s3.GetBucketLocationInput{
 		Bucket: &bucketName,
 	})
 	if err != nil {

--- a/pkg/targets/adapter/awssnstarget/config.go
+++ b/pkg/targets/adapter/awssnstarget/config.go
@@ -32,6 +32,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/adapter/awssqstarget/adapter.go
+++ b/pkg/targets/adapter/awssqstarget/adapter.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 
@@ -54,15 +55,20 @@ func NewTarget(ctx context.Context, envAcc pkgadapter.EnvConfigAccessor, ceClien
 
 	a := MustParseARN(env.AwsTargetArn)
 
-	sqsSession := session.Must(session.NewSession(aws.NewConfig().
+	sess := session.Must(session.NewSession(aws.NewConfig().
 		WithRegion(a.Region).
 		WithMaxRetries(5)))
+
+	config := &aws.Config{}
+	if env.AssumeIamRole != "" {
+		config.Credentials = stscreds.NewCredentials(sess, env.AssumeIamRole)
+	}
 
 	return &adapter{
 		awsArnString:     env.AwsTargetArn,
 		awsArn:           a,
 		discardCEContext: env.DiscardCEContext,
-		sqsClient:        sqs.New(sqsSession),
+		sqsClient:        sqs.New(sess, config),
 		messageGroupID:   env.MessageGroupID,
 
 		ceClient: ceClient,

--- a/pkg/targets/adapter/awssqstarget/config.go
+++ b/pkg/targets/adapter/awssqstarget/config.go
@@ -33,6 +33,9 @@ type envAccessor struct {
 
 	DiscardCEContext bool `envconfig:"AWS_DISCARD_CE_CONTEXT"`
 
+	// Assume this IAM Role when access keys provided.
+	AssumeIamRole string `envconfig:"AWS_ASSUME_ROLE_ARN"`
+
 	// The environment variables below aren't read from the envConfig struct
 	// by the AWS SDK, but rather directly using os.Getenv().
 	// They are nevertheless listed here for documentation purposes.

--- a/pkg/targets/reconciler/aws.go
+++ b/pkg/targets/reconciler/aws.go
@@ -31,6 +31,13 @@ func MakeAWSAuthEnvVars(auth v1alpha1.AWSAuth) []corev1.EnvVar {
 	if creds := auth.Credentials; creds != nil {
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvAccessKeyID, creds.AccessKeyID)
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSecretAccessKey, creds.SecretAccessKey)
+
+		if creds.AssumeIAMRole != nil {
+			authEnvVars = append(authEnvVars, corev1.EnvVar{
+				Name:  reconciler.EnvAssumeIamRole,
+				Value: creds.AssumeIAMRole.String(),
+			})
+		}
 	}
 
 	return authEnvVars


### PR DESCRIPTION
AWS components' auth support for cross-account IAM impersonation.

Available auth schemas:

_static creds_
```yaml
  ...
  auth:
    credentials:
      accessKeyID:
        value: <redacted>
      secretAccessKey:
        value: <redacted>
```
-client session is created with the IAM user account whose Access Key specified in the spec. Controller also uses the same access key.

_IAM Role_
```yaml
  ...
  auth:
    iamRole: <redacted>
```
-IAM role impersonation available on EKS only. New SA will be created for the adapter, controller's SA requires manual update to include EKS role annotation. STS trust relationship configuration required on IAM.

_**New: cross-account IAM Role**_
```yaml
  ...
  auth:
    credentials:
      accessKeyID:
        value: <redacted>
      secretAccessKey:
        value: <redacted>
      assumeIamRole: <redacted>
```
-after client session is created with the static credentials, `assumeIamRole` will be used to gain IAM permissions. STS trust relationship configuration required on IAM.

Resolves #1253 