### PR TITLE
Add object prefix filter in Google Cloud Storage Source

### DIFF
--- a/config/300-googlecloudstoragesource.yaml
+++ b/config/300-googlecloudstoragesource.yaml
@@ -89,6 +89,9 @@ spec:
                   - OBJECT_METADATA_UPDATE
                   - OBJECT_DELETE
                   - OBJECT_ARCHIVE
+              objectNamePrefix:
+                description: If present, will only receive notifications for objects whose names that begin with this prefix.
+                type: string
               serviceAccountKey:
                 description: Deprecated - please use spec.auth.serviceAccountKey. Service account key used to authenticate
                   the event source and allow it to interact with Google Cloud APIs. Only the JSON format is supported.

--- a/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
+++ b/pkg/apis/sources/v1alpha1/googlecloudstorage_types.go
@@ -65,6 +65,15 @@ type GoogleCloudStorageSourceSpec struct {
 	// +optional
 	EventTypes []string `json:"eventTypes,omitempty"`
 
+	// Object name prefix filter
+	//
+	// If present, will only receive notifications for objects whose names that begin with this prefix.
+	//
+	// If not set, notifications are received for all objects.
+	//
+	// +optional
+	ObjectNamePrefix string `json:"objectNamePrefix,omitempty"`
+
 	// Service account key in JSON format.
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 	// Deprecated, use Auth object instead.

--- a/pkg/sources/reconciler/googlecloudstoragesource/notif_config.go
+++ b/pkg/sources/reconciler/googlecloudstoragesource/notif_config.go
@@ -52,10 +52,11 @@ func EnsureNotificationConfig(ctx context.Context, cli *storage.Client,
 	status := &src.Status
 
 	desiredNotif := &storage.Notification{
-		EventTypes:     src.Spec.EventTypes,
-		PayloadFormat:  storage.JSONPayload,
-		TopicProjectID: topicResName.Project,
-		TopicID:        topicResName.Resource,
+		EventTypes:       src.Spec.EventTypes,
+		ObjectNamePrefix: src.Spec.ObjectNamePrefix,
+		PayloadFormat:    storage.JSONPayload,
+		TopicProjectID:   topicResName.Project,
+		TopicID:          topicResName.Resource,
 	}
 
 	bh := cli.Bucket(src.Spec.Bucket)


### PR DESCRIPTION
Addresses the issue in #1421 where the source creation fails when `object-prefix` flag is provided in `gcloud storage buckets notifications create` command.