### PR TITLE
Fix LogzTarget schema for spec.logsListenerURL

### DIFF
--- a/config/301-logztarget.yaml
+++ b/config/301-logztarget.yaml
@@ -77,10 +77,6 @@ spec:
               logsListenerURL:
                 type: string
                 description: Logz listener host to stream events to.
-                properties:
-                  payloadPolicy:
-                    type: string
-                    enum: [always, error, never]
               adapterOverrides:
                 description: Kubernetes object parameters to apply on top of default adapter values.
                 type: object


### PR DESCRIPTION
Greetings !

A quick MR to fix a schema issue in LogzTarget, this was preventing [CDK8S](https://cdk8s.io/) from generating the code 👍 

```
targets.triggermesh.io
  ...
  targets.triggermesh.io/logzmetricstarget
  targets.triggermesh.io/logztarget
Error: for "properties", if "type" is specified it has to be an "object"
    at TypeGenerator.emitTypeInternal (/tmp/node_modules/json2jsii/lib/type-generator.js:164:23)
    at TypeGenerator.typeForProperty (/tmp/node_modules/json2jsii/lib/type-generator.js:385:21)
    at TypeGenerator.emitProperty (/tmp/node_modules/json2jsii/lib/type-generator.js:324:35)
    at /tmp/node_modules/json2jsii/lib/type-generator.js:304:22
    at typesToEmit.<computed> (/tmp/node_modules/json2jsii/lib/type-generator.js:204:28)
    at TypeGenerator.renderToCode (/tmp/node_modules/json2jsii/lib/type-generator.js:238:33)
    at TypeGenerator.render (/tmp/node_modules/json2jsii/lib/type-generator.js:226:14)
    at CustomResourceDefinition.generateTypeScript (/tmp/node_modules/cdk8s-cli/lib/import/crd.js:87:29)
    at ImportCustomResourceDefinition.generateTypeScript (/tmp/node_modules/cdk8s-cli/lib/import/crd.js:130:23)
    at async ImportCustomResourceDefinition.import (/tmp/node_modules/cdk8s-cli/lib/import/base.js:71:13)
```