### PR TITLE
Add session token support to AWS components

### DIFF
--- a/config/300-awscloudwatchlogssource.yaml
+++ b/config/300-awscloudwatchlogssource.yaml
@@ -117,6 +117,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awscloudwatchsource.yaml
+++ b/config/300-awscloudwatchsource.yaml
@@ -176,6 +176,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awscodecommitsource.yaml
+++ b/config/300-awscodecommitsource.yaml
@@ -127,6 +127,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awscognitoidentitysource.yaml
+++ b/config/300-awscognitoidentitysource.yaml
@@ -114,6 +114,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awscognitouserpoolsource.yaml
+++ b/config/300-awscognitouserpoolsource.yaml
@@ -114,6 +114,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awsdynamodbsource.yaml
+++ b/config/300-awsdynamodbsource.yaml
@@ -113,6 +113,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awseventbridgesource.yaml
+++ b/config/300-awseventbridgesource.yaml
@@ -131,6 +131,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awskinesissource.yaml
+++ b/config/300-awskinesissource.yaml
@@ -112,6 +112,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awsperformanceinsightssource.yaml
+++ b/config/300-awsperformanceinsightssource.yaml
@@ -125,6 +125,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -186,6 +186,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -128,6 +128,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awscomprehendtarget.yaml
+++ b/config/301-awscomprehendtarget.yaml
@@ -111,6 +111,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awsdynamodbtarget.yaml
+++ b/config/301-awsdynamodbtarget.yaml
@@ -110,6 +110,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awseventbridgetarget.yaml
+++ b/config/301-awseventbridgetarget.yaml
@@ -110,6 +110,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awskinesistarget.yaml
+++ b/config/301-awskinesistarget.yaml
@@ -109,6 +109,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awslambdatarget.yaml
+++ b/config/301-awslambdatarget.yaml
@@ -107,6 +107,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awss3target.yaml
+++ b/config/301-awss3target.yaml
@@ -111,6 +111,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awssnstarget.yaml
+++ b/config/301-awssnstarget.yaml
@@ -110,6 +110,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/config/301-awssqstarget.yaml
+++ b/config/301-awssqstarget.yaml
@@ -107,6 +107,28 @@ spec:
                         oneOf:
                         - required: [value]
                         - required: [valueFromSecret]
+                      sessionToken:
+                        description: The AWS session token for temporary credentials.
+                        type: object
+                        properties:
+                          value:
+                            description: Literal value of the session token.
+                            type: string
+                            format: password
+                          valueFromSecret:
+                            description: A reference to a Kubernetes Secret object containing the session token.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
+                            required:
+                            - name
+                            - key
+                        oneOf:
+                        - required: [value]
+                        - required: [valueFromSecret]
                       assumeIamRole:
                         description: |-
                           The ARN of an IAM role for cross-account or remote EKS cluster authorization.

--- a/pkg/apis/common/v1alpha1/aws_types.go
+++ b/pkg/apis/common/v1alpha1/aws_types.go
@@ -51,6 +51,11 @@ type AWSSecurityCredentials struct {
 	AccessKeyID     ValueFromField `json:"accessKeyID"`
 	SecretAccessKey ValueFromField `json:"secretAccessKey"`
 
+	// The AWS session token for temporary credentials.
+	// See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken
+	// +optional
+	SessionToken ValueFromField `json:"sessionToken,omitempty"`
+
 	// The ARN of an IAM role for cross-account or remote impersonation on EKS.
 	// Require the access key credentials to create a client session.
 	// +optional

--- a/pkg/apis/common/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/common/v1alpha1/deepcopy_generated.go
@@ -79,6 +79,7 @@ func (in *AWSSecurityCredentials) DeepCopyInto(out *AWSSecurityCredentials) {
 	*out = *in
 	in.AccessKeyID.DeepCopyInto(&out.AccessKeyID)
 	in.SecretAccessKey.DeepCopyInto(&out.SecretAccessKey)
+	in.SessionToken.DeepCopyInto(&out.SessionToken)
 	if in.AssumeIAMRole != nil {
 		in, out := &in.AssumeIAMRole, &out.AssumeIAMRole
 		*out = new(apis.ARN)

--- a/pkg/reconciler/env.go
+++ b/pkg/reconciler/env.go
@@ -34,6 +34,7 @@ const (
 	EnvARN             = "ARN"
 	EnvAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	EnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
+	EnvSessionToken    = "AWS_SESSION_TOKEN"
 	EnvEndpointURL     = "AWS_ENDPOINT_URL"
 	EnvAssumeIamRole   = "AWS_ASSUME_ROLE_ARN"
 

--- a/pkg/sources/reconciler/aws.go
+++ b/pkg/sources/reconciler/aws.go
@@ -31,6 +31,7 @@ func MakeAWSAuthEnvVars(auth v1alpha1.AWSAuth) []corev1.EnvVar {
 	if creds := auth.Credentials; creds != nil {
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvAccessKeyID, creds.AccessKeyID)
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSecretAccessKey, creds.SecretAccessKey)
+		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSessionToken, creds.SessionToken)
 
 		if creds.AssumeIAMRole != nil {
 			authEnvVars = append(authEnvVars, corev1.EnvVar{


### PR DESCRIPTION
This PR adds AWS Sources and Targets support for temporary credentials through the introduction of `sessionToken` parameter in AWS auth object. Requested in  #1440.

Temporary credentials can be requested with AWS CLI:
```
$ aws sts get-session-token

{
    "Credentials": {
        "AccessKeyId": "redacted",
        "SecretAccessKey": "redacted",
        "SessionToken": "redacted",
        "Expiration": "2023-06-07T21:25:54+00:00"
    }
}
```
`AccessKeyId`, `SecretAccessKey`, and `SessionToken` from the response can be used in the auth spec "as is" to gain temporary access to the AWS API.
