### PR TITLE
DatadogTarget: Customize site variable

### DIFF
--- a/config/301-datadogtarget.yaml
+++ b/config/301-datadogtarget.yaml
@@ -75,6 +75,9 @@ spec:
                         type: string
                       name:
                         type: string
+              site:
+                type: string
+                description: Controls the site of the Datadog intake API
               eventOptions:
                 description: 'When should this target generate a response event for processing: always, on error, or never.'
                 type: object

--- a/docs/targets/datadog.md
+++ b/docs/targets/datadog.md
@@ -58,6 +58,22 @@ spec:
 
 A valid `apiKey` is ***REQUIRED*** to deploy
 
+If you're using a Datadog instance in the EU or another region, this can also be configured:
+
+```yaml
+apiVersion: targets.triggermesh.io/v1alpha1
+kind: DatadogTarget
+metadata:
+  name: datadogtarget
+spec:
+  site: datadoghq.eu
+  apiKey:
+    secretKeyRef:
+      name: ddapitoken
+      key: apiKey
+```
+
+Refer to the list of [sites](https://docs.datadoghq.com/getting_started/site/) for possible values of the site parameter.
 
 ## Event Types
 

--- a/pkg/apis/targets/v1alpha1/datadog_types.go
+++ b/pkg/apis/targets/v1alpha1/datadog_types.go
@@ -48,6 +48,10 @@ type DatadogTargetSpec struct {
 	// DatadogApiKey represents how Datadog credentials should be provided in the secret
 	DatadogAPIKey SecretValueFromSource `json:"apiKey"`
 
+	// DatadogSite controls the site of the Datadog intake API, defaults to `datadoghq.com`
+	// +optional
+	DatadogSite *string `json:"site,omitempty"`
+
 	// MetricPrefix is prepended to the name of the associated metrics.
 	// +optional
 	MetricPrefix *string `json:"metricPrefix"`

--- a/pkg/apis/targets/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/targets/v1alpha1/deepcopy_generated.go
@@ -1301,6 +1301,11 @@ func (in *DatadogTargetList) DeepCopyObject() runtime.Object {
 func (in *DatadogTargetSpec) DeepCopyInto(out *DatadogTargetSpec) {
 	*out = *in
 	in.DatadogAPIKey.DeepCopyInto(&out.DatadogAPIKey)
+	if in.DatadogSite != nil {
+		in, out := &in.DatadogSite, &out.DatadogSite
+		*out = new(string)
+		**out = **in
+	}
 	if in.MetricPrefix != nil {
 		in, out := &in.MetricPrefix, &out.MetricPrefix
 		*out = new(string)

--- a/pkg/targets/adapter/datadogtarget/config.go
+++ b/pkg/targets/adapter/datadogtarget/config.go
@@ -30,6 +30,9 @@ type envAccessor struct {
 	// APIKey defines a Datadog API key to be used for authentication
 	APIKey string `envconfig:"DD_CLIENT_API_KEY" required:"true"`
 
+	// Site defines the site of the Datadog intake API, defaults to `datadoghq.com`
+	Site string `envconfig:"DD_CLIENT_SITE" default:"datadoghq.com"`
+
 	// CloudEvents responses parametrization
 	CloudEventPayloadPolicy string `envconfig:"EVENTS_PAYLOAD_POLICY" default:"error"`
 

--- a/pkg/targets/reconciler/datadogtarget/adapter.go
+++ b/pkg/targets/reconciler/datadogtarget/adapter.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	envDatadogAPIKey       = "DD_CLIENT_API_KEY"
+	envDatadogSite         = "DD_CLIENT_SITE"
 	envEventsPayloadPolicy = "EVENTS_PAYLOAD_POLICY"
 )
 
@@ -67,6 +68,13 @@ func MakeAppEnv(o *v1alpha1.DatadogTarget) []corev1.EnvVar {
 				SecretKeyRef: o.Spec.DatadogAPIKey.SecretKeyRef,
 			},
 		},
+	}
+
+	if o.Spec.DatadogSite != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  envDatadogSite,
+			Value: *o.Spec.DatadogSite,
+		})
 	}
 
 	if o.Spec.EventOptions != nil && o.Spec.EventOptions.PayloadPolicy != nil {


### PR DESCRIPTION
Datadog is multi-site and each site gets its own domain so we need to be able to customize it.

See https://docs.datadoghq.com/getting_started/site/