### PR TITLE
Azure Blob Storage Source - Fix length name

### DIFF
--- a/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/event_subs.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"net/http"
+	"strconv"
 	"time"
 
 	"go.uber.org/zap"
@@ -271,8 +273,11 @@ func isDenied(err error) bool {
 
 // subscriptionName returns a predictable name for an Event Grid event
 // subscription associated with the given source instance.
-func subscriptionName(o *v1alpha1.AzureBlobStorageSource) string {
-	return "io.triggermesh.azureblobstoragesource." + o.Namespace + "." + o.Name
+// The Event Subscription name must be 3-64 characters in length and can only
+// contain a-z, A-Z, 0-9, and "-".
+func subscriptionName(src *v1alpha1.AzureBlobStorageSource) string {
+	nsNameChecksum := crc32.ChecksumIEEE([]byte(src.Namespace + "/" + src.Name))
+	return "io-triggermesh-azureblobstoragesource-" + strconv.FormatUint(uint64(nsNameChecksum), 10)
 }
 
 // cmpFunc can compare the equality of two interfaces. The function signature

--- a/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
+++ b/pkg/sources/reconciler/azureblobstoragesource/reconciler_test.go
@@ -266,7 +266,7 @@ const (
 	tName = "test"
 	tKey  = tNs + "/" + tName
 
-	tEventSubs = "io.triggermesh.azureblobstoragesource." + tNs + "." + tName
+	tEventSubs = "io-triggermesh-azureblobstoragesource-" + "521367233" // CRC-32 checksum of "<tNs>/<tName>"
 )
 
 var (


### PR DESCRIPTION
This PR fix the problem with the Azure Blob Storage Source: 
```
Message=\"The length of io.triggermesh.azureblobstoragesource.e2e-azureblobstoragesource-7838.test-96bdl is 80 which is invalid. EventSubscription name must be between 3 and 64 characters in length.
```

Related code:
https://github.com/triggermesh/triggermesh/blob/main/pkg/sources/reconciler/azureeventgridsource/event_subs.go#L223