### PR TITLE
E2E test - Azure blob storage - increase timeout

### DIFF
--- a/test/e2e/sources/azureblobstorage/main.go
+++ b/test/e2e/sources/azureblobstorage/main.go
@@ -204,7 +204,7 @@ var _ = Describe("Azure Blob Storage source", func() {
 				})
 
 				By("asserting that a BlobDeleted event is received", func() {
-					const receiveTimeout = 15 * time.Second
+					const receiveTimeout = 30 * time.Second
 					const pollInterval = 500 * time.Millisecond
 
 					var receivedEvents []cloudevents.Event


### PR DESCRIPTION
Sometimes azure takes more than time than usual and we fail, this PR increase the timeout.