### PR TITLE
Fix CRD linting

### DIFF
--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -48,14 +48,13 @@ spec:
             type: object
             properties:
               eventType:
-                description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event\
-                  \ related to the originating occurrence. Please refer to the CloudEvents specification for more details:\
-                  \ https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type"
+                description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event
+                  related to the originating occurrence. Please refer to the CloudEvents specification for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type"
                 type: string
               eventSource:
-                description: "Value of the CloudEvents 'source' attribute to set on ingested events. Identifies the context\
-                  \ in which an event happened. Must be expressed as a URI-reference. Please refer to the CloudEvents specification\
-                  \ for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
+                description: "Value of the CloudEvents 'source' attribute to set on ingested events. Identifies the context
+                  in which an event happened. Must be expressed as a URI-reference. Please refer to the CloudEvents specification
+                  for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
                 type: string
               endpoint:
                 description: HTTP/S URL of the endpoint to poll data from.

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -48,14 +48,13 @@ spec:
             type: object
             properties:
               eventType:
-                description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event\
-                  \ related to the originating occurrence. Please refer to the CloudEvents specification for more details:\
-                  \ https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type"
+                description: "Value of the CloudEvents 'type' attribute to set on ingested events. Describes the type of event
+                  related to the originating occurrence. Please refer to the CloudEvents specification for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type"
                 type: string
               eventSource:
-                description: "Value of the CloudEvents 'source' attribute to set on ingested events. Identifies the context\
-                  \ in which an event happened. Must be expressed as a URI-reference. Please refer to the CloudEvents specification\
-                  \ for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
+                description: "Value of the CloudEvents 'source' attribute to set on ingested events. Identifies the context
+                  in which an event happened. Must be expressed as a URI-reference. Please refer to the CloudEvents specification
+                  for more details: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#source-1"
                 type: string
               eventExtensionAttributes:
                 description: CloudEvents extension attributes to be added based on HTTP request fields.

--- a/config/301-logzmetricstarget.yaml
+++ b/config/301-logzmetricstarget.yaml
@@ -86,14 +86,14 @@ spec:
                     instrument:
                       type: string
                       enum: [Histogram, Counter, UpDownCounter]
-                      description: "Instrument Kind as defined by OpenTelemetry. Supported values are\n- Histogram, for absolute\
-                        \ values that can be aggregated. - Counter, for delta values that increase monotonically. - UpDownCounter,\
-                        \ for delta values that can increase and decrease."
+                      description: "Instrument Kind as defined by OpenTelemetry. Supported values are\n- Histogram, for absolute
+                        values that can be aggregated. - Counter, for delta values that increase monotonically. - UpDownCounter,
+                        for delta values that can increase and decrease."
                     number:
                       type: string
                       enum: [Int64, Float64]
-                      description: "Number Kind as defined by OpenTelemetry. Defines the measure data type accepted by the\
-                        \ Instrument. Supported values are\n- Int64 - Float64"
+                      description: "Number Kind as defined by OpenTelemetry. Defines the measure data type accepted by the
+                        Instrument. Supported values are\n- Int64 - Float64"
                   required:
                   - name
                   - instrument
@@ -103,9 +103,9 @@ spec:
                 description: Event replies options.
                 properties:
                   payloadPolicy:
-                    description: "Whether this target should generate response events. Possible values are\n- always, if a\
-                      \ response is available it will be sent. - error, only responses categorized as errors will be sent.\
-                      \ - never, no responses will be sent."
+                    description: "Whether this target should generate response events. Possible values are\n- always, if a
+                      response is available it will be sent. - error, only responses categorized as errors will be sent. -
+                      never, no responses will be sent."
 
                     type: string
                     enum: [always, error, never]


### PR DESCRIPTION
[ruamel.yaml](https://pypi.org/project/ruamel.yaml/) python library that we use to lint our YAMLs received a lot of updates recently and seems that it's changed its mind about some of the formats several times over the week. This update makes it happy again, although I thought we have a bot to fix that for us. 