### PR TITLE
Add AWS S3 source event filter

### DIFF
--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -134,6 +134,22 @@ spec:
                         pattern: ^arn:aws(-cn|-us-gov)?:sqs:[a-z]{2}(-gov)?-[a-z]+-\d:\d{12}:.+$
                     required:
                     - queueARN
+              filter:
+                description: Object key name filtering for event notifications
+                type: object
+                properties:
+                  rules:
+                    description: The object key name prefix or suffix identifying one or more objects to which the filtering rule applies
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          description: name
+                          type: string
+                        value:
+                          description: value
+                          type: string
               auth:
                 description: Authentication method to interact with the Amazon S3 and SQS APIs.
                 type: object

--- a/config/300-awss3source.yaml
+++ b/config/300-awss3source.yaml
@@ -139,7 +139,8 @@ spec:
                 type: object
                 properties:
                   rules:
-                    description: The object key name prefix or suffix identifying one or more objects to which the filtering rule applies
+                    description: The object key name prefix or suffix identifying one or more objects to which the filtering
+                      rule applies
                     type: array
                     items:
                       type: object

--- a/pkg/apis/sources/v1alpha1/awss3_types.go
+++ b/pkg/apis/sources/v1alpha1/awss3_types.go
@@ -67,6 +67,13 @@ type AWSS3SourceSpec struct {
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
 	EventTypes []string `json:"eventTypes"`
 
+	// The object key name prefix or suffix identifying one or more objects to which
+	// the filtering rule applies. The maximum length is 1,024 characters. Overlapping
+	// prefixes and suffixes are not supported. For more information, see Configuring
+	// Event Notifications (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+	// in the Amazon S3 User Guide.
+	Filter *AWSS3SourceFilter `json:"filter,omitempty"`
+
 	// The intermediate destination of notifications originating from the
 	// Amazon S3 bucket, before they are retrieved by this event source.
 	// If omitted, an Amazon SQS queue is automatically created and
@@ -111,4 +118,15 @@ type AWSS3SourceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AWSS3Source `json:"items"`
+}
+
+// AWSS3SourceFilterRule defines a notification filter rule for the event source.
+type AWSS3SourceFilterRule struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// AWSS3SourceFilter defines a notification filter for the event source.
+type AWSS3SourceFilter struct {
+	Rules []AWSS3SourceFilterRule `json:"rules,omitempty"`
 }


### PR DESCRIPTION
This PR adds support for configuring object name prefix/suffix [filters](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-filtering.html) for bucket notifications in an AWS S3 source.