### PR TITLE
Session token support for AWS targets 

### DIFF
--- a/pkg/targets/reconciler/aws.go
+++ b/pkg/targets/reconciler/aws.go
@@ -31,6 +31,7 @@ func MakeAWSAuthEnvVars(auth v1alpha1.AWSAuth) []corev1.EnvVar {
 	if creds := auth.Credentials; creds != nil {
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvAccessKeyID, creds.AccessKeyID)
 		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSecretAccessKey, creds.SecretAccessKey)
+		authEnvVars = reconciler.MaybeAppendValueFromEnvVar(authEnvVars, reconciler.EnvSessionToken, creds.SessionToken)
 
 		if creds.AssumeIAMRole != nil {
 			authEnvVars = append(authEnvVars, corev1.EnvVar{


### PR DESCRIPTION
The missing piece from #1446 that enables Session token support in AWS Targets.
Thanks to @RealArtemiy for your help with debugging this.