### PR TITLE
GCP Sources: relax GCP account regex

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -57,7 +57,8 @@ spec:
             type: object
             properties:
               arn:
-                description: ARN of the Log Group to source data from. The expected format is documented at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies
+                description: ARN of the Log Group to source data from. The expected format is documented at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-resources-for-iam-policies
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:logs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               pollingInterval:

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -58,7 +58,8 @@ spec:
             properties:
               arn:
                 description: ARN of the Amazon Cognito Identity Pool to receive notifications from. The expected format is
-                  documented at https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncognitoidentity.html#amazoncognitoidentity-resources-for-iam-policies.
+                  documented at
+                  https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncognitoidentity.html#amazoncognitoidentity-resources-for-iam-policies.
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:cognito-identity:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:identitypool\/.+$
               auth:

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -58,7 +58,8 @@ spec:
             properties:
               arn:
                 description: ARN of the Amazon Cognito User Pool to receive notifications from. The expected format is documented
-                  at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncognitouserpools.html#amazoncognitouserpools-resources-for-iam-policies
+                  at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncognitouserpools.html#amazoncognitouserpools-resources-for-iam-policies
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:cognito-idp:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:userpool\/.+$
               auth:

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -57,7 +57,8 @@ spec:
             properties:
               arn:
                 description: ARN of the Amazon RDS database instance to receive metrics for. The expected format is documented
-                  at https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonrds.html#amazonrds-resources-for-iam-policies.
+                  at
+                  https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonrds.html#amazonrds-resources-for-iam-policies.
                 type: string
                 pattern: ^arn:aws(-cn|-us-gov)?:rds:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
               pollingInterval:

--- a/config/300-azureeventgridsource.yaml
+++ b/config/300-azureeventgridsource.yaml
@@ -63,7 +63,8 @@ spec:
                   - a top-level resource from a resource provider (including Event Grid topic)
                     /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
                 type: string
-                pattern: ^\/subscriptions\/[a-z0-9-]+(?:\/resourceGroups\/[\w.()-]+(?:\/providers\/[A-Za-z.]+\/[a-zA-Z0-9][\w.-]+\/[a-zA-Z0-9][\w.-]+)?)?$
+                pattern:
+                  ^\/subscriptions\/[a-z0-9-]+(?:\/resourceGroups\/[\w.()-]+(?:\/providers\/[A-Za-z.]+\/[a-zA-Z0-9][\w.-]+\/[a-zA-Z0-9][\w.-]+)?)?$
               eventTypes:
                 description: |-
                   Types of events to subscribe to.

--- a/config/300-azureeventhubssource.yaml
+++ b/config/300-azureeventhubssource.yaml
@@ -60,9 +60,10 @@ spec:
                   Resource ID of the Event Hubs instance.
 
                   The expected format is
-                    /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
+                  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
                 type: string
-                pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
+                pattern:
+                  ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
               auth:
                 description: Authentication method to interact with the Azure Event Hubs REST API. If it not present, it will
                   try to use Azure AKS Managed Identity

--- a/config/300-azureservicebusqueuesource.yaml
+++ b/config/300-azureservicebusqueuesource.yaml
@@ -63,7 +63,8 @@ spec:
                   The expected format is
                     /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/queues/{queueName}
                 type: string
-                pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.ServiceBus\/namespaces\/[A-Za-z0-9-]{6,50}\/queues\/[A-Za-z0-9][\w.~/-]{0,258}[A-Za-z0-9]$
+                pattern:
+                  ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.ServiceBus\/namespaces\/[A-Za-z0-9-]{6,50}\/queues\/[A-Za-z0-9][\w.~/-]{0,258}[A-Za-z0-9]$
               auth:
                 description: Authentication method to interact with the Azure Service Bus Queue. If it not present, it will
                   try to use Azure AKS Managed Identity

--- a/config/300-azureservicebustopicsource.yaml
+++ b/config/300-azureservicebustopicsource.yaml
@@ -63,7 +63,8 @@ spec:
                   The expected format is
                     /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/topics/{topicName}
                 type: string
-                pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.ServiceBus\/namespaces\/[A-Za-z0-9-]{6,50}\/topics\/[A-Za-z0-9][\w.~/-]{0,258}[A-Za-z0-9]$
+                pattern:
+                  ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.ServiceBus\/namespaces\/[A-Za-z0-9-]{6,50}\/topics\/[A-Za-z0-9][\w.~/-]{0,258}[A-Za-z0-9]$
               auth:
                 description: Authentication method to interact with the Azure Service Bus API. This event source only supports
                   the Service Principal authentication. If it not present, it will try to use Azure AKS Managed Identity

--- a/config/300-googlecloudauditlogssource.yaml
+++ b/config/300-googlecloudauditlogssource.yaml
@@ -138,7 +138,7 @@ spec:
                   gcpServiceAccount:
                     description: GCP Service account name to impersonate Identity and Access Management (IAM) service accounts
                       to access Google Cloud services.
-                    pattern: ^[a-z][a-z0-9-]+@[a-z0-9-]+\.[a-z]+\.[a-z]{2,63}$
+                    pattern: ^[a-z0-9-]{6,30}@[a-z0-9-]{1,30}(?:\.[a-z0-9-]{1,30})?\.gserviceaccount\.com$
                     type: string
                   kubernetesServiceAccount:
                     description: The name of the Kubernetes Service account that will be created and bound to the gcpServiceAccount

--- a/config/300-googlecloudbillingsource.yaml
+++ b/config/300-googlecloudbillingsource.yaml
@@ -130,7 +130,7 @@ spec:
                   gcpServiceAccount:
                     description: GCP Service account name to impersonate Identity and Access Management (IAM) service accounts
                       to access Google Cloud services.
-                    pattern: ^[a-z][a-z0-9-]+@[a-z0-9-]+\.[a-z]+\.[a-z]{2,63}$
+                    pattern: ^[a-z0-9-]{6,30}@[a-z0-9-]{1,30}(?:\.[a-z0-9-]{1,30})?\.gserviceaccount\.com$
                     type: string
                   kubernetesServiceAccount:
                     description: The name of the Kubernetes Service account that will be created and bound to the gcpServiceAccount

--- a/config/300-googlecloudpubsubsource.yaml
+++ b/config/300-googlecloudpubsubsource.yaml
@@ -117,7 +117,7 @@ spec:
                   gcpServiceAccount:
                     description: GCP Service account name to impersonate Identity and Access Management (IAM) service accounts
                       to access Google Cloud services.
-                    pattern: ^[a-z][a-z0-9-]+@[a-z0-9-]+\.[a-z]+\.[a-z]{2,63}$
+                    pattern: ^[a-z0-9-]{6,30}@[a-z0-9-]{1,30}(?:\.[a-z0-9-]{1,30})?\.gserviceaccount\.com$
                     type: string
                   kubernetesServiceAccount:
                     description: The name of the Kubernetes Service account that will be created and bound to the gcpServiceAccount

--- a/config/300-googlecloudsourcerepositoriessource.yaml
+++ b/config/300-googlecloudsourcerepositoriessource.yaml
@@ -129,7 +129,7 @@ spec:
                   gcpServiceAccount:
                     description: GCP Service account name to impersonate Identity and Access Management (IAM) service accounts
                       to access Google Cloud services.
-                    pattern: ^[a-z][a-z0-9-]+@[a-z0-9-]+\.[a-z]+\.[a-z]{2,63}$
+                    pattern: ^[a-z0-9-]{6,30}@[a-z0-9-]{1,30}(?:\.[a-z0-9-]{1,30})?\.gserviceaccount\.com$
                     type: string
                   kubernetesServiceAccount:
                     description: The name of the Kubernetes Service account that will be created and bound to the gcpServiceAccount

--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -140,7 +140,7 @@ spec:
                   gcpServiceAccount:
                     description: GCP Service account name to impersonate Identity and Access Management (IAM) service accounts
                       to access Google Cloud services.
-                    pattern: ^[a-z][a-z0-9-]+@[a-z0-9-]+\.[a-z]+\.[a-z]{2,63}$
+                    pattern: ^[a-z0-9-]{6,30}@[a-z0-9-]{1,30}(?:\.[a-z0-9-]{1,30})?\.gserviceaccount\.com$
                     type: string
                   kubernetesServiceAccount:
                     description: The name of the Kubernetes Service account that will be created and bound to the gcpServiceAccount

--- a/config/301-azureeventhubstarget.yaml
+++ b/config/301-azureeventhubstarget.yaml
@@ -64,7 +64,8 @@ spec:
                   The expected format is
                     /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}
                 type: string
-                pattern: ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
+                pattern:
+                  ^\/subscriptions\/[a-z0-9-]+\/resourceGroups\/[\w.()-]+\/providers\/Microsoft.EventHub\/namespaces\/[A-Za-z0-9-]{6,50}\/event[Hh]ubs\/[a-zA-Z0-9][\w.-]{0,49}$
               discardCloudEventContext:
                 description: Whether to omit CloudEvent context attributes in objects created in Azure Event Hub. When this
                   property is false (default), the entire CloudEvent payload is included. When this property is true, only

--- a/hack/crd-update/crd-update.py
+++ b/hack/crd-update/crd-update.py
@@ -70,7 +70,7 @@ try:
             tolerations:
               description: Pod tolerations, as documented at
                 https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-                Tolerations require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/ 
+                Tolerations require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/
               type: array
               items:
                 type: object
@@ -96,14 +96,14 @@ try:
             nodeSelector:
               description: NodeSelector only allow the object pods to be created at nodes where all selector labels are present, as documented at
                 https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
-                NodeSelector require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/ 
+                NodeSelector require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/
               type: object
               additionalProperties:
                 type: string
             affinity:
               description: Scheduling constraints of the pod. More info at
                 https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
-                Affinity require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/ 
+                Affinity require additional configuration for Knative-based deployments - https://knative.dev/docs/serving/configuration/feature-flags/
               type: object
               x-kubernetes-preserve-unknown-fields: true
         """
@@ -191,5 +191,11 @@ for i in range(len(crd_versions)):
                 + " If left empty, the events will be sent back to the sender."
             )
 
+# Remove trailing space that happen after formatting descriptions that contain multiple lines.
+def remove_descriptions_trailing_space(stream):
+    if " \n" in stream:
+      return stream.replace(" \n", "\n")
+    return stream
 
-yaml.dump(crd, sys.stdout)
+yaml.dump(crd, sys.stdout, transform=remove_descriptions_trailing_space)
+


### PR DESCRIPTION
fixes #1408 

Tested with:

working set:
```
lorem-ipsumlorem-ipsum-dolor@gcp-sa-cloudbuild.iam.gserviceaccount.com
lorem-ipsumlorem-ipsum-dolor@my-project.gserviceaccount.com
lorem-ipsumlorem-ipsum-dolor@my-project.iam.gserviceaccount.com
lorem-ipsumlorem-ipsum-dolor@myproject.gserviceaccount.com
lorem-ipsumlorem-ipsum-dolor@myproject.iam.gserviceaccount.com
```

failing set:
```
another@myproject.extra.iam.gserviceaccount.com
another.project@cloudbuild.gserviceaccount.com
another@myproject.iam.nongserviceaccount.com
```
